### PR TITLE
v1.7.0: remove unreliable price data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.7.0] — 2026-06-17
+
+### Removed
+
+- **All MSRP price fields** (`msrp_usd` plus the localized `msrp_eur/gbp/inr/aed/aud/cad/vnd/chf`) — removed from the schema and stripped from 468 cameras. The pricing data was sparse (~36% of cameras, one currency each, undated) and unreliable; omitting it is more honest than publishing inaccurate prices.
+
+### Changed
+
+- Clarified in the schema that `video.streams[]` describes stream *capabilities* (what the camera outputs), distinct from `configs.frigate.*`, which holds the RTSP URLs to use — the two complement rather than overlap.
+
+---
+
 ## [1.6.0] — 2026-06-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ Common optional fields:
 | `audio.two_way` | `boolean` | `true` |
 | `protocols` | `string[]` | `["onvif", "rtsp"]` |
 | `markets` | `string[]` | `["UK", "EU", "DE"]` |
-| `msrp_usd` / `msrp_eur` / `msrp_gbp` | `number` | `79.99` |
 | `features` | `string[]` | `["no subscription", "IP67"]` |
 | `sources` | `string[]` | datasheet / retailer URLs |
 
@@ -285,10 +284,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full field reference, naming conv
 
 ## Roadmap
 
-- [ ] JSON Schema validation in CI (GitHub Actions)
+- [x] JSON Schema validation in CI (GitHub Actions)
 - [ ] Static web frontend — search, filter, compare
 - [ ] Side-by-side comparison view (2–4 cameras)
-- [ ] Price history tracking (msrp over time)
 - [ ] Frigate-compatible config export
 - [ ] Home Assistant integration template
 - [ ] API endpoint (read-only, hosted)

--- a/cameras/abus/ppic42520-at.json
+++ b/cameras/abus/ppic42520-at.json
@@ -62,7 +62,6 @@
     "IP66",
     "Austrian consumer favourite Conrad/MediaMarkt"
   ],
-  "msrp_eur": 219.99,
   "sources": [
     "https://www.abus.com/at/"
   ],

--- a/cameras/abus/ppic42520.json
+++ b/cameras/abus/ppic42520.json
@@ -62,7 +62,6 @@
     "IP66",
     "German brand"
   ],
-  "msrp_eur": 219.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/abus/ppic44520.json
+++ b/cameras/abus/ppic44520.json
@@ -63,7 +63,6 @@
     "IP66",
     "German brand"
   ],
-  "msrp_eur": 189.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/abus/ppic46520.json
+++ b/cameras/abus/ppic46520.json
@@ -63,7 +63,6 @@
     "no mandatory subscription",
     "German brand"
   ],
-  "msrp_eur": 219.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/abus/ppic90520.json
+++ b/cameras/abus/ppic90520.json
@@ -61,7 +61,6 @@
     "IP65",
     "German brand"
   ],
-  "msrp_eur": 199.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/abus/tvip42520.json
+++ b/cameras/abus/tvip42520.json
@@ -65,7 +65,6 @@
     "IP67",
     "ONVIF/RTSP"
   ],
-  "msrp_eur": 299.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/abus/tvip44520-at.json
+++ b/cameras/abus/tvip44520-at.json
@@ -67,7 +67,6 @@
     "no mandatory cloud",
     "GDPR compliant"
   ],
-  "msrp_eur": 249.99,
   "sources": [
     "https://www.abus.com/at/"
   ],

--- a/cameras/abus/tvip44520.json
+++ b/cameras/abus/tvip44520.json
@@ -64,7 +64,6 @@
     "IK10",
     "German engineering brand"
   ],
-  "msrp_eur": 249.99,
   "sources": [
     "https://www.abus.com/"
   ],

--- a/cameras/ajax/dualcam.json
+++ b/cameras/ajax/dualcam.json
@@ -52,7 +52,6 @@
     "IK07",
     "EU professional alarm market"
   ],
-  "msrp_eur": 199,
   "sources": [
     "https://ajax.systems/products/"
   ],

--- a/cameras/ajax/outdoor-cam-multisensor.json
+++ b/cameras/ajax/outdoor-cam-multisensor.json
@@ -60,7 +60,6 @@
     "professional installer market",
     "IK09 tamper resistant"
   ],
-  "msrp_gbp": 249.99,
   "sources": [
     "https://ajax.systems/products/outdoorcam/"
   ],

--- a/cameras/amcrest/ad410-doorbell.json
+++ b/cameras/amcrest/ad410-doorbell.json
@@ -57,7 +57,6 @@
     "IP65",
     "no subscription required"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://amcrest.com/products/video-doorbells/ad410"
   ],

--- a/cameras/amcrest/ip5m-t1179ew.json
+++ b/cameras/amcrest/ip5m-t1179ew.json
@@ -55,7 +55,6 @@
     "Amcrest View app",
     "IP67"
   ],
-  "msrp_usd": 34.99,
   "sources": [
     "https://amcrest.com/"
   ],

--- a/cameras/amcrest/ip5m-t1190ew.json
+++ b/cameras/amcrest/ip5m-t1190ew.json
@@ -57,7 +57,6 @@
     "Blue Iris compatible",
     "IP67"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://amcrest.com/"
   ],

--- a/cameras/amcrest/ip8m-2496ew.json
+++ b/cameras/amcrest/ip8m-2496ew.json
@@ -56,7 +56,6 @@
     "Blue Iris compatible",
     "built-in mic & speaker"
   ],
-  "msrp_usd": 69.99,
   "sources": [
     "https://amcrest.com/"
   ],

--- a/cameras/amcrest/ip8m-2556ew.json
+++ b/cameras/amcrest/ip8m-2556ew.json
@@ -57,7 +57,6 @@
     "IP67",
     "affordable 4K PTZ"
   ],
-  "msrp_usd": 119,
   "sources": [
     "https://amcrest.com/"
   ],

--- a/cameras/annke/ac500.json
+++ b/cameras/annke/ac500.json
@@ -58,7 +58,6 @@
     "IP67",
     "RTSP/ONVIF"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://www.annke.com/products/ac500"
   ],

--- a/cameras/annke/ac800.json
+++ b/cameras/annke/ac800.json
@@ -60,7 +60,6 @@
     "IP67",
     "IK08"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://www.annke.com/blogs/press/annke-reveals-next-gen-4k-surveillance-camera-lead-by-the-ac800-featuring-ai-active-deterrence-two-way-talk-and-color-night-vision"
   ],

--- a/cameras/annke/c500.json
+++ b/cameras/annke/c500.json
@@ -59,7 +59,6 @@
     "Alexa / Google",
     "no subscription"
   ],
-  "msrp_usd": 34.99,
   "sources": [
     "https://www.annke.com/products/c500"
   ],

--- a/cameras/annke/c800-bullet.json
+++ b/cameras/annke/c800-bullet.json
@@ -58,7 +58,6 @@
     "IK08",
     "RTSP/ONVIF"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://www.annke.com/products/c800"
   ],

--- a/cameras/annke/c800-turret.json
+++ b/cameras/annke/c800-turret.json
@@ -58,7 +58,6 @@
     "IK10",
     "RTSP/ONVIF"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://www.annke.com/products/c800"
   ],

--- a/cameras/annke/c800x.json
+++ b/cameras/annke/c800x.json
@@ -57,7 +57,6 @@
     "H.265+",
     "IP67"
   ],
-  "msrp_usd": 69.99,
   "sources": [
     "https://www.annke.com/products/c800x"
   ],

--- a/cameras/annke/cr400.json
+++ b/cameras/annke/cr400.json
@@ -51,7 +51,6 @@
     "IP67",
     "ONVIF compatible"
   ],
-  "msrp_usd": 39.99,
   "sources": [
     "https://www.annke.com/"
   ],

--- a/cameras/aqara/camera-hub-g3.json
+++ b/cameras/aqara/camera-hub-g3.json
@@ -55,7 +55,6 @@
     "Alexa / Google",
     "Matter compatible"
   ],
-  "msrp_eur": 89,
   "sources": [
     "https://eu.aqara.com/en-eu/products/camera-hub-g3"
   ],

--- a/cameras/aqara/camera-hub-g5-pro-ch.json
+++ b/cameras/aqara/camera-hub-g5-pro-ch.json
@@ -62,7 +62,6 @@
     "available Digitec / Galaxus CH",
     "popular Swiss HomeKit users"
   ],
-  "msrp_chf": 149.0,
   "sources": [
     "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro",
     "https://www.digitec.ch/"

--- a/cameras/aqara/camera-hub-g5-pro.json
+++ b/cameras/aqara/camera-hub-g5-pro.json
@@ -61,7 +61,6 @@
     "first shown IFA 2024 Berlin",
     "IP65 / -30°C"
   ],
-  "msrp_eur": 139.99,
   "sources": [
     "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro"
   ],

--- a/cameras/arlo/baby-monitor.json
+++ b/cameras/arlo/baby-monitor.json
@@ -51,7 +51,6 @@
     "cry detection alerts",
     "Arlo app"
   ],
-  "msrp_usd": 129.99,
   "sources": [
     "https://us.arlo.com/products/arlo-baby-monitor"
   ],

--- a/cameras/arlo/essential-indoor-1st-gen.json
+++ b/cameras/arlo/essential-indoor-1st-gen.json
@@ -51,7 +51,6 @@
     "Arlo Secure plan",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-indoor-camera"
   ],

--- a/cameras/arlo/essential-indoor-2nd-gen.json
+++ b/cameras/arlo/essential-indoor-2nd-gen.json
@@ -51,7 +51,6 @@
     "Arlo Secure plan for cloud"
   ],
   "release_year": 2022,
-  "msrp_usd": 89.99,
   "sources": [
     "https://www.arlo.com/cameras/essential/arlo-essential-indoor.html"
   ],

--- a/cameras/arlo/essential-outdoor-2nd-gen.json
+++ b/cameras/arlo/essential-outdoor-2nd-gen.json
@@ -53,7 +53,6 @@
     "Arlo Secure plan",
     "IP65"
   ],
-  "msrp_usd": 99,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-battery-2nd-gen"
   ],

--- a/cameras/arlo/essential-outdoor-3rd-gen.json
+++ b/cameras/arlo/essential-outdoor-3rd-gen.json
@@ -55,7 +55,6 @@
     "IP65",
     "improved battery life vs Gen 2"
   ],
-  "msrp_usd": 99,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
   ],

--- a/cameras/arlo/essential-spotlight-1st-gen.json
+++ b/cameras/arlo/essential-spotlight-1st-gen.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 129.99,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-spotlight"
   ],

--- a/cameras/arlo/essential-xl-outdoor.json
+++ b/cameras/arlo/essential-xl-outdoor.json
@@ -53,7 +53,6 @@
     "Apple HomeKit / Google / Alexa",
     "Arlo Secure plan"
   ],
-  "msrp_usd": 129.99,
   "sources": [
     "https://www.arlo.com/cameras/essential/arlo-essential-outdoor.html"
   ],

--- a/cameras/arlo/essential-xl-v2.json
+++ b/cameras/arlo/essential-xl-v2.json
@@ -53,7 +53,6 @@
     "IP65",
     "ideal for remote installs"
   ],
-  "msrp_usd": 129,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-xl-v2"
   ],

--- a/cameras/arlo/essential-xlr.json
+++ b/cameras/arlo/essential-xlr.json
@@ -50,7 +50,6 @@
     "Alexa / Google / HomeKit"
   ],
   "release_year": 2021,
-  "msrp_usd": 129.99,
   "sources": [
     "https://www.arlo.com/cameras/essential/arlo-essential-xl-spotlight.html"
   ],

--- a/cameras/arlo/floodlight-camera-pro.json
+++ b/cameras/arlo/floodlight-camera-pro.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "IP55"
   ],
-  "msrp_usd": 249,
   "sources": [
     "https://us.arlo.com/"
   ],

--- a/cameras/arlo/go-2.json
+++ b/cameras/arlo/go-2.json
@@ -54,7 +54,6 @@
     "Arlo Secure for cloud",
     "works anywhere with cellular signal"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.arlo.com/cameras/go/arlo-go-2.html"
   ],

--- a/cameras/arlo/indoor-plug-in.json
+++ b/cameras/arlo/indoor-plug-in.json
@@ -51,7 +51,6 @@
     "Apple HomeKit / Google / Alexa",
     "Arlo Secure plan"
   ],
-  "msrp_usd": 89,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-indoor-plug-in"
   ],

--- a/cameras/arlo/pro-3-floodlight.json
+++ b/cameras/arlo/pro-3-floodlight.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 249.99,
   "sources": [
     "https://us.arlo.com/products/arlo-pro-3-floodlight"
   ],

--- a/cameras/arlo/pro-3.json
+++ b/cameras/arlo/pro-3.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "Apple HomeKit / Alexa / Google"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://us.arlo.com/products/arlo-pro-3"
   ],

--- a/cameras/arlo/pro-4-spotlight.json
+++ b/cameras/arlo/pro-4-spotlight.json
@@ -51,7 +51,6 @@
     "Arlo Secure plan",
     "IP65"
   ],
-  "msrp_usd": 129,
   "sources": [
     "https://www.arlo.com/cameras/pro/arlo-pro-4-spotlight-camera.html"
   ],

--- a/cameras/arlo/pro-4.json
+++ b/cameras/arlo/pro-4.json
@@ -53,7 +53,6 @@
     "Arlo Secure subscription for cloud history"
   ],
   "release_year": 2021,
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.arlo.com/asia/cameras/pro/arlo-pro-4.html"
   ],

--- a/cameras/arlo/pro-5s-4k-ultra.json
+++ b/cameras/arlo/pro-5s-4k-ultra.json
@@ -54,7 +54,6 @@
     "IP65",
     "Arlo flagship 2025"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
   ],

--- a/cameras/arlo/pro-5s-au.json
+++ b/cameras/arlo/pro-5s-au.json
@@ -56,7 +56,6 @@
     "IP65 rated AU conditions",
     "JB Hi-Fi / Harvey Norman stocked"
   ],
-  "msrp_aud": 259.99,
   "sources": [
     "https://www.arlo.com/en-au/"
   ],

--- a/cameras/arlo/pro-5s-ca.json
+++ b/cameras/arlo/pro-5s-ca.json
@@ -56,7 +56,6 @@
     "rated -20°C",
     "Best Buy Canada stocked"
   ],
-  "msrp_cad": 219.99,
   "sources": [
     "https://www.arlo.com/en-ca/"
   ],

--- a/cameras/arlo/pro-5s-eu.json
+++ b/cameras/arlo/pro-5s-eu.json
@@ -58,7 +58,6 @@
     "Arlo Secure plan",
     "EU-compliant cloud storage"
   ],
-  "msrp_eur": 179.99,
   "sources": [
     "https://www.arlo.com/de-de/"
   ],

--- a/cameras/arlo/pro-5s-uk.json
+++ b/cameras/arlo/pro-5s-uk.json
@@ -55,7 +55,6 @@
     "Apple HomeKit / Google / Alexa",
     "Arlo Secure plan"
   ],
-  "msrp_gbp": 149.99,
   "sources": [
     "https://www.arlo.com/en-gb/"
   ],

--- a/cameras/arlo/pro-5s.json
+++ b/cameras/arlo/pro-5s.json
@@ -53,7 +53,6 @@
     "Arlo Secure plan for cloud history"
   ],
   "release_year": 2023,
-  "msrp_usd": 249.99,
   "sources": [
     "https://www.arlo.com/cameras/pro/arlo-pro-5s.html"
   ],

--- a/cameras/arlo/security-light.json
+++ b/cameras/arlo/security-light.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 149.99,
   "sources": [
     "https://us.arlo.com/products/arlo-security-light"
   ],

--- a/cameras/arlo/solar-panel-cam.json
+++ b/cameras/arlo/solar-panel-cam.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://us.arlo.com/products/arlo-solar-panel-cam"
   ],

--- a/cameras/arlo/ultra-2-spotlight.json
+++ b/cameras/arlo/ultra-2-spotlight.json
@@ -53,7 +53,6 @@
     "Arlo Secure plan",
     "IP65"
   ],
-  "msrp_usd": 299,
   "sources": [
     "https://www.arlo.com/cameras/ultra/arlo-ultra-2-spotlight-camera.html"
   ],

--- a/cameras/arlo/ultra.json
+++ b/cameras/arlo/ultra.json
@@ -53,7 +53,6 @@
     "Arlo Secure plan",
     "Apple HomeKit / Alexa / Google"
   ],
-  "msrp_usd": 299.99,
   "sources": [
     "https://us.arlo.com/products/arlo-ultra"
   ],

--- a/cameras/arlo/video-doorbell-hd.json
+++ b/cameras/arlo/video-doorbell-hd.json
@@ -52,7 +52,6 @@
     "Arlo Secure plan",
     "IP55"
   ],
-  "msrp_usd": 149,
   "sources": [
     "https://www.arlo.com/cameras/doorbells/"
   ],

--- a/cameras/arlo/wired-doorbell-2nd-gen.json
+++ b/cameras/arlo/wired-doorbell-2nd-gen.json
@@ -53,7 +53,6 @@
     "Arlo Secure plan",
     "IP55"
   ],
-  "msrp_usd": 129,
   "sources": [
     "https://us.arlo.com/products/arlo-doorbell-wired-2nd-gen"
   ],

--- a/cameras/arlo/wired-floodlight-2025.json
+++ b/cameras/arlo/wired-floodlight-2025.json
@@ -53,7 +53,6 @@
     "Apple HomeKit / Google / Alexa",
     "Arlo Secure plan for cloud storage"
   ],
-  "msrp_usd": 249.99,
   "sources": [
     "https://www.arlo.com/"
   ],

--- a/cameras/blink/indoor.json
+++ b/cameras/blink/indoor.json
@@ -52,7 +52,6 @@
     "Blink Sync Module required",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/mini-2.json
+++ b/cameras/blink/mini-2.json
@@ -52,7 +52,6 @@
     "Alexa / Fire TV",
     "Blink Subscription for cloud storage"
   ],
-  "msrp_usd": 39.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/mini-2k-plus.json
+++ b/cameras/blink/mini-2k-plus.json
@@ -52,7 +52,6 @@
     "IP54",
     "Alexa / Fire TV"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/mini-pan-tilt-mount.json
+++ b/cameras/blink/mini-pan-tilt-mount.json
@@ -52,7 +52,6 @@
     "Alexa / Fire TV",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 59.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/mini-pro.json
+++ b/cameras/blink/mini-pro.json
@@ -52,7 +52,6 @@
     "Blink Subscription for cloud",
     "IP54"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/mini.json
+++ b/cameras/blink/mini.json
@@ -51,7 +51,6 @@
     "Blink Sync Module for local USB storage",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 34.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/outdoor-2k-plus.json
+++ b/cameras/blink/outdoor-2k-plus.json
@@ -54,7 +54,6 @@
     "Alexa / Fire TV",
     "Sync Module for local MicroSD storage"
   ],
-  "msrp_usd": 59.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/outdoor-3rd-gen.json
+++ b/cameras/blink/outdoor-3rd-gen.json
@@ -53,7 +53,6 @@
     "Blink Sync Module required",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/outdoor-4-eu.json
+++ b/cameras/blink/outdoor-4-eu.json
@@ -58,7 +58,6 @@
     "Blink Subscription for cloud",
     "popular budget EU Amazon camera"
   ],
-  "msrp_eur": 54.99,
   "sources": [
     "https://blinkforhome.com/de-de/"
   ],

--- a/cameras/blink/outdoor-4-floodlight.json
+++ b/cameras/blink/outdoor-4-floodlight.json
@@ -53,7 +53,6 @@
     "wire-free installation",
     "Blink Sync Module XR for extended range"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/outdoor-4-plus-solar.json
+++ b/cameras/blink/outdoor-4-plus-solar.json
@@ -52,7 +52,6 @@
     "Blink Sync Module for local USB storage",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 119.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/outdoor-4.json
+++ b/cameras/blink/outdoor-4.json
@@ -55,7 +55,6 @@
     "Blink Sync Module required for local storage",
     "Blink Subscription Plan for cloud"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/video-doorbell.json
+++ b/cameras/blink/video-doorbell.json
@@ -52,7 +52,6 @@
     "Blink Subscription for cloud video history",
     "local storage via Sync Module"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/wired-floodlight.json
+++ b/cameras/blink/wired-floodlight.json
@@ -52,7 +52,6 @@
     "Alexa / Fire TV",
     "Blink Subscription for cloud"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/blink/xt2.json
+++ b/cameras/blink/xt2.json
@@ -53,7 +53,6 @@
     "Blink Sync Module required",
     "free cloud storage included at launch"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://blinkforhome.com/products"
   ],

--- a/cameras/bosch-smart-home/outdoor-cam-2-ch.json
+++ b/cameras/bosch-smart-home/outdoor-cam-2-ch.json
@@ -62,7 +62,6 @@
     "Digitec / Galaxus CH stocked",
     "very popular CH/AT premium smart home brand"
   ],
-  "msrp_chf": 229.0,
   "sources": [
     "https://www.bosch-smarthome.com/ch/de/"
   ],

--- a/cameras/bosch-smart-home/outdoor-cam-2.json
+++ b/cameras/bosch-smart-home/outdoor-cam-2.json
@@ -60,7 +60,6 @@
     "GDPR-compliant German cloud (for EU)",
     "anthracite or white"
   ],
-  "msrp_gbp": 199.99,
   "sources": [
     "https://www.bosch-smarthome.com/uk/en/products/cameras/"
   ],

--- a/cameras/cp-plus/cp-e35q.json
+++ b/cameras/cp-plus/cp-e35q.json
@@ -60,7 +60,6 @@
     "CP Plus app",
     "₹3,500–4,500 price range"
   ],
-  "msrp_inr": 3999,
   "sources": [
     "https://www.cpplusworld.com/"
   ],

--- a/cameras/cp-plus/cp-unc-da21pl3.json
+++ b/cameras/cp-plus/cp-unc-da21pl3.json
@@ -62,7 +62,6 @@
     "₹3,000–5,000 price range",
     "STQC model available"
   ],
-  "msrp_inr": 3999,
   "sources": [
     "https://www.cpplusworld.com/cp-unc-da21pl3"
   ],

--- a/cameras/cp-plus/cp-unc-da41l3c-d-lq.json
+++ b/cameras/cp-plus/cp-unc-da41l3c-d-lq.json
@@ -61,7 +61,6 @@
     "IP67",
     "Made in India"
   ],
-  "msrp_inr": 6999,
   "sources": [
     "https://www.cpplusworld.com/"
   ],

--- a/cameras/cp-plus/cp-unc-ta21l3b-lq.json
+++ b/cameras/cp-plus/cp-unc-ta21l3b-lq.json
@@ -60,7 +60,6 @@
     "NVR compatible",
     "₹4,000–5,000"
   ],
-  "msrp_inr": 4999,
   "sources": [
     "https://www.cpplusworld.com/"
   ],

--- a/cameras/cp-plus/cp-unc-ta21pl3.json
+++ b/cameras/cp-plus/cp-unc-ta21pl3.json
@@ -60,7 +60,6 @@
     "most popular India outdoor bullet",
     "₹3,500–5,500 price range"
   ],
-  "msrp_inr": 4499,
   "sources": [
     "https://www.cpplusworld.com/cp-unc-ta21pl3"
   ],

--- a/cameras/cp-plus/cp-unc-ta41l3c-d-lq.json
+++ b/cameras/cp-plus/cp-unc-ta41l3c-d-lq.json
@@ -60,7 +60,6 @@
     "IP67",
     "Made in India"
   ],
-  "msrp_inr": 7499,
   "sources": [
     "https://www.cpplusworld.com/"
   ],

--- a/cameras/cp-plus/cp-z43q.json
+++ b/cameras/cp-plus/cp-z43q.json
@@ -62,7 +62,6 @@
     "IP66",
     "₹5,000–7,000"
   ],
-  "msrp_inr": 5999,
   "sources": [
     "https://www.cpplusworld.com/"
   ],

--- a/cameras/dahua/ipc-hdw2831t-as-s2.json
+++ b/cameras/dahua/ipc-hdw2831t-as-s2.json
@@ -55,7 +55,6 @@
     "IK10",
     "budget 4K"
   ],
-  "msrp_usd": 44.99,
   "sources": [
     "https://www.dahuasecurity.com"
   ],

--- a/cameras/dahua/ipc-hdw2849h-s-il-india.json
+++ b/cameras/dahua/ipc-hdw2849h-s-il-india.json
@@ -60,7 +60,6 @@
     "very popular Indian system integrators",
     "₹8,000–12,000"
   ],
-  "msrp_inr": 9999,
   "sources": [
     "https://www.dahuasecurity.com/"
   ],

--- a/cameras/dahua/ipc-hdw3849h-as-pv-eu.json
+++ b/cameras/dahua/ipc-hdw3849h-as-pv-eu.json
@@ -63,7 +63,6 @@
     "IK10",
     "very popular EU CCTV installer choice"
   ],
-  "msrp_eur": 139.99,
   "sources": [
     "https://www.dahuasecurity.com/eu/"
   ],

--- a/cameras/dahua/ipc-hdw3849h-as-pv-mena.json
+++ b/cameras/dahua/ipc-hdw3849h-as-pv-mena.json
@@ -63,7 +63,6 @@
     "IK10",
     "very popular UAE/KSA commercial installers"
   ],
-  "msrp_aed": 650,
   "sources": [
     "https://www.dahuasecurity.com/mena/"
   ],

--- a/cameras/dahua/ipc-hfw2431t-as-s2.json
+++ b/cameras/dahua/ipc-hfw2431t-as-s2.json
@@ -55,7 +55,6 @@
     "IK10",
     "high value"
   ],
-  "msrp_usd": 39.99,
   "sources": [
     "https://www.dahuasecurity.com"
   ],

--- a/cameras/dahua/ipc-hfw2849s-s-il-mena.json
+++ b/cameras/dahua/ipc-hfw2849s-s-il-mena.json
@@ -64,7 +64,6 @@
     "≈498 AED on Amazon.ae",
     "popular UAE budget 4K outdoor bullet"
   ],
-  "msrp_aed": 498,
   "sources": [
     "https://www.amazon.ae/IPC-HFW2849S-S-Network-WizSense-Full-Color-Security/dp/B0FL7XWMHM",
     "https://www.dahuasecurity.com/mena/"

--- a/cameras/dahua/ipc-hfw2849s-s-il-vn.json
+++ b/cameras/dahua/ipc-hfw2849s-s-il-vn.json
@@ -61,7 +61,6 @@
     "popular Vietnam business + residential installers",
     "Dahua local distributors Hanoi / HCMC"
   ],
-  "msrp_vnd": 1500000,
   "sources": [
     "https://www.dahuasecurity.com/vn-vi/"
   ],

--- a/cameras/dahua/sd49225xa-hnr-mena.json
+++ b/cameras/dahua/sd49225xa-hnr-mena.json
@@ -64,7 +64,6 @@
     "IP66",
     "widely used hotels/malls UAE & Saudi Arabia"
   ],
-  "msrp_aed": 1899,
   "sources": [
     "https://shop.acssllc.ae/product-category/dahua-camera/",
     "https://www.dahuasecurity.com/mena/"

--- a/cameras/eufy/eufycam-2-pro.json
+++ b/cameras/eufy/eufycam-2-pro.json
@@ -53,7 +53,6 @@
     "HomeBase local storage",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 219.99,
   "sources": [
     "https://www.eufy.com/products/eufycam-2-pro"
   ],

--- a/cameras/eufy/eufycam-2c.json
+++ b/cameras/eufy/eufycam-2c.json
@@ -51,7 +51,6 @@
     "HomeBase local storage",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 139.99,
   "sources": [
     "https://www.eufy.com/products/eufycam-2c"
   ],

--- a/cameras/eufy/eufycam-3-pro.json
+++ b/cameras/eufy/eufycam-3-pro.json
@@ -53,7 +53,6 @@
     "HomeBase local 16GB storage",
     "Apple HomeKit / Alexa / Google"
   ],
-  "msrp_usd": 249.99,
   "sources": [
     "https://www.eufy.com/products/eufycam-3-pro"
   ],

--- a/cameras/eufy/eufycam-3c-2k.json
+++ b/cameras/eufy/eufycam-3c-2k.json
@@ -54,7 +54,6 @@
     "IP67",
     "more affordable EufyCam 3 entry variant"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://www.eufy.com/products/eufycam-3c"
   ],

--- a/cameras/eufy/eufycam-e330-pro.json
+++ b/cameras/eufy/eufycam-e330-pro.json
@@ -52,7 +52,6 @@
     "no subscription required",
     "Apple HomeKit / Alexa / Google"
   ],
-  "msrp_usd": 279.99,
   "sources": [
     "https://www.eufy.com/products/eufycam-e330-pro"
   ],

--- a/cameras/eufy/eufycam-s330-pro.json
+++ b/cameras/eufy/eufycam-s330-pro.json
@@ -54,7 +54,6 @@
     "HomeKit / Alexa / Google",
     "IP67"
   ],
-  "msrp_usd": 179,
   "sources": [
     "https://www.eufy.com/products/eufycam-s330-pro"
   ],

--- a/cameras/eufy/floodlight-cam-2-pro.json
+++ b/cameras/eufy/floodlight-cam-2-pro.json
@@ -52,7 +52,6 @@
     "Alexa / Google"
   ],
   "release_year": 2022,
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.eufy.com/products/floodlight-cam-2-pro"
   ],

--- a/cameras/eufy/floodlight-cam-e220.json
+++ b/cameras/eufy/floodlight-cam-e220.json
@@ -56,7 +56,6 @@
     "HomeKit / Alexa / Google",
     "IP67"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://www.eufy.com/products/floodlight-cam-e220"
   ],

--- a/cameras/eufy/floodlight-cam-e340.json
+++ b/cameras/eufy/floodlight-cam-e340.json
@@ -52,7 +52,6 @@
     "HomeKit / Alexa / Google",
     "IP67"
   ],
-  "msrp_usd": 249,
   "sources": [
     "https://www.eufy.com/products/floodlight-cam-e340"
   ],

--- a/cameras/eufy/floodlight-e340.json
+++ b/cameras/eufy/floodlight-e340.json
@@ -62,7 +62,6 @@
     "IP67",
     "top-rated EU floodlight cam"
   ],
-  "msrp_eur": 249.99,
   "sources": [
     "https://www.eufy.com/de-de/"
   ],

--- a/cameras/eufy/garage-cam-s330.json
+++ b/cameras/eufy/garage-cam-s330.json
@@ -51,7 +51,6 @@
     "real-time door status alerts",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://www.eufy.com/products/garage-cam-s330"
   ],

--- a/cameras/eufy/homebase-3-s380-cam-e340.json
+++ b/cameras/eufy/homebase-3-s380-cam-e340.json
@@ -51,7 +51,6 @@
     "no subscription",
     "Alexa / Google"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.eufy.com/"
   ],

--- a/cameras/eufy/homebase-s380-cam-s330.json
+++ b/cameras/eufy/homebase-s380-cam-s330.json
@@ -48,7 +48,6 @@
     "Alexa / Google integration"
   ],
   "release_year": 2023,
-  "msrp_usd": 149.99,
   "sources": [
     "https://www.eufy.com/products/eufycam-3c"
   ],

--- a/cameras/eufy/indoor-cam-2k-pan-tilt.json
+++ b/cameras/eufy/indoor-cam-2k-pan-tilt.json
@@ -57,7 +57,6 @@
     "RTSP support",
     "€35–45 best-value Eufy indoor"
   ],
-  "msrp_usd": 35,
   "sources": [
     "https://www.eufy.com/products/indoor-cam-2k-pan-tilt"
   ],

--- a/cameras/eufy/indoor-cam-c120.json
+++ b/cameras/eufy/indoor-cam-c120.json
@@ -55,7 +55,6 @@
     "RTSP support",
     "Alexa / Google HomeKit"
   ],
-  "msrp_usd": 29.99,
   "sources": [
     "https://www.eufy.com/products/indoor-cam-c120"
   ],

--- a/cameras/eufy/indoor-cam-e220.json
+++ b/cameras/eufy/indoor-cam-e220.json
@@ -53,7 +53,6 @@
     "HomeKit / Alexa / Google",
     "RTSP support"
   ],
-  "msrp_usd": 39,
   "sources": [
     "https://www.eufy.com/products/indoor-cam-e220"
   ],

--- a/cameras/eufy/indoor-cam-mini.json
+++ b/cameras/eufy/indoor-cam-mini.json
@@ -50,7 +50,6 @@
     "microSD card slot",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 29.99,
   "sources": [
     "https://www.eufy.com/products/indoor-cam-mini"
   ],

--- a/cameras/eufy/indoor-cam-s350.json
+++ b/cameras/eufy/indoor-cam-s350.json
@@ -53,7 +53,6 @@
     "HomeKit / Alexa / Google",
     "RTSP support"
   ],
-  "msrp_usd": 99,
   "sources": [
     "https://www.eufy.com/products/indoor-cam-s350"
   ],

--- a/cameras/eufy/outdoor-cam-e210.json
+++ b/cameras/eufy/outdoor-cam-e210.json
@@ -52,7 +52,6 @@
     "IP67 weatherproof",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://www.eufy.com/products/outdoor-cam-e210"
   ],

--- a/cameras/eufy/s220-solocam.json
+++ b/cameras/eufy/s220-solocam.json
@@ -49,7 +49,6 @@
     "Alexa / Google"
   ],
   "release_year": 2023,
-  "msrp_usd": 99.99,
   "sources": [
     "https://www.eufy.com/products/solocam-s220"
   ],

--- a/cameras/eufy/solocam-c210.json
+++ b/cameras/eufy/solocam-c210.json
@@ -52,7 +52,6 @@
     "Alexa / Google",
     "IP67"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://www.eufy.com/products/solocam-c210"
   ],

--- a/cameras/eufy/solocam-e40.json
+++ b/cameras/eufy/solocam-e40.json
@@ -50,7 +50,6 @@
   ],
   "operating_temp_c": "-20 to 50",
   "release_year": 2022,
-  "msrp_usd": 119.99,
   "sources": [
     "https://support.eufy.com/s/article/eufy-SoloCam-E40-FAQ",
     "https://service.eufy.com/article-description/Introducing-eufy-SoloCam-E40"

--- a/cameras/eufy/solocam-l20.json
+++ b/cameras/eufy/solocam-l20.json
@@ -52,7 +52,6 @@
     "IP67 weatherproof",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 39.99,
   "sources": [
     "https://www.eufy.com/products/solocam-l20"
   ],

--- a/cameras/eufy/solocam-l40.json
+++ b/cameras/eufy/solocam-l40.json
@@ -52,7 +52,6 @@
     "IP67 weatherproof",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 59.99,
   "sources": [
     "https://www.eufy.com/products/solocam-l40"
   ],

--- a/cameras/eufy/solocam-s220-uk.json
+++ b/cameras/eufy/solocam-s220-uk.json
@@ -55,7 +55,6 @@
     "Alexa / Google HomeKit",
     "popular UK Amazon choice"
   ],
-  "msrp_gbp": 99.99,
   "sources": [
     "https://www.eufy.com/en-gb/"
   ],

--- a/cameras/eufy/solocam-s230.json
+++ b/cameras/eufy/solocam-s230.json
@@ -53,7 +53,6 @@
     "IP67 weatherproof",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 119.99,
   "sources": [
     "https://www.eufy.com/products/solocam-s230"
   ],

--- a/cameras/eufy/solocam-s340-au.json
+++ b/cameras/eufy/solocam-s340-au.json
@@ -56,7 +56,6 @@
     "IP67",
     "JB Hi-Fi / The Good Guys AU stocked"
   ],
-  "msrp_aud": 329.99,
   "sources": [
     "https://www.eufy.com/au-en/"
   ],

--- a/cameras/eufy/solocam-s340-ca.json
+++ b/cameras/eufy/solocam-s340-ca.json
@@ -58,7 +58,6 @@
     "rated -20°C",
     "Best Buy Canada top pick"
   ],
-  "msrp_cad": 269.99,
   "sources": [
     "https://www.eufy.com/ca-en/"
   ],

--- a/cameras/eufy/solocam-s340-ch.json
+++ b/cameras/eufy/solocam-s340-ch.json
@@ -58,7 +58,6 @@
     "IP67",
     "Digitec / Galaxus CH top pick no-fee camera"
   ],
-  "msrp_chf": 219.0,
   "sources": [
     "https://www.eufy.com/ch-de/",
     "https://www.digitec.ch/"

--- a/cameras/eufy/solocam-s340-eu.json
+++ b/cameras/eufy/solocam-s340-eu.json
@@ -59,7 +59,6 @@
     "IP67",
     "popular EU Amazon #1 no-fee camera"
   ],
-  "msrp_eur": 199.99,
   "sources": [
     "https://www.eufy.com/de-de/"
   ],

--- a/cameras/eufy/solocam-s340.json
+++ b/cameras/eufy/solocam-s340.json
@@ -52,7 +52,6 @@
     "local HomeBase storage",
     "Alexa / Google"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.eufy.com/products/solocam-s340"
   ],

--- a/cameras/eufy/solocam-s40.json
+++ b/cameras/eufy/solocam-s40.json
@@ -49,7 +49,6 @@
     "Alexa and Google Assistant integration"
   ],
   "release_year": 2022,
-  "msrp_usd": 129.99,
   "sources": [
     "https://www.eufy.com/products/t8124"
   ],

--- a/cameras/eufy/video-doorbell-dual.json
+++ b/cameras/eufy/video-doorbell-dual.json
@@ -49,7 +49,6 @@
     "HomeBase 2 compatible (optional)"
   ],
   "release_year": 2022,
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.eufy.com/video-doorbells"
   ],

--- a/cameras/eufy/video-doorbell-e340.json
+++ b/cameras/eufy/video-doorbell-e340.json
@@ -53,7 +53,6 @@
     "two-way audio",
     "IP65"
   ],
-  "msrp_usd": 159,
   "sources": [
     "https://www.eufy.com/products/video-doorbell-e340"
   ],

--- a/cameras/eufy/video-doorbell-s220.json
+++ b/cameras/eufy/video-doorbell-s220.json
@@ -50,7 +50,6 @@
     "no subscription required",
     "Alexa / Google Assistant"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://www.eufy.com/products/video-doorbell-s220"
   ],

--- a/cameras/eufy/video-doorbell-s330.json
+++ b/cameras/eufy/video-doorbell-s330.json
@@ -56,7 +56,6 @@
     "two-way audio",
     "IP65"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://www.eufy.com/products/video-doorbell-s330"
   ],

--- a/cameras/ezviz/bc1c-elife.json
+++ b/cameras/ezviz/bc1c-elife.json
@@ -55,7 +55,6 @@
     "EZVIZ app / Alexa / Google",
     "IP66"
   ],
-  "msrp_eur": 89,
   "sources": [
     "https://www.ezviz.com/product/ezviz-elife/"
   ],

--- a/cameras/ezviz/c1c-pir.json
+++ b/cameras/ezviz/c1c-pir.json
@@ -57,7 +57,6 @@
     "pet/baby monitoring",
     "very compact €30 price"
   ],
-  "msrp_eur": 29,
   "sources": [
     "https://www.ezviz.com/product/c1c/"
   ],

--- a/cameras/ezviz/c3w-pro.json
+++ b/cameras/ezviz/c3w-pro.json
@@ -59,7 +59,6 @@
     "Alexa / Google",
     "EZVIZ app"
   ],
-  "msrp_eur": 59,
   "sources": [
     "https://www.ezviz.com/product/c3w-pro/"
   ],

--- a/cameras/ezviz/c3x.json
+++ b/cameras/ezviz/c3x.json
@@ -56,7 +56,6 @@
     "RTSP/ONVIF",
     "IP67"
   ],
-  "msrp_eur": 79,
   "sources": [
     "https://www.ezviz.com/product/c3x/"
   ],

--- a/cameras/ezviz/c6n-mena.json
+++ b/cameras/ezviz/c6n-mena.json
@@ -61,7 +61,6 @@
     "≈99 AED ultra-budget",
     "#1 budget indoor cam Amazon.ae Noon"
   ],
-  "msrp_aed": 99,
   "sources": [
     "https://www.ezviz.com/me-en/",
     "https://www.amazon.ae/"

--- a/cameras/ezviz/c6n-vn.json
+++ b/cameras/ezviz/c6n-vn.json
@@ -60,7 +60,6 @@
     "#1 budget indoor WiFi cam Lazada/Shopee/Tiki Vietnam",
     "≈400,000–600,000 VND price point"
   ],
-  "msrp_vnd": 499000,
   "sources": [
     "https://www.ezviz.com/vn-vi/"
   ],

--- a/cameras/ezviz/c6n.json
+++ b/cameras/ezviz/c6n.json
@@ -60,7 +60,6 @@
     "RTSP/ONVIF",
     "night vision"
   ],
-  "msrp_gbp": 29.99,
   "sources": [
     "https://www.ezviz.com/product/c6n/"
   ],

--- a/cameras/ezviz/c8c.json
+++ b/cameras/ezviz/c8c.json
@@ -62,7 +62,6 @@
     "RTSP/ONVIF",
     "Alexa / Google"
   ],
-  "msrp_gbp": 49.99,
   "sources": [
     "https://www.ezviz.com/product/c8c/"
   ],

--- a/cameras/ezviz/c8pf.json
+++ b/cameras/ezviz/c8pf.json
@@ -59,7 +59,6 @@
     "H.265",
     "RTSP/ONVIF"
   ],
-  "msrp_gbp": 79.99,
   "sources": [
     "https://www.ezviz.com/product/c8pf/"
   ],

--- a/cameras/ezviz/c8w-pro-eu.json
+++ b/cameras/ezviz/c8w-pro-eu.json
@@ -66,7 +66,6 @@
     "Alexa / Google",
     "popular EU Amazon budget PTZ"
   ],
-  "msrp_eur": 69.99,
   "sources": [
     "https://www.ezviz.com/de-de/"
   ],

--- a/cameras/ezviz/db2-doorbell.json
+++ b/cameras/ezviz/db2-doorbell.json
@@ -57,7 +57,6 @@
     "IP65",
     "H.265"
   ],
-  "msrp_eur": 79,
   "sources": [
     "https://www.ezviz.com/product/db2/"
   ],

--- a/cameras/ezviz/db2c-doorbell.json
+++ b/cameras/ezviz/db2c-doorbell.json
@@ -56,7 +56,6 @@
     "IP65",
     "budget entry doorbell"
   ],
-  "msrp_eur": 59,
   "sources": [
     "https://www.ezviz.com/product/db2c/"
   ],

--- a/cameras/ezviz/h3c-2k.json
+++ b/cameras/ezviz/h3c-2k.json
@@ -57,7 +57,6 @@
     "privacy shield cover",
     "H.265"
   ],
-  "msrp_eur": 39,
   "sources": [
     "https://www.ezviz.com/product/h3c/"
   ],

--- a/cameras/ezviz/h8-pro-3k-mena.json
+++ b/cameras/ezviz/h8-pro-3k-mena.json
@@ -63,7 +63,6 @@
     "Alexa/Google",
     "popular budget choice Amazon.ae / Noon UAE"
   ],
-  "msrp_aed": 299,
   "sources": [
     "https://www.ezviz.com/me-en/",
     "https://www.amazon.ae/"

--- a/cameras/ezviz/h8-pro-3k.json
+++ b/cameras/ezviz/h8-pro-3k.json
@@ -63,7 +63,6 @@
     "H.265",
     "Alexa / Google"
   ],
-  "msrp_gbp": 69.99,
   "sources": [
     "https://www.ezviz.com/product/h8+pro+3k/"
   ],

--- a/cameras/ezviz/h8c-pro-2k-plus.json
+++ b/cameras/ezviz/h8c-pro-2k-plus.json
@@ -62,7 +62,6 @@
     "RTSP/ONVIF",
     "H.265"
   ],
-  "msrp_gbp": 64.99,
   "sources": [
     "https://www.ezviz.com/product/h8c+pro+2k/"
   ],

--- a/cameras/ezviz/h8c-pro-4k.json
+++ b/cameras/ezviz/h8c-pro-4k.json
@@ -62,7 +62,6 @@
     "RTSP/ONVIF",
     "H.265"
   ],
-  "msrp_gbp": 89.99,
   "sources": [
     "https://www.ezviz.com/product/h8c+pro+4k/"
   ],

--- a/cameras/ezviz/h8c-vn.json
+++ b/cameras/ezviz/h8c-vn.json
@@ -62,7 +62,6 @@
     "popular outdoor WiFi Shopee/Lazada Vietnam",
     "≈900,000–1,200,000 VND"
   ],
-  "msrp_vnd": 999000,
   "sources": [
     "https://www.ezviz.com/vn-vi/"
   ],

--- a/cameras/ezviz/h8c.json
+++ b/cameras/ezviz/h8c.json
@@ -62,7 +62,6 @@
     "RTSP/ONVIF",
     "Alexa / Google"
   ],
-  "msrp_gbp": 59.99,
   "sources": [
     "https://www.ezviz.com/product/h8c/"
   ],

--- a/cameras/godrej/eve-cube.json
+++ b/cameras/godrej/eve-cube.json
@@ -58,7 +58,6 @@
     "no subscription",
     "₹4,500"
   ],
-  "msrp_inr": 4500,
   "sources": [
     "https://pricee.com/godrej-eve-cube-cctv-security-camera-price-in-india-90722"
   ],

--- a/cameras/godrej/eve-mini.json
+++ b/cameras/godrej/eve-mini.json
@@ -58,7 +58,6 @@
     "no subscription",
     "₹5,500"
   ],
-  "msrp_inr": 5524,
   "sources": [
     "https://pricee.com/godrej-eve-mini-cctv-security-camera-price-in-india-90724"
   ],

--- a/cameras/godrej/eve-nx-pt.json
+++ b/cameras/godrej/eve-nx-pt.json
@@ -61,7 +61,6 @@
     "no subscription required",
     "₹3,000–5,000"
   ],
-  "msrp_inr": 3999,
   "sources": [
     "https://www.amazon.in/Godrej-Eve-Nx-PT-Security/dp/B0886XDDDF"
   ],

--- a/cameras/godrej/eve-pro-outdoor.json
+++ b/cameras/godrej/eve-pro-outdoor.json
@@ -54,7 +54,6 @@
     "no subscription",
     "₹5,999"
   ],
-  "msrp_inr": 5999,
   "sources": [
     "https://www.amazon.in/"
   ],

--- a/cameras/google/nest-cam-battery-1st-gen.json
+++ b/cameras/google/nest-cam-battery-1st-gen.json
@@ -52,7 +52,6 @@
     "Nest Aware subscription for extended history",
     "Google Home app required"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://store.google.com/product/nest_cam_battery"
   ],

--- a/cameras/google/nest-cam-battery-2021.json
+++ b/cameras/google/nest-cam-battery-2021.json
@@ -59,7 +59,6 @@
   "dimensions_mm": "83 × 83 × 83",
   "weight_g": 398,
   "release_year": 2021,
-  "msrp_usd": 179.99,
   "sources": [
     "https://store.google.com/product/nest_cam_battery_specs"
   ],

--- a/cameras/google/nest-cam-indoor-1st-gen.json
+++ b/cameras/google/nest-cam-indoor-1st-gen.json
@@ -52,7 +52,6 @@
     "magnetic base",
     "Nest app / Google Home"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://store.google.com/product/nest_cam_indoor"
   ],

--- a/cameras/google/nest-cam-indoor-3rd-gen.json
+++ b/cameras/google/nest-cam-indoor-3rd-gen.json
@@ -55,7 +55,6 @@
     "encrypted video",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
   ],

--- a/cameras/google/nest-cam-iq-indoor.json
+++ b/cameras/google/nest-cam-iq-indoor.json
@@ -52,7 +52,6 @@
     "activity zones",
     "Nest app / Google Home"
   ],
-  "msrp_usd": 299,
   "sources": [
     "https://store.google.com/product/nest_cam_iq"
   ],

--- a/cameras/google/nest-cam-iq-outdoor.json
+++ b/cameras/google/nest-cam-iq-outdoor.json
@@ -53,7 +53,6 @@
     "IP66 weatherproof",
     "Nest app / Google Home"
   ],
-  "msrp_usd": 349,
   "sources": [
     "https://store.google.com/product/nest_cam_iq_outdoor"
   ],

--- a/cameras/google/nest-cam-outdoor-1st-gen.json
+++ b/cameras/google/nest-cam-outdoor-1st-gen.json
@@ -53,7 +53,6 @@
     "magnetic mount",
     "Nest app / Google Home"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://store.google.com/product/nest_cam_outdoor"
   ],

--- a/cameras/google/nest-cam-outdoor-2nd-gen-eu.json
+++ b/cameras/google/nest-cam-outdoor-2nd-gen-eu.json
@@ -60,7 +60,6 @@
     "Alexa / Google Home",
     "EU GDPR-compliant (Google Cloud EU)"
   ],
-  "msrp_eur": 149.99,
   "sources": [
     "https://store.google.com/de/product/nest_cam_outdoor_specs"
   ],

--- a/cameras/google/nest-cam-outdoor-2nd-gen.json
+++ b/cameras/google/nest-cam-outdoor-2nd-gen.json
@@ -55,7 +55,6 @@
     "encrypted video",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 149.99,
   "sources": [
     "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
   ],

--- a/cameras/google/nest-cam-wired-2021.json
+++ b/cameras/google/nest-cam-wired-2021.json
@@ -54,7 +54,6 @@
     "Alexa"
   ],
   "release_year": 2021,
-  "msrp_usd": 99.99,
   "sources": [
     "https://store.google.com/product/nest_cam_specs"
   ],

--- a/cameras/google/nest-cam-with-floodlight.json
+++ b/cameras/google/nest-cam-with-floodlight.json
@@ -52,7 +52,6 @@
     "Alexa / Google Home",
     "color night vision"
   ],
-  "msrp_usd": 279.99,
   "sources": [
     "https://store.google.com/product/nest_cam_floodlight_specs"
   ],

--- a/cameras/google/nest-doorbell-3rd-gen.json
+++ b/cameras/google/nest-doorbell-3rd-gen.json
@@ -56,7 +56,6 @@
     "compatible with Gen 2 backplate",
     "Google Home Premium for Gemini"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
   ],

--- a/cameras/google/nest-doorbell-wired-2nd-gen-uk.json
+++ b/cameras/google/nest-doorbell-wired-2nd-gen-uk.json
@@ -53,7 +53,6 @@
     "dual-band WiFi",
     "Alexa / Google Home"
   ],
-  "msrp_gbp": 179.99,
   "sources": [
     "https://store.google.com/gb/product/nest_doorbell_wired_2nd_gen_specs"
   ],

--- a/cameras/google/nest-doorbell-wired-2nd-gen.json
+++ b/cameras/google/nest-doorbell-wired-2nd-gen.json
@@ -53,7 +53,6 @@
     "Alexa / Google Home",
     "DXOMARK best doorbell image quality at launch"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://store.google.com/product/nest_doorbell_wired_2nd_gen_specs"
   ],

--- a/cameras/hikvision/ds-2cd1143g2-liuf-india.json
+++ b/cameras/hikvision/ds-2cd1143g2-liuf-india.json
@@ -61,7 +61,6 @@
     "sold via Prama Hikvision India",
     "₹5,000–8,000"
   ],
-  "msrp_inr": 6999,
   "sources": [
     "https://www.hikvision.com/in-en/"
   ],

--- a/cameras/hikvision/ds-2cd2047g2-lu-sl-mena.json
+++ b/cameras/hikvision/ds-2cd2047g2-lu-sl-mena.json
@@ -62,7 +62,6 @@
     "SIRA-approved",
     "popular Dubai commercial & warehouse sites"
   ],
-  "msrp_aed": 699,
   "sources": [
     "https://hikvision-uae.ae/product/ds-2cd2047g2-lu-sl/",
     "https://www.hikvision.com/mena-en/"

--- a/cameras/hikvision/ds-2cd2143g2-iu-vn.json
+++ b/cameras/hikvision/ds-2cd2143g2-iu-vn.json
@@ -61,7 +61,6 @@
     "popular Vietnam residential + commercial dome camera",
     "Hikvision local Vietnam distributor network"
   ],
-  "msrp_vnd": 1200000,
   "sources": [
     "https://www.hikvision.com/vn-vi/"
   ],

--- a/cameras/hikvision/ds-2cd2147g2h-liu-eu.json
+++ b/cameras/hikvision/ds-2cd2147g2h-liu-eu.json
@@ -68,7 +68,6 @@
     "IK10",
     "most popular EU professional installer 4MP dome"
   ],
-  "msrp_eur": 109.99,
   "sources": [
     "https://www.hikvision.com/de-de/"
   ],

--- a/cameras/hikvision/ds-2cd2387g2-lu-au.json
+++ b/cameras/hikvision/ds-2cd2387g2-lu-au.json
@@ -62,7 +62,6 @@
     "most popular AU installer IP camera (Precision Security / Hypower Security)",
     "available AU security wholesalers"
   ],
-  "msrp_aud": 219.99,
   "sources": [
     "https://www.hikvision.com/au-en/"
   ],

--- a/cameras/hikvision/ds-2cd2387g2-lu-mena.json
+++ b/cameras/hikvision/ds-2cd2387g2-lu-mena.json
@@ -65,7 +65,6 @@
     "≈815 AED price point",
     "popular Dubai villas & retail"
   ],
-  "msrp_aed": 815,
   "sources": [
     "https://hikvision-uae.ae/product/hikvision-ds-2cd2387g2-lu/",
     "https://www.hikvision.com/mena-en/"

--- a/cameras/hikvision/ds-2cd2t47g2-l-ch.json
+++ b/cameras/hikvision/ds-2cd2t47g2-l-ch.json
@@ -63,7 +63,6 @@
     "popular CH/AT installer market",
     "available Swiss security distributors"
   ],
-  "msrp_chf": 179.0,
   "sources": [
     "https://www.hikvision.com/ch-de/"
   ],

--- a/cameras/hikvision/ds-2cd2t47g2-l-mena.json
+++ b/cameras/hikvision/ds-2cd2t47g2-l-mena.json
@@ -64,7 +64,6 @@
     "≈620 AED",
     "most popular outdoor bullet UAE/KSA installer market"
   ],
-  "msrp_aed": 620,
   "sources": [
     "https://hikvisioncameradubai.com/product/hikvision-ds-2cd2t47g2-l/",
     "https://www.hikvision.com/mena-en/"

--- a/cameras/hikvision/ds-2cd2t47g2-l-vn.json
+++ b/cameras/hikvision/ds-2cd2t47g2-l-vn.json
@@ -61,7 +61,6 @@
     "most popular outdoor PoE camera Vietnam installers",
     "available at Điện máy Xanh / Thế Giới Di Động / Bach Khoa"
   ],
-  "msrp_vnd": 1800000,
   "sources": [
     "https://www.hikvision.com/vn-vi/"
   ],

--- a/cameras/hikvision/ds-2de4425iw-de-t5-india.json
+++ b/cameras/hikvision/ds-2de4425iw-de-t5-india.json
@@ -61,7 +61,6 @@
     "very popular commercial India PTZ",
     "₹25,000–35,000"
   ],
-  "msrp_inr": 28999,
   "sources": [
     "https://www.hikvision.com/in-en/"
   ],

--- a/cameras/hikvision/ds-2de4425iwg-e-mena.json
+++ b/cameras/hikvision/ds-2de4425iwg-e-mena.json
@@ -64,7 +64,6 @@
     "standard PTZ for malls/hotels/airports UAE & Saudi",
     "≈2,200 AED"
   ],
-  "msrp_aed": 2200,
   "sources": [
     "https://www.hikvision.com/mena-en/"
   ],

--- a/cameras/hikvision/ds-2de4a404iwg-e.json
+++ b/cameras/hikvision/ds-2de4a404iwg-e.json
@@ -56,7 +56,6 @@
     "auto-tracking",
     "most affordable Hikvision PoE mini PTZ"
   ],
-  "msrp_usd": 299,
   "sources": [
     "https://www.hikvision.com/en/products/"
   ],

--- a/cameras/hilook/ipc-b140h.json
+++ b/cameras/hilook/ipc-b140h.json
@@ -58,7 +58,6 @@
     "most affordable Hikvision-ecosystem bullet",
     "UK/EU installer favourite"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-b180ha-lu.json
+++ b/cameras/hilook/ipc-b180ha-lu.json
@@ -59,7 +59,6 @@
     "Hikvision NVR compatible",
     "mid-range HiLook upgrade"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-b240h.json
+++ b/cameras/hilook/ipc-b240h.json
@@ -56,7 +56,6 @@
     "IP67",
     "Hikvision NVR compatible"
   ],
-  "msrp_usd": 52,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-b480h.json
+++ b/cameras/hilook/ipc-b480h.json
@@ -57,7 +57,6 @@
     "Hikvision NVR compatible",
     "best-value 4K bullet entry-level"
   ],
-  "msrp_usd": 59,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-b541h-z.json
+++ b/cameras/hilook/ipc-b541h-z.json
@@ -59,7 +59,6 @@
     "Hikvision NVR compatible",
     "mid-range HiLook"
   ],
-  "msrp_usd": 69,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-b580h-z.json
+++ b/cameras/hilook/ipc-b580h-z.json
@@ -58,7 +58,6 @@
     "Hikvision NVR compatible",
     "mid-range HiLook varifocal"
   ],
-  "msrp_usd": 89,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-c220ha-dw.json
+++ b/cameras/hilook/ipc-c220ha-dw.json
@@ -56,7 +56,6 @@
     "IP67",
     "most affordable HiLook WiFi outdoor cam"
   ],
-  "msrp_usd": 39,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-c340ha-dw.json
+++ b/cameras/hilook/ipc-c340ha-dw.json
@@ -55,7 +55,6 @@
     "H.265+",
     "IP67"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-d140h.json
+++ b/cameras/hilook/ipc-d140h.json
@@ -58,7 +58,6 @@
     "Hikvision NVR compatible",
     "budget UK/EU installer dome"
   ],
-  "msrp_usd": 45,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-d140ha-lu.json
+++ b/cameras/hilook/ipc-d140ha-lu.json
@@ -57,7 +57,6 @@
     "IP67",
     "Hikvision NVR compatible"
   ],
-  "msrp_usd": 55,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-d180h.json
+++ b/cameras/hilook/ipc-d180h.json
@@ -57,7 +57,6 @@
     "IK10",
     "Hikvision NVR compatible"
   ],
-  "msrp_usd": 55,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-d240h.json
+++ b/cameras/hilook/ipc-d240h.json
@@ -57,7 +57,6 @@
     "IK10",
     "Hikvision NVR compatible"
   ],
-  "msrp_usd": 50,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-t140h.json
+++ b/cameras/hilook/ipc-t140h.json
@@ -58,7 +58,6 @@
     "Hikvision NVR compatible",
     "most popular UK budget turret"
   ],
-  "msrp_usd": 47,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-t240h.json
+++ b/cameras/hilook/ipc-t240h.json
@@ -56,7 +56,6 @@
     "IP67",
     "formerly UK bestselling HiLook model"
   ],
-  "msrp_usd": 45,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-t240ha.json
+++ b/cameras/hilook/ipc-t240ha.json
@@ -57,7 +57,6 @@
     "IK10",
     "Hikvision NVR compatible"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-t280h.json
+++ b/cameras/hilook/ipc-t280h.json
@@ -58,7 +58,6 @@
     "Hikvision NVR compatible",
     "4K upgrade HiLook turret"
   ],
-  "msrp_usd": 55,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ipc-t280ha-lu.json
+++ b/cameras/hilook/ipc-t280ha-lu.json
@@ -60,7 +60,6 @@
     "Hikvision NVR compatible",
     "best-value 4K turret with hybrid light"
   ],
-  "msrp_usd": 75,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/ptz-n4mp.json
+++ b/cameras/hilook/ptz-n4mp.json
@@ -58,7 +58,6 @@
     "Hikvision NVR compatible",
     "most affordable HiLook PTZ"
   ],
-  "msrp_usd": 149,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/thc-b140m.json
+++ b/cameras/hilook/thc-b140m.json
@@ -54,7 +54,6 @@
     "IP66",
     "budget analog upgrade path for legacy coax systems"
   ],
-  "msrp_usd": 35,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hilook/thc-t140m.json
+++ b/cameras/hilook/thc-t140m.json
@@ -53,7 +53,6 @@
     "IK10",
     "most affordable HiLook camera for coax upgrades"
   ],
-  "msrp_usd": 33,
   "sources": [
     "https://www.hikvision.com/en/products/HiLook-IP-Products/"
   ],

--- a/cameras/hive/cam-porch-sensor.json
+++ b/cameras/hive/cam-porch-sensor.json
@@ -47,7 +47,6 @@
   "markets": [
     "UK"
   ],
-  "msrp_gbp": 119,
   "power_source": [
     "usb"
   ]

--- a/cameras/hive/view-indoor-2.json
+++ b/cameras/hive/view-indoor-2.json
@@ -46,7 +46,6 @@
   "markets": [
     "UK"
   ],
-  "msrp_gbp": 99,
   "power_source": [
     "usb"
   ]

--- a/cameras/hive/view-indoor.json
+++ b/cameras/hive/view-indoor.json
@@ -56,7 +56,6 @@
     "designed by Yves Béhar",
     "UK market leader in smart home"
   ],
-  "msrp_gbp": 99.99,
   "sources": [
     "https://www.hivehome.com/"
   ],

--- a/cameras/hive/view-outdoor-2.json
+++ b/cameras/hive/view-outdoor-2.json
@@ -52,7 +52,6 @@
     "30-day cloud subscription",
     "IP65"
   ],
-  "msrp_gbp": 149,
   "sources": [
     "https://www.hivehome.com/"
   ],

--- a/cameras/hive/view-outdoor.json
+++ b/cameras/hive/view-outdoor.json
@@ -57,7 +57,6 @@
     "UK British Gas brand recognition",
     "30-day cloud storage subscription"
   ],
-  "msrp_gbp": 119.99,
   "sources": [
     "https://www.hivehome.com/"
   ],

--- a/cameras/honeywell/hcc-ip-3mp-dome.json
+++ b/cameras/honeywell/hcc-ip-3mp-dome.json
@@ -60,7 +60,6 @@
     "preferred enterprise/government India",
     "₹8,000–15,000"
   ],
-  "msrp_inr": 10999,
   "sources": [
     "https://www.honeywell.com/en-us/company/india"
   ],

--- a/cameras/honeywell/hcc-ip-4mp-bullet.json
+++ b/cameras/honeywell/hcc-ip-4mp-bullet.json
@@ -60,7 +60,6 @@
     "preferred enterprise/government India",
     "₹10,000–16,000"
   ],
-  "msrp_inr": 13999,
   "sources": [
     "https://www.honeywell.com/en-us/company/india"
   ],

--- a/cameras/honeywell/pro-320pt.json
+++ b/cameras/honeywell/pro-320pt.json
@@ -49,7 +49,6 @@
     "Alexa / Google",
     "two-way audio"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.honeywellhome.com/"
   ],

--- a/cameras/imou/bullet-2e-5mp.json
+++ b/cameras/imou/bullet-2e-5mp.json
@@ -64,7 +64,6 @@
     "Alexa",
     "₹5,000–7,000 popular India outdoor"
   ],
-  "msrp_inr": 5999,
   "sources": [
     "https://www.imoulife.com/"
   ],

--- a/cameras/imou/cruiser-2-5mp-mena.json
+++ b/cameras/imou/cruiser-2-5mp-mena.json
@@ -65,7 +65,6 @@
     "≈399 AED",
     "value outdoor PTZ"
   ],
-  "msrp_aed": 399,
   "sources": [
     "https://www.imoulife.com/me-en/",
     "https://www.amazon.ae/"

--- a/cameras/imou/cruiser-2-5mp.json
+++ b/cameras/imou/cruiser-2-5mp.json
@@ -62,7 +62,6 @@
     "Alexa",
     "₹7,000–9,000 best outdoor India PTZ"
   ],
-  "msrp_inr": 7499,
   "sources": [
     "https://www.imoulife.com/"
   ],

--- a/cameras/imou/ranger-2-vn.json
+++ b/cameras/imou/ranger-2-vn.json
@@ -61,7 +61,6 @@
     "≈350,000–500,000 VND",
     "top-selling Shopee Vietnam indoor camera 2024"
   ],
-  "msrp_vnd": 399000,
   "sources": [
     "https://www.imoulife.com/vn-vi/"
   ],

--- a/cameras/imou/ranger-2.json
+++ b/cameras/imou/ranger-2.json
@@ -62,7 +62,6 @@
     "Alexa / Google",
     "₹2,500–4,000 best-value India indoor camera"
   ],
-  "msrp_inr": 2999,
   "sources": [
     "https://www.imoulife.com/"
   ],

--- a/cameras/imou/ranger-s2-mena.json
+++ b/cameras/imou/ranger-s2-mena.json
@@ -62,7 +62,6 @@
     "Alexa",
     "≈199 AED budget indoor cam Noon/Amazon.ae"
   ],
-  "msrp_aed": 199,
   "sources": [
     "https://www.imoulife.com/me-en/"
   ],

--- a/cameras/imou/ranger-s2.json
+++ b/cameras/imou/ranger-s2.json
@@ -63,7 +63,6 @@
     "Alexa",
     "₹3,500–5,000"
   ],
-  "msrp_inr": 3999,
   "sources": [
     "https://www.imoulife.com/"
   ],

--- a/cameras/kbvision/kx-a2012c3-b.json
+++ b/cameras/kbvision/kx-a2012c3-b.json
@@ -60,7 +60,6 @@
     "popular Vietnam small business / apartment buildings",
     "≈450,000–700,000 VND"
   ],
-  "msrp_vnd": 550000,
   "sources": [
     "https://kbvisionvietnam.com/"
   ],

--- a/cameras/kbvision/kx-a4k12c2.json
+++ b/cameras/kbvision/kx-a4k12c2.json
@@ -63,7 +63,6 @@
     "available Bach Khoa / ITC Telecom Vietnam",
     "≈900,000–1,300,000 VND"
   ],
-  "msrp_vnd": 1100000,
   "sources": [
     "https://kbvisionvietnam.com/"
   ],

--- a/cameras/laview/f1.json
+++ b/cameras/laview/f1.json
@@ -37,7 +37,6 @@
     "two-way audio",
     "cloud storage"
   ],
-  "msrp_usd": 45,
   "sources": [
     "https://www.laviewusa.com/products/laview-security-cameras-4pc"
   ],

--- a/cameras/laview/l2.json
+++ b/cameras/laview/l2.json
@@ -37,7 +37,6 @@
     "color + IR night vision",
     "two-way audio"
   ],
-  "msrp_usd": 18,
   "sources": [
     "https://www.laviewusa.com/products/l2-light-bulb-camera-4g"
   ],

--- a/cameras/laview/n3.json
+++ b/cameras/laview/n3.json
@@ -46,7 +46,6 @@
     "50-day battery / 365-day with solar",
     "no subscription required for local storage"
   ],
-  "msrp_usd": 50,
   "sources": [
     "https://www.laviewusa.com/products/n3-outdoor-camera"
   ],

--- a/cameras/laview/r12.json
+++ b/cameras/laview/r12.json
@@ -37,7 +37,6 @@
     "solar compatible",
     "motion detection"
   ],
-  "msrp_usd": 70,
   "sources": [
     "https://www.laviewusa.com/products/copy-of-r12b-outdoor-camera-1"
   ],

--- a/cameras/laview/r18.json
+++ b/cameras/laview/r18.json
@@ -36,7 +36,6 @@
     "color night vision",
     "real-time alerts"
   ],
-  "msrp_usd": 130,
   "sources": [
     "https://www.laviewusa.com/products/r18-outdoor-360-camera-copy"
   ],

--- a/cameras/laview/r28.json
+++ b/cameras/laview/r28.json
@@ -43,7 +43,6 @@
     "Alexa/Google compatible",
     "no subscription required for local storage"
   ],
-  "msrp_usd": 80,
   "sources": [
     "https://www.laviewusa.com/products/r28-wireless-outdoor-camera"
   ],

--- a/cameras/lorex/b862aj-canada.json
+++ b/cameras/lorex/b862aj-canada.json
@@ -61,7 +61,6 @@
     "Alexa",
     "rated -40°C Canadian winters"
   ],
-  "msrp_cad": 149.99,
   "sources": [
     "https://www.lorex.ca/"
   ],

--- a/cameras/lorex/e893ab.json
+++ b/cameras/lorex/e893ab.json
@@ -56,7 +56,6 @@
     "NVR compatible",
     "no monthly fees"
   ],
-  "msrp_usd": 89.99,
   "sources": [
     "https://www.lorex.com/products/e893ab-4k-ip-wired-bullet-smart-deterrence"
   ],

--- a/cameras/lorex/lnb9292b-canada.json
+++ b/cameras/lorex/lnb9292b-canada.json
@@ -63,7 +63,6 @@
     "ONVIF/RTSP",
     "Costco Canada bestseller"
   ],
-  "msrp_cad": 199.99,
   "sources": [
     "https://www.lorex.ca/products/4k-8mp-nocturnal-motorized-varifocal-smart-ip-bullet-security-camera"
   ],

--- a/cameras/lorex/lne9292b-canada.json
+++ b/cameras/lorex/lne9292b-canada.json
@@ -62,7 +62,6 @@
     "no subscription",
     "popular Canada home security bundle"
   ],
-  "msrp_cad": 189.99,
   "sources": [
     "https://www.lorex.ca/"
   ],

--- a/cameras/lorex/lnr6100.json
+++ b/cameras/lorex/lnr6100.json
@@ -51,7 +51,6 @@
     "H.265",
     "basic affordable IP camera"
   ],
-  "msrp_usd": 60,
   "sources": [
     "https://www.lorex.com/products/2k-ip-turret-camera"
   ],

--- a/cameras/lorex/u471aa.json
+++ b/cameras/lorex/u471aa.json
@@ -55,7 +55,6 @@
     "no monthly fees",
     "Alexa / Google"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://www.lorex.com/blogs/products/u471aa-series"
   ],

--- a/cameras/lorex/w452asd.json
+++ b/cameras/lorex/w452asd.json
@@ -56,7 +56,6 @@
     "no monthly fees",
     "Alexa / Google"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://www.lorex.com/products/2k-floodlight-camera"
   ],

--- a/cameras/lorex/w462aq-pantilt.json
+++ b/cameras/lorex/w462aq-pantilt.json
@@ -52,7 +52,6 @@
     "Alexa / Google",
     "no monthly fees"
   ],
-  "msrp_cad": 79,
   "sources": [
     "https://www.lorex.ca/"
   ],

--- a/cameras/lorex/w482cad-canada.json
+++ b/cameras/lorex/w482cad-canada.json
@@ -59,7 +59,6 @@
     "Lorex Home app",
     "Alexa / Google"
   ],
-  "msrp_cad": 139.99,
   "sources": [
     "https://www.lorex.ca/"
   ],

--- a/cameras/lorex/w891uad.json
+++ b/cameras/lorex/w891uad.json
@@ -53,7 +53,6 @@
     "no monthly fees",
     "Alexa / Google"
   ],
-  "msrp_usd": 149.99,
   "sources": [
     "https://www.lorex.com/products/w891uad-e-4k-dual-lens-wi-fi-camera"
   ],

--- a/cameras/lupus/le201-wlan.json
+++ b/cameras/lupus/le201-wlan.json
@@ -65,7 +65,6 @@
     "German support Conrad/Lupus-Electronics.de",
     "€80–120"
   ],
-  "msrp_eur": 99,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le202-wlan.json
+++ b/cameras/lupus/le202-wlan.json
@@ -65,7 +65,6 @@
     "German brand",
     "€80–120"
   ],
-  "msrp_eur": 109,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le203-poe.json
+++ b/cameras/lupus/le203-poe.json
@@ -64,7 +64,6 @@
     "entry-level LUPUS PoE camera",
     "€80–100"
   ],
-  "msrp_eur": 89,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le204-wlan.json
+++ b/cameras/lupus/le204-wlan.json
@@ -64,7 +64,6 @@
     "German brand",
     "€120–150"
   ],
-  "msrp_eur": 139,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le206-mini.json
+++ b/cameras/lupus/le206-mini.json
@@ -63,7 +63,6 @@
     "baby / pet monitoring",
     "€50–80"
   ],
-  "msrp_eur": 69,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le207-outdoor.json
+++ b/cameras/lupus/le207-outdoor.json
@@ -66,7 +66,6 @@
     "entry PoE dome",
     "€80–100"
   ],
-  "msrp_eur": 89,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le209-4k-poe.json
+++ b/cameras/lupus/le209-4k-poe.json
@@ -66,7 +66,6 @@
     "DSGVO-compliant no cloud",
     "€150–200"
   ],
-  "msrp_eur": 169,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le211-wifi.json
+++ b/cameras/lupus/le211-wifi.json
@@ -64,7 +64,6 @@
     "DSGVO local-first",
     "€100–130"
   ],
-  "msrp_eur": 119,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le215-color.json
+++ b/cameras/lupus/le215-color.json
@@ -64,7 +64,6 @@
     "DSGVO local",
     "€130–160"
   ],
-  "msrp_eur": 149,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le217-wifi-dome.json
+++ b/cameras/lupus/le217-wifi-dome.json
@@ -66,7 +66,6 @@
     "DSGVO local-first",
     "€160–200"
   ],
-  "msrp_eur": 179,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le221-poe.json
+++ b/cameras/lupus/le221-poe.json
@@ -66,7 +66,6 @@
     "flagship LUPUS outdoor PoE",
     "€300–350"
   ],
-  "msrp_eur": 329,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le224-poe.json
+++ b/cameras/lupus/le224-poe.json
@@ -66,7 +66,6 @@
     "DSGVO local-first",
     "€200–250"
   ],
-  "msrp_eur": 229,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le228-poe.json
+++ b/cameras/lupus/le228-poe.json
@@ -65,7 +65,6 @@
     "DSGVO local",
     "€150–200"
   ],
-  "msrp_eur": 179,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le231-dual-light.json
+++ b/cameras/lupus/le231-dual-light.json
@@ -64,7 +64,6 @@
     "DSGVO local-first",
     "€150–180"
   ],
-  "msrp_eur": 169,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le232-alarm.json
+++ b/cameras/lupus/le232-alarm.json
@@ -66,7 +66,6 @@
     "new 2024 DE model",
     "€200–250"
   ],
-  "msrp_eur": 229,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le233-varifocal.json
+++ b/cameras/lupus/le233-varifocal.json
@@ -66,7 +66,6 @@
     "DSGVO local-first",
     "€250–300"
   ],
-  "msrp_eur": 279,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le941-ptz.json
+++ b/cameras/lupus/le941-ptz.json
@@ -65,7 +65,6 @@
     "DSGVO local storage",
     "€400–500 price range"
   ],
-  "msrp_eur": 449,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le941t-4k-ptz.json
+++ b/cameras/lupus/le941t-4k-ptz.json
@@ -66,7 +66,6 @@
     "flagship LUPUS PTZ",
     "€500–600"
   ],
-  "msrp_eur": 549,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/lupus/le942-ptz-outdoor.json
+++ b/cameras/lupus/le942-ptz-outdoor.json
@@ -66,7 +66,6 @@
     "DSGVO local",
     "€350–450"
   ],
-  "msrp_eur": 399,
   "sources": [
     "https://www.lupus-electronics.de/"
   ],

--- a/cameras/netatmo/smart-indoor-camera-at.json
+++ b/cameras/netatmo/smart-indoor-camera-at.json
@@ -59,7 +59,6 @@
     "two-way audio",
     "very popular privacy-conscious AT/CH buyers"
   ],
-  "msrp_eur": 179.99,
   "sources": [
     "https://www.netatmo.com/at-de/"
   ],

--- a/cameras/netatmo/smart-indoor-camera.json
+++ b/cameras/netatmo/smart-indoor-camera.json
@@ -60,7 +60,6 @@
     "100% local data",
     "French brand privacy focus"
   ],
-  "msrp_gbp": 179.99,
   "sources": [
     "https://www.netatmo.com/"
   ],

--- a/cameras/netatmo/smart-outdoor-camera-siren.json
+++ b/cameras/netatmo/smart-outdoor-camera-siren.json
@@ -65,7 +65,6 @@
     "GDPR-compliant (French company, EU data)",
     "IP66"
   ],
-  "msrp_eur": 229.99,
   "sources": [
     "https://www.netatmo.com/"
   ],

--- a/cameras/netatmo/smart-outdoor-camera-with-siren.json
+++ b/cameras/netatmo/smart-outdoor-camera-with-siren.json
@@ -60,7 +60,6 @@
     "GDPR EU data",
     "IP66"
   ],
-  "msrp_eur": 229,
   "sources": [
     "https://www.netatmo.com/"
   ],

--- a/cameras/netatmo/smart-outdoor-camera.json
+++ b/cameras/netatmo/smart-outdoor-camera.json
@@ -63,7 +63,6 @@
     "100% local data processing",
     "French brand privacy focus"
   ],
-  "msrp_gbp": 199.99,
   "sources": [
     "https://www.netatmo.com/"
   ],

--- a/cameras/netatmo/smart-video-doorbell.json
+++ b/cameras/netatmo/smart-video-doorbell.json
@@ -62,7 +62,6 @@
     "165° wide FOV",
     "GDPR-compliant EU data"
   ],
-  "msrp_eur": 149,
   "sources": [
     "https://www.netatmo.com/"
   ],

--- a/cameras/qubo/bullet-cam-pro.json
+++ b/cameras/qubo/bullet-cam-pro.json
@@ -58,7 +58,6 @@
     "Alexa",
     "Made in India Hero Group"
   ],
-  "msrp_inr": 4999,
   "sources": [
     "https://www.quboworld.com/"
   ],

--- a/cameras/qubo/doorbell-cam.json
+++ b/cameras/qubo/doorbell-cam.json
@@ -52,7 +52,6 @@
     "Made in India Hero Group",
     "₹4,999"
   ],
-  "msrp_inr": 4999,
   "sources": [
     "https://www.quboworld.com/"
   ],

--- a/cameras/qubo/smart-cam-360-3mp.json
+++ b/cameras/qubo/smart-cam-360-3mp.json
@@ -62,7 +62,6 @@
     "Alexa compatible",
     "₹3,990–5,200"
   ],
-  "msrp_inr": 3990,
   "sources": [
     "https://www.quboworld.com/products/smart-cam-360-3mp"
   ],

--- a/cameras/qubo/smart-cam-360-pro-4mp.json
+++ b/cameras/qubo/smart-cam-360-pro-4mp.json
@@ -61,7 +61,6 @@
     "Alexa",
     "Made in India"
   ],
-  "msrp_inr": 5499,
   "sources": [
     "https://www.quboworld.com/"
   ],

--- a/cameras/reolink/altas-pt-ultra.json
+++ b/cameras/reolink/altas-pt-ultra.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/altas-pt-ultra/"
   ],
-  "msrp_usd": 159,
   "aliases": [
     "B660"
   ],

--- a/cameras/reolink/argus-2.json
+++ b/cameras/reolink/argus-2.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/argus-2/"
   ],
-  "msrp_usd": 69,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-2e.json
+++ b/cameras/reolink/argus-2e.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/argus-2e/"
   ],
-  "msrp_usd": 49,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-3-2k.json
+++ b/cameras/reolink/argus-3-2k.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/argus-3/"
   ],
-  "msrp_usd": 49,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-3-pro-au.json
+++ b/cameras/reolink/argus-3-pro-au.json
@@ -60,7 +60,6 @@
     "outlasted Arlo Pro 5 in AU long-term battery tests",
     "AU$99–129"
   ],
-  "msrp_aud": 129.99,
   "sources": [
     "https://reolink.com/au/",
     "https://www.safewise.com/au/best-wireless-security-cameras/"

--- a/cameras/reolink/argus-4-pro-at.json
+++ b/cameras/reolink/argus-4-pro-at.json
@@ -60,7 +60,6 @@
     "Alexa / Google",
     "available Amazon.at / Conrad AT"
   ],
-  "msrp_eur": 149.99,
   "sources": [
     "https://reolink.com/at/",
     "https://www.amazon.at/"

--- a/cameras/reolink/argus-5-pro.json
+++ b/cameras/reolink/argus-5-pro.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/argus-5-pro/"
   ],
-  "msrp_usd": 109,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-eco-ultra.json
+++ b/cameras/reolink/argus-eco-ultra.json
@@ -43,7 +43,6 @@
     "solar compatible",
     "no subscription"
   ],
-  "msrp_usd": 97,
   "sources": [
     "https://reolink.com/product/argus-eco-ultra/"
   ],

--- a/cameras/reolink/argus-eco.json
+++ b/cameras/reolink/argus-eco.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/argus-eco/"
   ],
-  "msrp_usd": 39,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-magicam.json
+++ b/cameras/reolink/argus-magicam.json
@@ -54,7 +54,6 @@
     "Power-Efficient Series"
   ],
   "release_notes": "Launched June 2026 alongside OMVI Series.",
-  "msrp_usd": 49.99,
   "sources": [
     "https://securityjournaluk.com/reolink-launches-new-cameras/"
   ],

--- a/cameras/reolink/argus-pro.json
+++ b/cameras/reolink/argus-pro.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/argus-pro/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "battery"
   ]

--- a/cameras/reolink/argus-pt-2k.json
+++ b/cameras/reolink/argus-pt-2k.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/argus-pt-2k/"
   ],
-  "msrp_usd": 69,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/argus-pt-ultra.json
+++ b/cameras/reolink/argus-pt-ultra.json
@@ -56,7 +56,6 @@
     "solar optional",
     "IP66"
   ],
-  "msrp_usd": 139,
   "sources": [
     "https://reolink.com/product/argus-pt-ultra/"
   ],

--- a/cameras/reolink/argus-pt.json
+++ b/cameras/reolink/argus-pt.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/argus-pt/"
   ],
-  "msrp_usd": 59,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/b1200.json
+++ b/cameras/reolink/b1200.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/b1200/"
   ],
-  "msrp_usd": 35,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/b400.json
+++ b/cameras/reolink/b400.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/b400/"
   ],
-  "msrp_usd": 19,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/b500.json
+++ b/cameras/reolink/b500.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/b500/"
   ],
-  "msrp_usd": 25,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/b800.json
+++ b/cameras/reolink/b800.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/b800/"
   ],
-  "msrp_usd": 29,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/cx410.json
+++ b/cameras/reolink/cx410.json
@@ -53,7 +53,6 @@
     "dual warning (light + siren)",
     "no subscription"
   ],
-  "msrp_usd": 72,
   "sources": [
     "https://reolink.com/product/cx410/"
   ],

--- a/cameras/reolink/d1200.json
+++ b/cameras/reolink/d1200.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/d1200/"
   ],
-  "msrp_usd": 35,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/d400.json
+++ b/cameras/reolink/d400.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/d400/"
   ],
-  "msrp_usd": 19,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/d500.json
+++ b/cameras/reolink/d500.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/d500/"
   ],
-  "msrp_usd": 25,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/d800.json
+++ b/cameras/reolink/d800.json
@@ -44,7 +44,6 @@
   "sources": [
     "https://reolink.com/product/d800/"
   ],
-  "msrp_usd": 29,
   "power_source": [
     "poe"
   ],

--- a/cameras/reolink/duo-2-battery.json
+++ b/cameras/reolink/duo-2-battery.json
@@ -50,7 +50,6 @@
     "solar compatible",
     "no subscription"
   ],
-  "msrp_usd": 170,
   "sources": [
     "https://reolink.com/product/reolink-duo/"
   ],

--- a/cameras/reolink/duo-2-lte.json
+++ b/cameras/reolink/duo-2-lte.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/reolink-duo-2-lte/"
   ],
-  "msrp_usd": 149,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/duo-4g.json
+++ b/cameras/reolink/duo-4g.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/reolink-duo-4g/"
   ],
-  "msrp_usd": 119,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/e1-indoor.json
+++ b/cameras/reolink/e1-indoor.json
@@ -43,7 +43,6 @@
   "sources": [
     "https://reolink.com/product/e1/"
   ],
-  "msrp_usd": 25,
   "power_source": [
     "usb"
   ]

--- a/cameras/reolink/e1-outdoor-cx.json
+++ b/cameras/reolink/e1-outdoor-cx.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/e1-outdoor-cx/"
   ],
-  "msrp_usd": 69,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/e1-outdoor-pro.json
+++ b/cameras/reolink/e1-outdoor-pro.json
@@ -53,7 +53,6 @@
     "WiFi 6",
     "no subscription"
   ],
-  "msrp_usd": 110,
   "sources": [
     "https://reolink.com/product/e1-outdoor-pro/"
   ],

--- a/cameras/reolink/e1-outdoor-wifi.json
+++ b/cameras/reolink/e1-outdoor-wifi.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/e1-outdoor/"
   ],
-  "msrp_usd": 39,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/e1-pro-v2.json
+++ b/cameras/reolink/e1-pro-v2.json
@@ -56,7 +56,6 @@
     "RTSP",
     "Consumer Reports tested 2024"
   ],
-  "msrp_usd": 39,
   "sources": [
     "https://reolink.com/product/reolink-e1-pro/"
   ],

--- a/cameras/reolink/e1-pro.json
+++ b/cameras/reolink/e1-pro.json
@@ -51,7 +51,6 @@
     "dual-band WiFi",
     "no subscription"
   ],
-  "msrp_usd": 55,
   "sources": [
     "https://reolink.com/product/e1-pro/"
   ],

--- a/cameras/reolink/e1-zoom.json
+++ b/cameras/reolink/e1-zoom.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/e1-zoom/"
   ],
-  "msrp_usd": 45,
   "power_source": [
     "usb"
   ],

--- a/cameras/reolink/elite-floodlight-wifi.json
+++ b/cameras/reolink/elite-floodlight-wifi.json
@@ -48,7 +48,6 @@
   "sources": [
     "https://reolink.com/product/elite-floodlight-wifi/"
   ],
-  "msrp_usd": 109,
   "power_source": [
     "ac-mains"
   ],

--- a/cameras/reolink/elite-pro-floodlight-poe.json
+++ b/cameras/reolink/elite-pro-floodlight-poe.json
@@ -51,7 +51,6 @@
     "no subscription"
   ],
   "release_year": 2025,
-  "msrp_usd": 188.99,
   "sources": [
     "https://slickdeals.net/f/18802744"
   ],

--- a/cameras/reolink/elite-wifi.json
+++ b/cameras/reolink/elite-wifi.json
@@ -53,7 +53,6 @@
     "Bluetooth",
     "no subscription"
   ],
-  "msrp_usd": 160,
   "sources": [
     "https://reolink.com/product/elite-wifi/"
   ],

--- a/cameras/reolink/go-4g.json
+++ b/cameras/reolink/go-4g.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/reolink-go/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/go-pt-plus.json
+++ b/cameras/reolink/go-pt-plus.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/reolink-go-pt-plus/"
   ],
-  "msrp_usd": 109,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/go-pt-ultra.json
+++ b/cameras/reolink/go-pt-ultra.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/reolink-go-pt-ultra/"
   ],
-  "msrp_usd": 149,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/go-pt.json
+++ b/cameras/reolink/go-pt.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/reolink-go-pt/"
   ],
-  "msrp_usd": 99,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/home-hub.json
+++ b/cameras/reolink/home-hub.json
@@ -47,7 +47,6 @@
     "no cloud required",
     "NVR hub — not a camera"
   ],
-  "msrp_usd": 69,
   "sources": [
     "https://reolink.com/product/home-hub/"
   ],

--- a/cameras/reolink/keen-ranger-pt.json
+++ b/cameras/reolink/keen-ranger-pt.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/keen-ranger-pt/"
   ],
-  "msrp_usd": 159,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/lumus.json
+++ b/cameras/reolink/lumus.json
@@ -49,7 +49,6 @@
   "sources": [
     "https://reolink.com/product/reolink-lumus/"
   ],
-  "msrp_usd": 49,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/omvi-3i-poe.json
+++ b/cameras/reolink/omvi-3i-poe.json
@@ -53,7 +53,6 @@
     "no subscription"
   ],
   "release_year": 2025,
-  "msrp_usd": 299.99,
   "sources": [
     "https://reolink.com/product/omvi-3i-poe/"
   ],

--- a/cameras/reolink/omvi-3i-wifi.json
+++ b/cameras/reolink/omvi-3i-wifi.json
@@ -54,7 +54,6 @@
     "perimeter protection",
     "no subscription"
   ],
-  "msrp_usd": 319.99,
   "sources": [
     "https://reolink.com/blog/reolink-new-products-at-ces/"
   ],

--- a/cameras/reolink/omvi-x16-poe.json
+++ b/cameras/reolink/omvi-x16-poe.json
@@ -56,7 +56,6 @@
     "iF DESIGN AWARD 2026",
     "CES 2026 Innovation Award Honoree"
   ],
-  "msrp_usd": 499.99,
   "sources": [
     "https://www.prnewswire.com/news-releases/reolink-redefines-full-coverage-smart-security-with-the-triple-lens-omvi-series-and-reolink-x-qualcomm-power-efficient-series-cameras-302786356.html"
   ],

--- a/cameras/reolink/p340.json
+++ b/cameras/reolink/p340.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/p340/"
   ],
-  "msrp_usd": 59,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/p430.json
+++ b/cameras/reolink/p430.json
@@ -52,7 +52,6 @@
     "time-lapse",
     "no subscription"
   ],
-  "msrp_usd": 150,
   "sources": [
     "https://reolink.com/product/p430/"
   ],

--- a/cameras/reolink/reolink-go-plus.json
+++ b/cameras/reolink/reolink-go-plus.json
@@ -56,7 +56,6 @@
     "IP65",
     "works anywhere with cellular signal — farms/remote areas"
   ],
-  "msrp_usd": 129,
   "sources": [
     "https://reolink.com/product/reolink-go-plus/"
   ],

--- a/cameras/reolink/rlc-1210a.json
+++ b/cameras/reolink/rlc-1210a.json
@@ -48,7 +48,6 @@
   "sources": [
     "https://reolink.com/product/rlc-1210a/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-1220a.json
+++ b/cameras/reolink/rlc-1220a.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/rlc-1220a/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-410.json
+++ b/cameras/reolink/rlc-410.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-410/"
   ],
-  "msrp_usd": 35,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-422.json
+++ b/cameras/reolink/rlc-422.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-422/"
   ],
-  "msrp_usd": 49,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-423.json
+++ b/cameras/reolink/rlc-423.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-423/"
   ],
-  "msrp_usd": 49,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-510wa.json
+++ b/cameras/reolink/rlc-510wa.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/rlc-510wa/"
   ],
-  "msrp_usd": 39,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/rlc-511.json
+++ b/cameras/reolink/rlc-511.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-511/"
   ],
-  "msrp_usd": 35,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-511w.json
+++ b/cameras/reolink/rlc-511w.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-511w/"
   ],
-  "msrp_usd": 39,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/rlc-511wa.json
+++ b/cameras/reolink/rlc-511wa.json
@@ -48,7 +48,6 @@
   "sources": [
     "https://reolink.com/product/rlc-511wa/"
   ],
-  "msrp_usd": 69,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/rlc-520.json
+++ b/cameras/reolink/rlc-520.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/product/rlc-520/"
   ],
-  "msrp_usd": 35,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-520a-wifi6.json
+++ b/cameras/reolink/rlc-520a-wifi6.json
@@ -56,7 +56,6 @@
     "IP67",
     "IK10"
   ],
-  "msrp_usd": 39,
   "sources": [
     "https://reolink.com/product/rlc-520a/"
   ],

--- a/cameras/reolink/rlc-522.json
+++ b/cameras/reolink/rlc-522.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/rlc-522/"
   ],
-  "msrp_usd": 45,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/reolink/rlc-523wa.json
+++ b/cameras/reolink/rlc-523wa.json
@@ -48,7 +48,6 @@
   "sources": [
     "https://reolink.com/product/rlc-523wa/"
   ],
-  "msrp_usd": 69,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/rlc-542wa.json
+++ b/cameras/reolink/rlc-542wa.json
@@ -47,7 +47,6 @@
   "sources": [
     "https://reolink.com/product/rlc-542wa/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "dc"
   ],

--- a/cameras/reolink/rlc-810a-india.json
+++ b/cameras/reolink/rlc-810a-india.json
@@ -58,7 +58,6 @@
     "₹6,000–9,000 value 4K India",
     "Amazon India popular"
   ],
-  "msrp_inr": 7499,
   "sources": [
     "https://reolink.com/in/"
   ],

--- a/cameras/reolink/rlc-810wa.json
+++ b/cameras/reolink/rlc-810wa.json
@@ -48,7 +48,6 @@
     "time-lapse",
     "no subscription"
   ],
-  "msrp_usd": 120,
   "sources": [
     "https://reolink.com/product/rlc-810wa/"
   ],

--- a/cameras/reolink/rlc-811wa.json
+++ b/cameras/reolink/rlc-811wa.json
@@ -51,7 +51,6 @@
     "time-lapse",
     "no subscription"
   ],
-  "msrp_usd": 160,
   "sources": [
     "https://reolink.com/product/rlc-811wa/"
   ],

--- a/cameras/reolink/rlc-823a-au.json
+++ b/cameras/reolink/rlc-823a-au.json
@@ -61,7 +61,6 @@
     "IP67",
     "available Amazon AU / Officeworks"
   ],
-  "msrp_aud": 109.99,
   "sources": [
     "https://reolink.com/au/"
   ],

--- a/cameras/reolink/rlc-823a-canada.json
+++ b/cameras/reolink/rlc-823a-canada.json
@@ -62,7 +62,6 @@
     "IP67 rated -10°C to +55°C",
     "available Home Depot Canada / Amazon.ca"
   ],
-  "msrp_cad": 79.99,
   "sources": [
     "https://reolink.com/ca/",
     "https://www.amazon.ca/"

--- a/cameras/reolink/rlc-823a-ch.json
+++ b/cameras/reolink/rlc-823a-ch.json
@@ -63,7 +63,6 @@
     "IP67",
     "Digitec / Amazon.ch popular"
   ],
-  "msrp_chf": 99.0,
   "sources": [
     "https://reolink.com/ch/",
     "https://www.digitec.ch/"

--- a/cameras/reolink/rlc-823a-germany.json
+++ b/cameras/reolink/rlc-823a-germany.json
@@ -65,7 +65,6 @@
     "RTSP/ONVIF Frigate/Home Assistant compatible",
     "IP67"
   ],
-  "msrp_eur": 79.99,
   "sources": [
     "https://reolink.com/eu/product/rlc-823a/"
   ],

--- a/cameras/reolink/rlc-823a-mena.json
+++ b/cameras/reolink/rlc-823a-mena.json
@@ -64,7 +64,6 @@
     "≈349 AED Amazon.ae",
     "popular no-fee 4K UAE"
   ],
-  "msrp_aed": 349,
   "sources": [
     "https://reolink.com/me-en/",
     "https://www.amazon.ae/"

--- a/cameras/reolink/rlc-823a-v2.json
+++ b/cameras/reolink/rlc-823a-v2.json
@@ -54,7 +54,6 @@
     "RTSP/ONVIF",
     "IP67"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://reolink.com/"
   ],

--- a/cameras/reolink/rlc-830a-v2.json
+++ b/cameras/reolink/rlc-830a-v2.json
@@ -52,7 +52,6 @@
     "active deterrence",
     "no subscription"
   ],
-  "msrp_usd": 44.99,
   "sources": [
     "https://reolink.com/product/rlc-840a/"
   ],

--- a/cameras/reolink/trackmix-lte.json
+++ b/cameras/reolink/trackmix-lte.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/product/reolink-trackmix-lte/"
   ],
-  "msrp_usd": 149,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/reolink/trackmix-poe.json
+++ b/cameras/reolink/trackmix-poe.json
@@ -52,7 +52,6 @@
     "spotlight color night vision",
     "no subscription"
   ],
-  "msrp_usd": 161,
   "sources": [
     "https://reolink.com/product/reolink-trackmix-poe/"
   ],

--- a/cameras/reolink/trackmix-wifi.json
+++ b/cameras/reolink/trackmix-wifi.json
@@ -55,7 +55,6 @@
     "time-lapse",
     "no subscription"
   ],
-  "msrp_usd": 190,
   "sources": [
     "https://reolink.com/product/reolink-trackmix-wifi/"
   ],

--- a/cameras/reolink/video-doorbell-2nd-gen.json
+++ b/cameras/reolink/video-doorbell-2nd-gen.json
@@ -46,7 +46,6 @@
   "sources": [
     "https://reolink.com/blog/reolink-new-products-at-ces/"
   ],
-  "msrp_usd": 129,
   "power_source": [
     "battery"
   ],

--- a/cameras/reolink/video-doorbell-se.json
+++ b/cameras/reolink/video-doorbell-se.json
@@ -45,7 +45,6 @@
   "sources": [
     "https://reolink.com/blog/reolink-new-products-at-ces/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "battery"
   ],

--- a/cameras/reolink/video-doorbell-wifi.json
+++ b/cameras/reolink/video-doorbell-wifi.json
@@ -51,7 +51,6 @@
   "sources": [
     "https://reolink.com/product/reolink-video-doorbell-wifi/"
   ],
-  "msrp_usd": 79,
   "power_source": [
     "ac-mains"
   ],

--- a/cameras/ring/alarm-outdoor-contact-sensor.json
+++ b/cameras/ring/alarm-outdoor-contact-sensor.json
@@ -52,7 +52,6 @@
     "Alexa",
     "most affordable Ring camera"
   ],
-  "msrp_usd": 44,
   "sources": [
     "https://ring.com/products/indoor-cam"
   ],

--- a/cameras/ring/alarm-security-cam-pro.json
+++ b/cameras/ring/alarm-security-cam-pro.json
@@ -52,7 +52,6 @@
     "Alexa",
     "Ring Alarm system integration"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://ring.com/products/alarm-security-cam-pro"
   ],

--- a/cameras/ring/battery-doorbell-pro-2025.json
+++ b/cameras/ring/battery-doorbell-pro-2025.json
@@ -53,7 +53,6 @@
     "Alexa integration",
     "Ring Protect plan for cloud video"
   ],
-  "msrp_usd": 149.99,
   "sources": [
     "https://ring.com/products/battery-video-doorbell-pro"
   ],

--- a/cameras/ring/doorbell-elite.json
+++ b/cameras/ring/doorbell-elite.json
@@ -52,7 +52,6 @@
     "Alexa",
     "popular enterprise/commercial buildings"
   ],
-  "msrp_usd": 349,
   "sources": [
     "https://ring.com/products/doorbell-elite"
   ],

--- a/cameras/ring/floodlight-cam-wired-plus.json
+++ b/cameras/ring/floodlight-cam-wired-plus.json
@@ -51,7 +51,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://ring.com/products/floodlight-cam-wired-plus"
   ],

--- a/cameras/ring/floodlight-cam-wired-pro.json
+++ b/cameras/ring/floodlight-cam-wired-pro.json
@@ -49,7 +49,6 @@
     "Alexa integration"
   ],
   "release_year": 2021,
-  "msrp_usd": 249.99,
   "sources": [
     "https://ring.com/products/floodlight-cam-wired-pro"
   ],

--- a/cameras/ring/indoor-cam-2nd-gen-uk.json
+++ b/cameras/ring/indoor-cam-2nd-gen-uk.json
@@ -55,7 +55,6 @@
     "Ring Protect plan for cloud video",
     "Alexa"
   ],
-  "msrp_gbp": 44.99,
   "sources": [
     "https://ring.com/en-gb/"
   ],

--- a/cameras/ring/indoor-cam-2nd-gen.json
+++ b/cameras/ring/indoor-cam-2nd-gen.json
@@ -48,7 +48,6 @@
     "Ring subscription for cloud video"
   ],
   "release_year": 2022,
-  "msrp_usd": 59.99,
   "sources": [
     "https://ring.com/products/indoor-cam"
   ],

--- a/cameras/ring/outdoor-cam-wired.json
+++ b/cameras/ring/outdoor-cam-wired.json
@@ -47,7 +47,6 @@
     "Ring subscription for cloud video"
   ],
   "release_year": 2023,
-  "msrp_usd": 79.99,
   "sources": [
     "https://ring.com/products/outdoor-cam"
   ],

--- a/cameras/ring/pan-tilt-indoor-cam.json
+++ b/cameras/ring/pan-tilt-indoor-cam.json
@@ -49,7 +49,6 @@
     "Ring Protect for cloud video",
     "Alexa"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://ring.com/products/pan-tilt-indoor-cam"
   ],

--- a/cameras/ring/peephole-cam.json
+++ b/cameras/ring/peephole-cam.json
@@ -52,7 +52,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 129.99,
   "sources": [
     "https://ring.com/products/peephole-cam"
   ],

--- a/cameras/ring/spotlight-cam-battery-gen2.json
+++ b/cameras/ring/spotlight-cam-battery-gen2.json
@@ -51,7 +51,6 @@
     "Alexa",
     "IP55"
   ],
-  "msrp_usd": 149,
   "sources": [
     "https://ring.com/products/spotlight-cam-battery"
   ],

--- a/cameras/ring/spotlight-cam-plus-battery.json
+++ b/cameras/ring/spotlight-cam-plus-battery.json
@@ -48,7 +48,6 @@
     "Ring subscription for cloud video history"
   ],
   "release_year": 2022,
-  "msrp_usd": 149.99,
   "sources": [
     "https://ring.com/products/spotlight-cam-battery"
   ],

--- a/cameras/ring/spotlight-cam-plus-eu.json
+++ b/cameras/ring/spotlight-cam-plus-eu.json
@@ -57,7 +57,6 @@
     "Alexa / Amazon",
     "IP55 EU version"
   ],
-  "msrp_eur": 179.99,
   "sources": [
     "https://ring.com/de-de/"
   ],

--- a/cameras/ring/spotlight-cam-plus-plug-in.json
+++ b/cameras/ring/spotlight-cam-plus-plug-in.json
@@ -52,7 +52,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://ring.com/products/spotlight-cam-plus-plug-in"
   ],

--- a/cameras/ring/spotlight-cam-plus-solar.json
+++ b/cameras/ring/spotlight-cam-plus-solar.json
@@ -52,7 +52,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://ring.com/products/spotlight-cam-plus-solar"
   ],

--- a/cameras/ring/spotlight-cam-pro.json
+++ b/cameras/ring/spotlight-cam-pro.json
@@ -53,7 +53,6 @@
     "person/vehicle/package/motion alerts",
     "Alexa integration"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://ring.com/products/spotlight-cam-pro"
   ],

--- a/cameras/ring/stick-up-cam-battery-2nd-gen.json
+++ b/cameras/ring/stick-up-cam-battery-2nd-gen.json
@@ -51,7 +51,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://ring.com/products/stick-up-cam-battery"
   ],

--- a/cameras/ring/stick-up-cam-battery-3rd-gen.json
+++ b/cameras/ring/stick-up-cam-battery-3rd-gen.json
@@ -55,7 +55,6 @@
     "person/motion detection",
     "IP55 weatherproof"
   ],
-  "msrp_gbp": 69.99,
   "sources": [
     "https://ring.com/en-gb/"
   ],

--- a/cameras/ring/stick-up-cam-plug-in.json
+++ b/cameras/ring/stick-up-cam-plug-in.json
@@ -51,7 +51,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://ring.com/products/stick-up-cam-plug-in"
   ],

--- a/cameras/ring/stick-up-cam-pro.json
+++ b/cameras/ring/stick-up-cam-pro.json
@@ -53,7 +53,6 @@
     "Ring Protect for cloud video",
     "Alexa"
   ],
-  "msrp_usd": 179.99,
   "sources": [
     "https://ring.com/products/stick-up-security-camera"
   ],

--- a/cameras/ring/video-doorbell-2nd-gen.json
+++ b/cameras/ring/video-doorbell-2nd-gen.json
@@ -51,7 +51,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 99.99,
   "sources": [
     "https://ring.com/products/video-doorbell-gen-2"
   ],

--- a/cameras/ring/video-doorbell-3-plus.json
+++ b/cameras/ring/video-doorbell-3-plus.json
@@ -50,7 +50,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 229.99,
   "sources": [
     "https://ring.com/products/video-doorbell-3-plus"
   ],

--- a/cameras/ring/video-doorbell-4.json
+++ b/cameras/ring/video-doorbell-4.json
@@ -52,7 +52,6 @@
   ],
   "operating_temp_c": "-20 to 48",
   "release_year": 2021,
-  "msrp_usd": 99.99,
   "sources": [
     "https://ring.com/gb/en/support/articles/uc381/Learn-About-Video-Doorbell-4"
   ],

--- a/cameras/ring/video-doorbell-wired.json
+++ b/cameras/ring/video-doorbell-wired.json
@@ -50,7 +50,6 @@
     "Ring Protect plan",
     "Alexa integration"
   ],
-  "msrp_usd": 64.99,
   "sources": [
     "https://ring.com/products/video-doorbell-wired"
   ],

--- a/cameras/simplisafe/outdoor-cam-v2.json
+++ b/cameras/simplisafe/outdoor-cam-v2.json
@@ -51,7 +51,6 @@
     "no long-term contract",
     "IP65"
   ],
-  "msrp_usd": 119,
   "sources": [
     "https://simplisafe.com/cameras"
   ],

--- a/cameras/simplisafe/smart-alarm-indoor-cam.json
+++ b/cameras/simplisafe/smart-alarm-indoor-cam.json
@@ -49,7 +49,6 @@
     "SimpliSafe ecosystem",
     "no long-term contract"
   ],
-  "msrp_usd": 79.0,
   "sources": [
     "https://simplisafe.com/cameras"
   ],

--- a/cameras/simplisafe/wireless-outdoor-security-cam.json
+++ b/cameras/simplisafe/wireless-outdoor-security-cam.json
@@ -54,7 +54,6 @@
     "SimpliSafe Smart Alarm System integration",
     "no long-term contract"
   ],
-  "msrp_usd": 99.0,
   "sources": [
     "https://simplisafe.com/cameras"
   ],

--- a/cameras/somfy/indoor-camera.json
+++ b/cameras/somfy/indoor-camera.json
@@ -62,7 +62,6 @@
     "GDPR-compliant French-hosted cloud",
     "Alexa / Google"
   ],
-  "msrp_eur": 129.99,
   "sources": [
     "https://www.somfy.fr/"
   ],

--- a/cameras/somfy/one-plus.json
+++ b/cameras/somfy/one-plus.json
@@ -52,7 +52,6 @@
     "GDPR-compliant EU cloud",
     "Alexa / Google"
   ],
-  "msrp_eur": 199,
   "sources": [
     "https://www.somfy.fr/"
   ],

--- a/cameras/somfy/outdoor-camera.json
+++ b/cameras/somfy/outdoor-camera.json
@@ -63,7 +63,6 @@
     "Alexa / Google",
     "IP55"
   ],
-  "msrp_eur": 229.99,
   "sources": [
     "https://www.somfy.fr/"
   ],

--- a/cameras/steinel/l-620-cam-sc.json
+++ b/cameras/steinel/l-620-cam-sc.json
@@ -55,7 +55,6 @@
     "AI person/vehicle/animal detection",
     "IP44"
   ],
-  "msrp_eur": 359,
   "sources": [
     "https://www.steinel.de/"
   ],

--- a/cameras/steinel/l-620-cam.json
+++ b/cameras/steinel/l-620-cam.json
@@ -65,7 +65,6 @@
     "local storage only (GDPR-friendly)",
     "very popular DE market \"WAF camera\""
   ],
-  "msrp_eur": 319.99,
   "sources": [
     "https://www.steinel.de/"
   ],

--- a/cameras/steinel/l-625-cam.json
+++ b/cameras/steinel/l-625-cam.json
@@ -64,7 +64,6 @@
     "GDPR-friendly no cloud mandatory",
     "high aesthetic WAF design"
   ],
-  "msrp_eur": 399.99,
   "sources": [
     "https://www.steinel.de/"
   ],

--- a/cameras/swann/buddy-doorbell.json
+++ b/cameras/swann/buddy-doorbell.json
@@ -48,7 +48,6 @@
     "AU",
     "US"
   ],
-  "msrp_aud": 79,
   "power_source": [
     "battery",
     "ac-mains"

--- a/cameras/swann/swnvk-8advanx4d-au.json
+++ b/cameras/swann/swnvk-8advanx4d-au.json
@@ -50,7 +50,6 @@
     "AU",
     "US"
   ],
-  "msrp_aud": 749,
   "power_source": [
     "poe",
     "dc"

--- a/cameras/swann/swnvk-advancedx4b-au.json
+++ b/cameras/swann/swnvk-advancedx4b-au.json
@@ -63,7 +63,6 @@
     "JB Hi-Fi / Bunnings Australia stocked",
     "as seen on The Block AU"
   ],
-  "msrp_aud": 699.99,
   "sources": [
     "https://au.swann.com/swnvk-8advanx4b/"
   ],

--- a/cameras/swann/swnvk-maxranger4k-sd2-au.json
+++ b/cameras/swann/swnvk-maxranger4k-sd2-au.json
@@ -67,7 +67,6 @@
     "multiple award-winner 2024",
     "perfect for rural AU properties / farms / large blocks"
   ],
-  "msrp_aud": 799.99,
   "sources": [
     "https://au.swann.com/swnvk-mr4ksd2/"
   ],

--- a/cameras/swann/swnvk-mr4kprosd4-au.json
+++ b/cameras/swann/swnvk-mr4kprosd4-au.json
@@ -64,7 +64,6 @@
     "IP66",
     "flagship Swann AU model 2025"
   ],
-  "msrp_aud": 1099.99,
   "sources": [
     "https://au.swann.com/swnvk-mr4kprosd4/"
   ],

--- a/cameras/swann/swpro-1080msfb.json
+++ b/cameras/swann/swpro-1080msfb.json
@@ -57,7 +57,6 @@
     "IP66",
     "requires Swann DVR"
   ],
-  "msrp_gbp": 39.99,
   "sources": [
     "https://www.swann.com/"
   ],

--- a/cameras/swann/swpro-4kmsb.json
+++ b/cameras/swann/swpro-4kmsb.json
@@ -57,7 +57,6 @@
     "IP66",
     "requires Swann DVR recorder"
   ],
-  "msrp_gbp": 79.99,
   "sources": [
     "https://www.swann.com/"
   ],

--- a/cameras/swann/swwhd-intcam.json
+++ b/cameras/swann/swwhd-intcam.json
@@ -58,7 +58,6 @@
     "Alexa / Google",
     "no hub required"
   ],
-  "msrp_gbp": 69.99,
   "sources": [
     "https://www.swann.com/"
   ],

--- a/cameras/swann/swwhd-outcam.json
+++ b/cameras/swann/swwhd-outcam.json
@@ -61,7 +61,6 @@
     "no DVR required",
     "RTSP stream"
   ],
-  "msrp_gbp": 69.99,
   "sources": [
     "https://www.swann.com/"
   ],

--- a/cameras/synology/bc500-bullet.json
+++ b/cameras/synology/bc500-bullet.json
@@ -57,7 +57,6 @@
     "NDAA compliant",
     "instant search"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://www.synology.com/en-us/store/BC500"
   ],

--- a/cameras/synology/bc500.json
+++ b/cameras/synology/bc500.json
@@ -59,7 +59,6 @@
     "NDAA compliant",
     "~$200 MSRP"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.synology.com/en-us/store/BC500"
   ],

--- a/cameras/synology/bc800z.json
+++ b/cameras/synology/bc800z.json
@@ -61,7 +61,6 @@
     "NDAA/TAA compliant",
     "modular licensing"
   ],
-  "msrp_usd": 299.99,
   "sources": [
     "https://www.synology.com/en-us/products/BC800Z"
   ],

--- a/cameras/synology/tc500-dome.json
+++ b/cameras/synology/tc500-dome.json
@@ -57,7 +57,6 @@
     "NDAA compliant",
     "seamless NAS integration"
   ],
-  "msrp_usd": 199,
   "sources": [
     "https://www.synology.com/en-us/store/TC500"
   ],

--- a/cameras/synology/tc500.json
+++ b/cameras/synology/tc500.json
@@ -59,7 +59,6 @@
     "NDAA compliant",
     "~$200 MSRP"
   ],
-  "msrp_usd": 199.99,
   "sources": [
     "https://www.synology.com/en-eu/products/TC500"
   ],

--- a/cameras/tapo/c100-indoor.json
+++ b/cameras/tapo/c100-indoor.json
@@ -55,7 +55,6 @@
     "most affordable Tapo indoor camera",
     "RTSP support"
   ],
-  "msrp_usd": 17,
   "sources": [
     "https://www.tapo.com/en/product/indoor-camera/tapo-c100/"
   ],

--- a/cameras/tapo/c100.json
+++ b/cameras/tapo/c100.json
@@ -52,7 +52,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2020,
-  "msrp_usd": 17.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c110.json
+++ b/cameras/tapo/c110.json
@@ -53,7 +53,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2022,
-  "msrp_usd": 19.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c120-indoor.json
+++ b/cameras/tapo/c120-indoor.json
@@ -54,7 +54,6 @@
     "Tapo app / Alexa / Google / HomeKit",
     "budget indoor camera 2024"
   ],
-  "msrp_usd": 24,
   "sources": [
     "https://www.tapo.com/en/product/indoor-camera/tapo-c120/"
   ],

--- a/cameras/tapo/c120.json
+++ b/cameras/tapo/c120.json
@@ -58,7 +58,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 29.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c125.json
+++ b/cameras/tapo/c125.json
@@ -55,7 +55,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 39.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c200.json
+++ b/cameras/tapo/c200.json
@@ -55,7 +55,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2020,
-  "msrp_usd": 19.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c210-india.json
+++ b/cameras/tapo/c210-india.json
@@ -61,7 +61,6 @@
     "RTSP/ONVIF",
     "₹2,500–3,500 best value India indoor cam"
   ],
-  "msrp_inr": 2699,
   "sources": [
     "https://www.tapo.com/in/"
   ],

--- a/cameras/tapo/c210-mena.json
+++ b/cameras/tapo/c210-mena.json
@@ -62,7 +62,6 @@
     "≈109 AED on Amazon.ae / Jarir KSA",
     "#1 budget indoor UAE/KSA home camera"
   ],
-  "msrp_aed": 109,
   "sources": [
     "https://www.tapo.com/me-en/",
     "https://www.jarir.com/"

--- a/cameras/tapo/c210-vn.json
+++ b/cameras/tapo/c210-vn.json
@@ -61,7 +61,6 @@
     "Shopee/Lazada Vietnam top-rated indoor cam",
     "≈500,000–800,000 VND"
   ],
-  "msrp_vnd": 649000,
   "sources": [
     "https://www.tp-link.com/vn/"
   ],

--- a/cameras/tapo/c210.json
+++ b/cameras/tapo/c210.json
@@ -55,7 +55,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2021,
-  "msrp_usd": 23.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c216.json
+++ b/cameras/tapo/c216.json
@@ -59,7 +59,6 @@
     "HybridCam 360"
   ],
   "release_year": 2025,
-  "msrp_usd": 49.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c220.json
+++ b/cameras/tapo/c220.json
@@ -56,7 +56,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 29.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c222-indoor.json
+++ b/cameras/tapo/c222-indoor.json
@@ -56,7 +56,6 @@
     "RTSP/ONVIF",
     "Tapo app / Alexa / Google / HomeKit"
   ],
-  "msrp_usd": 29,
   "sources": [
     "https://www.tapo.com/en/product/indoor-camera/tapo-c222/"
   ],

--- a/cameras/tapo/c225-ch.json
+++ b/cameras/tapo/c225-ch.json
@@ -63,7 +63,6 @@
     "budget Digitec CH bestseller indoor cam",
     "CHF 49–59"
   ],
-  "msrp_chf": 59.0,
   "sources": [
     "https://www.tapo.com/ch-de/",
     "https://www.digitec.ch/"

--- a/cameras/tapo/c225-eu.json
+++ b/cameras/tapo/c225-eu.json
@@ -64,7 +64,6 @@
     "RTSP/ONVIF",
     "top-rated EU Amazon indoor cam"
   ],
-  "msrp_eur": 44.99,
   "sources": [
     "https://www.tapo.com/de/"
   ],

--- a/cameras/tapo/c225.json
+++ b/cameras/tapo/c225.json
@@ -57,7 +57,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 34.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c230.json
+++ b/cameras/tapo/c230.json
@@ -54,7 +54,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2024,
-  "msrp_usd": 39.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c246d.json
+++ b/cameras/tapo/c246d.json
@@ -57,7 +57,6 @@
     "HybridCam Duo"
   ],
   "release_year": 2025,
-  "msrp_usd": 59.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c260.json
+++ b/cameras/tapo/c260.json
@@ -58,7 +58,6 @@
     "RoomCam 360"
   ],
   "release_year": 2025,
-  "msrp_usd": 79.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c310.json
+++ b/cameras/tapo/c310.json
@@ -55,7 +55,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2021,
-  "msrp_usd": 29.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c320ws-mena.json
+++ b/cameras/tapo/c320ws-mena.json
@@ -62,7 +62,6 @@
     "IP67",
     "≈169 AED popular outdoor UAE/KSA Amazon.ae"
   ],
-  "msrp_aed": 169,
   "sources": [
     "https://www.tapo.com/me-en/"
   ],

--- a/cameras/tapo/c320ws.json
+++ b/cameras/tapo/c320ws.json
@@ -56,7 +56,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2022,
-  "msrp_usd": 39.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c325wb-ca.json
+++ b/cameras/tapo/c325wb-ca.json
@@ -62,7 +62,6 @@
     "Canadian Tire & Best Buy stocked",
     "CAD$59.99"
   ],
-  "msrp_cad": 59.99,
   "sources": [
     "https://www.tapo.com/ca-en/"
   ],

--- a/cameras/tapo/c325wb-india.json
+++ b/cameras/tapo/c325wb-india.json
@@ -61,7 +61,6 @@
     "RTSP/ONVIF",
     "₹4,000–5,500 popular India outdoor WiFi cam"
   ],
-  "msrp_inr": 4299,
   "sources": [
     "https://www.tapo.com/in/"
   ],

--- a/cameras/tapo/c325wb.json
+++ b/cameras/tapo/c325wb.json
@@ -62,7 +62,6 @@
     "ColorPro Outdoor Camera"
   ],
   "release_year": 2024,
-  "msrp_usd": 59.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c402.json
+++ b/cameras/tapo/c402.json
@@ -56,7 +56,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 39.99,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/tapo/c420.json
+++ b/cameras/tapo/c420.json
@@ -54,7 +54,6 @@
     "solar panel compatible",
     "no subscription"
   ],
-  "msrp_usd": 49.99,
   "sources": [
     "https://www.tapo.com/en/product/smart-camera/tapo-c420/"
   ],

--- a/cameras/tapo/c425.json
+++ b/cameras/tapo/c425.json
@@ -58,7 +58,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2024,
-  "msrp_usd": 59.99,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/tapo/c440-outdoor.json
+++ b/cameras/tapo/c440-outdoor.json
@@ -57,7 +57,6 @@
     "Tapo app / Alexa / Google / HomeKit",
     "IP67"
   ],
-  "msrp_usd": 39,
   "sources": [
     "https://www.tapo.com/en/product/outdoor-camera/tapo-c440/"
   ],

--- a/cameras/tapo/c460.json
+++ b/cameras/tapo/c460.json
@@ -60,7 +60,6 @@
     "MagCam 4K Solar"
   ],
   "release_year": 2025,
-  "msrp_usd": 89.99,
   "power_source": [
     "battery",
     "solar"

--- a/cameras/tapo/c500-eu.json
+++ b/cameras/tapo/c500-eu.json
@@ -64,7 +64,6 @@
     "IP65",
     "budget EU Amazon outdoor cam"
   ],
-  "msrp_eur": 29.99,
   "sources": [
     "https://www.tapo.com/de/"
   ],

--- a/cameras/tapo/c500-outdoor.json
+++ b/cameras/tapo/c500-outdoor.json
@@ -56,7 +56,6 @@
     "IP65",
     "budget outdoor PTZ"
   ],
-  "msrp_usd": 29,
   "sources": [
     "https://www.tapo.com/en/product/outdoor-camera/tapo-c500/"
   ],

--- a/cameras/tapo/c500.json
+++ b/cameras/tapo/c500.json
@@ -56,7 +56,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2022,
-  "msrp_usd": 34.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c510w.json
+++ b/cameras/tapo/c510w.json
@@ -56,7 +56,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 44.99,
   "power_source": [
     "usb"
   ],

--- a/cameras/tapo/c520ws.json
+++ b/cameras/tapo/c520ws.json
@@ -60,7 +60,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2023,
-  "msrp_usd": 59.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c530ws.json
+++ b/cameras/tapo/c530ws.json
@@ -58,7 +58,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2024,
-  "msrp_usd": 69.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c560ws.json
+++ b/cameras/tapo/c560ws.json
@@ -61,7 +61,6 @@
     "VistaCam 360"
   ],
   "release_year": 2025,
-  "msrp_usd": 99.99,
   "power_source": [
     "dc"
   ],

--- a/cameras/tapo/c615f-kit.json
+++ b/cameras/tapo/c615f-kit.json
@@ -55,7 +55,6 @@
     "activity zones",
     "no subscription"
   ],
-  "msrp_usd": 89.99,
   "sources": [
     "https://us.store.tapo.com/"
   ],

--- a/cameras/tapo/c660-kit.json
+++ b/cameras/tapo/c660-kit.json
@@ -55,7 +55,6 @@
     "time-lapse",
     "no subscription"
   ],
-  "msrp_usd": 149.99,
   "sources": [
     "https://www.tapo.com/us/product/smart-camera/tapo-c660-kit/"
   ],

--- a/cameras/tapo/c720-india.json
+++ b/cameras/tapo/c720-india.json
@@ -62,7 +62,6 @@
     "RTSP/ONVIF",
     "₹5,000–7,000 popular India outdoor PTZ WiFi"
   ],
-  "msrp_inr": 5499,
   "sources": [
     "https://www.tapo.com/in/"
   ],

--- a/cameras/tapo/c720-ptz.json
+++ b/cameras/tapo/c720-ptz.json
@@ -57,7 +57,6 @@
     "RTSP/ONVIF",
     "Tapo app / Alexa / Google / HomeKit"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.tapo.com/en/product/outdoor-camera/tapo-c720/"
   ],

--- a/cameras/tapo/c720.json
+++ b/cameras/tapo/c720.json
@@ -58,7 +58,6 @@
     "https://www.tapo.com/"
   ],
   "release_year": 2024,
-  "msrp_usd": 79.99,
   "power_source": [
     "ac-mains"
   ],

--- a/cameras/tapo/c840.json
+++ b/cameras/tapo/c840.json
@@ -53,7 +53,6 @@
     "privacy shutter",
     "no subscription"
   ],
-  "msrp_usd": 59.99,
   "sources": [
     "https://www.tapo.com/us/product/smart-camera/tapo-c840/"
   ],

--- a/cameras/tapo/d225.json
+++ b/cameras/tapo/d225.json
@@ -54,7 +54,6 @@
     "Alexa / Google",
     "no subscription"
   ],
-  "msrp_usd": 79.99,
   "sources": [
     "https://www.tapo.com/us/product/smart-camera/tapo-d225/"
   ],

--- a/cameras/tapo/d230s1.json
+++ b/cameras/tapo/d230s1.json
@@ -54,7 +54,6 @@
     "no subscription",
     "requires Tapo H200 hub"
   ],
-  "msrp_usd": 89.99,
   "sources": [
     "https://www.tapo.com/us/product/smart-camera/tapo-d230s1/"
   ],

--- a/cameras/tapo/d235-doorbell.json
+++ b/cameras/tapo/d235-doorbell.json
@@ -56,7 +56,6 @@
     "HomeKit / Alexa / Google",
     "free cloud storage"
   ],
-  "msrp_usd": 89,
   "sources": [
     "https://www.tapo.com/en/product/smart-doorbell/tapo-d235/"
   ],

--- a/cameras/tapo/tc82-floodlight.json
+++ b/cameras/tapo/tc82-floodlight.json
@@ -59,7 +59,6 @@
     "Tapo app / Alexa / Google / HomeKit",
     "IP44"
   ],
-  "msrp_usd": 49,
   "sources": [
     "https://www.tapo.com/en/product/outdoor-camera/tapo-tc82/"
   ],

--- a/cameras/ubiquiti/ai-360.json
+++ b/cameras/ubiquiti/ai-360.json
@@ -53,7 +53,6 @@
     "UniFi Protect ecosystem",
     "built-in mic and speaker"
   ],
-  "msrp_usd": 499,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-ai-360"
   ],

--- a/cameras/ubiquiti/ai-dslr.json
+++ b/cameras/ubiquiti/ai-dslr.json
@@ -50,7 +50,6 @@
     "UniFi Protect ecosystem"
   ],
   "release_year": 2024,
-  "msrp_usd": 999,
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-dslr"
   ],

--- a/cameras/ubiquiti/ai-pro-white.json
+++ b/cameras/ubiquiti/ai-pro-white.json
@@ -57,7 +57,6 @@
     "two-way audio"
   ],
   "release_year": 2024,
-  "msrp_usd": 499,
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro-white"
   ],

--- a/cameras/ubiquiti/ai-pro.json
+++ b/cameras/ubiquiti/ai-pro.json
@@ -56,7 +56,6 @@
     "two-way audio"
   ],
   "release_year": 2024,
-  "msrp_usd": 499,
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro"
   ],

--- a/cameras/ubiquiti/g3-bullet.json
+++ b/cameras/ubiquiti/g3-bullet.json
@@ -50,7 +50,6 @@
     "UniFi Protect ecosystem",
     "infrared LEDs for night vision"
   ],
-  "msrp_usd": 149,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g3-bullet"
   ],

--- a/cameras/ubiquiti/g3-flex.json
+++ b/cameras/ubiquiti/g3-flex.json
@@ -51,7 +51,6 @@
     "EFL 4 mm lens",
     "infrared night vision"
   ],
-  "msrp_usd": 79,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g3-flex"
   ],

--- a/cameras/ubiquiti/g3-instant.json
+++ b/cameras/ubiquiti/g3-instant.json
@@ -50,7 +50,6 @@
     "compact form factor",
     "infrared night vision"
   ],
-  "msrp_usd": 29,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g3-ins"
   ],

--- a/cameras/ubiquiti/g3-pro.json
+++ b/cameras/ubiquiti/g3-pro.json
@@ -51,7 +51,6 @@
     "UniFi Protect ecosystem",
     "infrared night vision"
   ],
-  "msrp_usd": 299,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g3-pro"
   ],

--- a/cameras/ubiquiti/g4-doorbell.json
+++ b/cameras/ubiquiti/g4-doorbell.json
@@ -54,7 +54,6 @@
     "UniFi Protect ecosystem"
   ],
   "release_year": 2022,
-  "msrp_usd": 199,
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-doorbell"
   ],

--- a/cameras/ubiquiti/g4-ptz.json
+++ b/cameras/ubiquiti/g4-ptz.json
@@ -53,7 +53,6 @@
     "UniFi Protect ecosystem",
     "auto-tracking"
   ],
-  "msrp_usd": 1499,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g4-ptz"
   ],

--- a/cameras/ubiquiti/g5-flex.json
+++ b/cameras/ubiquiti/g5-flex.json
@@ -52,7 +52,6 @@
     "UniFi Protect ecosystem",
     "infrared night vision"
   ],
-  "msrp_usd": 99,
   "sources": [
     "https://store.ui.com/us/en/products/uvc-g5-flex"
   ],

--- a/cameras/ubiquiti/g5-turret.json
+++ b/cameras/ubiquiti/g5-turret.json
@@ -51,7 +51,6 @@
     "built-in mic"
   ],
   "release_year": 2024,
-  "msrp_usd": 99,
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g5-turret"
   ],

--- a/cameras/uniview/ipc3614sb-adf28km-i0-mena.json
+++ b/cameras/uniview/ipc3614sb-adf28km-i0-mena.json
@@ -63,7 +63,6 @@
     "IK08",
     "competitive MENA value vs Hikvision/Dahua"
   ],
-  "msrp_aed": 599,
   "sources": [
     "https://www.uniview.com/me-en/"
   ],

--- a/cameras/verkada/cb62-usa.json
+++ b/cameras/verkada/cb62-usa.json
@@ -63,7 +63,6 @@
     "-40°C to +60°C",
     "popular US enterprise/government/K-12 schools"
   ],
-  "msrp_usd": 999,
   "sources": [
     "https://www.verkada.com/security-cameras/outdoor-cameras/"
   ],

--- a/cameras/verkada/cd61-usa.json
+++ b/cameras/verkada/cd61-usa.json
@@ -61,7 +61,6 @@
     "annual per-camera license pricing model",
     "popular US healthcare/education/enterprise"
   ],
-  "msrp_usd": 849,
   "sources": [
     "https://www.verkada.com/security-cameras/indoor-dome-cameras/"
   ],

--- a/cameras/verkada/cm61.json
+++ b/cameras/verkada/cm61.json
@@ -54,7 +54,6 @@
     "zero-touch provisioning",
     "IP66"
   ],
-  "msrp_usd": 999,
   "sources": [
     "https://www.verkada.com/"
   ],

--- a/cameras/wyze/battery-cam-pro.json
+++ b/cameras/wyze/battery-cam-pro.json
@@ -52,7 +52,6 @@
     "no subscription required for basic",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 100,
   "sources": [
     "https://www.wyze.com/products/wyze-battery-cam-pro"
   ],

--- a/cameras/wyze/cam-floodlight-pro.json
+++ b/cameras/wyze/cam-floodlight-pro.json
@@ -52,7 +52,6 @@
     "no subscription required",
     "Alexa / Google"
   ],
-  "msrp_usd": 149.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-floodlight-pro"
   ],

--- a/cameras/wyze/cam-og-telephoto.json
+++ b/cameras/wyze/cam-og-telephoto.json
@@ -53,7 +53,6 @@
     "no subscription for basic features",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 32,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-og"
   ],

--- a/cameras/wyze/cam-og.json
+++ b/cameras/wyze/cam-og.json
@@ -52,7 +52,6 @@
     "no subscription for basic features",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 24,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-og"
   ],

--- a/cameras/wyze/cam-outdoor-pro.json
+++ b/cameras/wyze/cam-outdoor-pro.json
@@ -53,7 +53,6 @@
     "solar optional",
     "Alexa / Google"
   ],
-  "msrp_usd": 59,
   "sources": [
     "https://www.wyze.com/"
   ],

--- a/cameras/wyze/cam-outdoor-v2.json
+++ b/cameras/wyze/cam-outdoor-v2.json
@@ -55,7 +55,6 @@
     "no subscription required",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 49.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-outdoor"
   ],

--- a/cameras/wyze/cam-pan-v2.json
+++ b/cameras/wyze/cam-pan-v2.json
@@ -56,7 +56,6 @@
     "no subscription required",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 34,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-pan"
   ],

--- a/cameras/wyze/cam-pan-v3.json
+++ b/cameras/wyze/cam-pan-v3.json
@@ -55,7 +55,6 @@
     "24/7 recording (microSD)",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 37.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-pan"
   ],

--- a/cameras/wyze/cam-v2.json
+++ b/cameras/wyze/cam-v2.json
@@ -53,7 +53,6 @@
     "continuous recording (microSD)",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 26,
   "sources": [
     "https://www.wyze.com/products/wyze-cam"
   ],

--- a/cameras/wyze/cam-v3-pro.json
+++ b/cameras/wyze/cam-v3-pro.json
@@ -56,7 +56,6 @@
     "Alexa / Google Home",
     "RTSP"
   ],
-  "msrp_usd": 59.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-pro"
   ],

--- a/cameras/wyze/cam-v3.json
+++ b/cameras/wyze/cam-v3.json
@@ -55,7 +55,6 @@
     "Alexa / Google Home",
     "RTSP support"
   ],
-  "msrp_usd": 35.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam"
   ],

--- a/cameras/wyze/cam-v4.json
+++ b/cameras/wyze/cam-v4.json
@@ -58,7 +58,6 @@
     "Alexa / Google Home",
     "RTSP support"
   ],
-  "msrp_usd": 35.98,
   "sources": [
     "https://www.wyze.com/products/wyze-cam"
   ],

--- a/cameras/wyze/floodlight-cam-v2.json
+++ b/cameras/wyze/floodlight-cam-v2.json
@@ -53,7 +53,6 @@
     "no subscription required for basic",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 60,
   "sources": [
     "https://www.wyze.com/products/wyze-cam-floodlight"
   ],

--- a/cameras/wyze/video-doorbell-pro.json
+++ b/cameras/wyze/video-doorbell-pro.json
@@ -54,7 +54,6 @@
     "built-in chime",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 49.98,
   "sources": [
     "https://www.wyze.com/products/wyze-doorbell-pro"
   ],

--- a/cameras/wyze/video-doorbell-v2.json
+++ b/cameras/wyze/video-doorbell-v2.json
@@ -51,7 +51,6 @@
     "built-in chime",
     "Alexa / Google Home"
   ],
-  "msrp_usd": 50,
   "sources": [
     "https://www.wyze.com/products/wyze-video-doorbell-v2"
   ],

--- a/cameras/yale/sv-abfx-w.json
+++ b/cameras/yale/sv-abfx-w.json
@@ -59,7 +59,6 @@
     "no monthly fees",
     "solar panel optional"
   ],
-  "msrp_gbp": 79.99,
   "sources": [
     "https://www.yale.co.uk/"
   ],

--- a/cameras/yale/sv-dafx-w.json
+++ b/cameras/yale/sv-dafx-w.json
@@ -58,7 +58,6 @@
     "Amazon Alexa certified",
     "IP65"
   ],
-  "msrp_gbp": 99.99,
   "sources": [
     "https://www.yale.co.uk/"
   ],

--- a/cameras/yale/sv-ddfx-w.json
+++ b/cameras/yale/sv-ddfx-w.json
@@ -58,7 +58,6 @@
     "activity zones",
     "UK brand trust factor"
   ],
-  "msrp_gbp": 79.99,
   "sources": [
     "https://www.yale.co.uk/"
   ],

--- a/cameras/yale/sv-dpfx-w.json
+++ b/cameras/yale/sv-dpfx-w.json
@@ -57,7 +57,6 @@
     "Alexa compatible",
     "activity zones"
   ],
-  "msrp_gbp": 59.99,
   "sources": [
     "https://www.yale.co.uk/"
   ],

--- a/cameras/yale/wipc-303w.json
+++ b/cameras/yale/wipc-303w.json
@@ -54,7 +54,6 @@
     "Yale Home View App",
     "entry-level budget Yale indoor cam"
   ],
-  "msrp_gbp": 49.99,
   "sources": [
     "https://www.yale.co.uk/"
   ],

--- a/cameras/zebronics/zeb-ipsr100-ir-wifi.json
+++ b/cameras/zebronics/zeb-ipsr100-ir-wifi.json
@@ -58,7 +58,6 @@
     "Zebronics Smart app",
     "₹1,500–2,500 ultra-budget India"
   ],
-  "msrp_inr": 1799,
   "sources": [
     "https://www.zebronics.com/"
   ],

--- a/cameras/zebronics/zeb-ns-cam2000.json
+++ b/cameras/zebronics/zeb-ns-cam2000.json
@@ -54,7 +54,6 @@
     "no subscription",
     "₹2,499"
   ],
-  "msrp_inr": 2499,
   "sources": [
     "https://www.zebronics.com/"
   ],

--- a/cameras/zebronics/zeb-ns-cam4000.json
+++ b/cameras/zebronics/zeb-ns-cam4000.json
@@ -44,7 +44,6 @@
   "markets": [
     "IN"
   ],
-  "msrp_inr": 3499,
   "power_source": [
     "dc"
   ]

--- a/cameras/zebronics/zeb-smartcam200.json
+++ b/cameras/zebronics/zeb-smartcam200.json
@@ -47,7 +47,6 @@
   "markets": [
     "IN"
   ],
-  "msrp_inr": 1499,
   "power_source": [
     "usb"
   ]

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -133,7 +133,6 @@
       "IP66",
       "German brand"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -224,7 +223,6 @@
       "IP66",
       "Austrian consumer favourite Conrad/MediaMarkt"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/at/"
     ],
@@ -387,7 +385,6 @@
       "IP66",
       "German brand"
     ],
-    "msrp_eur": 189.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -479,7 +476,6 @@
       "no mandatory subscription",
       "German brand"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -569,7 +565,6 @@
       "IP65",
       "German brand"
     ],
-    "msrp_eur": 199.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -709,7 +704,6 @@
       "IP67",
       "ONVIF/RTSP"
     ],
-    "msrp_eur": 299.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -875,7 +869,6 @@
       "IK10",
       "German engineering brand"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -972,7 +965,6 @@
       "no mandatory cloud",
       "GDPR compliant"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.abus.com/at/"
     ],
@@ -2403,7 +2395,6 @@
       "IK07",
       "EU professional alarm market"
     ],
-    "msrp_eur": 199,
     "sources": [
       "https://ajax.systems/products/"
     ],
@@ -2473,7 +2464,6 @@
       "professional installer market",
       "IK09 tamper resistant"
     ],
-    "msrp_gbp": 249.99,
     "sources": [
       "https://ajax.systems/products/outdoorcam/"
     ],
@@ -2541,7 +2531,6 @@
       "IP65",
       "no subscription required"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://amcrest.com/products/video-doorbells/ad410"
     ],
@@ -3216,7 +3205,6 @@
       "Amcrest View app",
       "IP67"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3303,7 +3291,6 @@
       "Blue Iris compatible",
       "IP67"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3721,7 +3708,6 @@
       "Blue Iris compatible",
       "built-in mic & speaker"
     ],
-    "msrp_usd": 69.99,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3890,7 +3876,6 @@
       "IP67",
       "affordable 4K PTZ"
     ],
-    "msrp_usd": 119,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -4520,7 +4505,6 @@
       "IP67",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/ac500"
     ],
@@ -4610,7 +4594,6 @@
       "IP67",
       "IK08"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.annke.com/blogs/press/annke-reveals-next-gen-4k-surveillance-camera-lead-by-the-ac800-featuring-ai-active-deterrence-two-way-talk-and-color-night-vision"
     ],
@@ -4864,7 +4847,6 @@
       "Alexa / Google",
       "no subscription"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://www.annke.com/products/c500"
     ],
@@ -5024,7 +5006,6 @@
       "IK08",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/c800"
     ],
@@ -5185,7 +5166,6 @@
       "IK10",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/c800"
     ],
@@ -5343,7 +5323,6 @@
       "H.265+",
       "IP67"
     ],
-    "msrp_usd": 69.99,
     "sources": [
       "https://www.annke.com/products/c800x"
     ],
@@ -5582,7 +5561,6 @@
       "IP67",
       "ONVIF compatible"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.annke.com/"
     ],
@@ -6257,7 +6235,6 @@
       "Alexa / Google",
       "Matter compatible"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://eu.aqara.com/en-eu/products/camera-hub-g3"
     ],
@@ -6334,7 +6311,6 @@
       "first shown IFA 2024 Berlin",
       "IP65 / -30°C"
     ],
-    "msrp_eur": 139.99,
     "sources": [
       "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro"
     ],
@@ -6412,7 +6388,6 @@
       "available Digitec / Galaxus CH",
       "popular Swiss HomeKit users"
     ],
-    "msrp_chf": 149,
     "sources": [
       "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro",
       "https://www.digitec.ch/"
@@ -6480,7 +6455,6 @@
       "cry detection alerts",
       "Arlo app"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://us.arlo.com/products/arlo-baby-monitor"
     ],
@@ -6541,7 +6515,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-indoor-camera"
     ],
@@ -6602,7 +6575,6 @@
       "Arlo Secure plan for cloud"
     ],
     "release_year": 2022,
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-indoor.html"
     ],
@@ -6665,7 +6637,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-2nd-gen"
     ],
@@ -6731,7 +6702,6 @@
       "IP65",
       "improved battery life vs Gen 2"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
     ],
@@ -6794,7 +6764,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-spotlight"
     ],
@@ -6857,7 +6826,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-outdoor.html"
     ],
@@ -6921,7 +6889,6 @@
       "IP65",
       "ideal for remote installs"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-xl-v2"
     ],
@@ -6981,7 +6948,6 @@
       "Alexa / Google / HomeKit"
     ],
     "release_year": 2021,
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-xl-spotlight.html"
     ],
@@ -7043,7 +7009,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 249,
     "sources": [
       "https://us.arlo.com/"
     ],
@@ -7107,7 +7072,6 @@
       "Arlo Secure for cloud",
       "works anywhere with cellular signal"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.arlo.com/cameras/go/arlo-go-2.html"
     ],
@@ -7169,7 +7133,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-indoor-plug-in"
     ],
@@ -7231,7 +7194,6 @@
       "Arlo Secure plan",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://us.arlo.com/products/arlo-pro-3"
     ],
@@ -7293,7 +7255,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://us.arlo.com/products/arlo-pro-3-floodlight"
     ],
@@ -7356,7 +7317,6 @@
       "Arlo Secure subscription for cloud history"
     ],
     "release_year": 2021,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.arlo.com/asia/cameras/pro/arlo-pro-4.html"
     ],
@@ -7417,7 +7377,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://www.arlo.com/cameras/pro/arlo-pro-4-spotlight-camera.html"
     ],
@@ -7481,7 +7440,6 @@
       "Arlo Secure plan for cloud history"
     ],
     "release_year": 2023,
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.arlo.com/cameras/pro/arlo-pro-5s.html"
     ],
@@ -7546,7 +7504,6 @@
       "IP65",
       "Arlo flagship 2025"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
     ],
@@ -7613,7 +7570,6 @@
       "IP65 rated AU conditions",
       "JB Hi-Fi / Harvey Norman stocked"
     ],
-    "msrp_aud": 259.99,
     "sources": [
       "https://www.arlo.com/en-au/"
     ],
@@ -7681,7 +7637,6 @@
       "rated -20°C",
       "Best Buy Canada stocked"
     ],
-    "msrp_cad": 219.99,
     "sources": [
       "https://www.arlo.com/en-ca/"
     ],
@@ -7751,7 +7706,6 @@
       "Arlo Secure plan",
       "EU-compliant cloud storage"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://www.arlo.com/de-de/"
     ],
@@ -7818,7 +7772,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_gbp": 149.99,
     "sources": [
       "https://www.arlo.com/en-gb/"
     ],
@@ -7882,7 +7835,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://us.arlo.com/products/arlo-security-light"
     ],
@@ -7944,7 +7896,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://us.arlo.com/products/arlo-solar-panel-cam"
     ],
@@ -8008,7 +7959,6 @@
       "Arlo Secure plan",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 299.99,
     "sources": [
       "https://us.arlo.com/products/arlo-ultra"
     ],
@@ -8071,7 +8021,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://www.arlo.com/cameras/ultra/arlo-ultra-2-spotlight-camera.html"
     ],
@@ -8134,7 +8083,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://www.arlo.com/cameras/doorbells/"
     ],
@@ -8198,7 +8146,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://us.arlo.com/products/arlo-doorbell-wired-2nd-gen"
     ],
@@ -8261,7 +8208,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan for cloud storage"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.arlo.com/"
     ],
@@ -15557,7 +15503,6 @@
       "Blink Sync Module required",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15618,7 +15563,6 @@
       "Blink Sync Module for local USB storage",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15680,7 +15624,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud storage"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15794,7 +15737,6 @@
       "IP54",
       "Alexa / Fire TV"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15856,7 +15798,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15918,7 +15859,6 @@
       "Blink Subscription for cloud",
       "IP54"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15982,7 +15922,6 @@
       "Alexa / Fire TV",
       "Sync Module for local MicroSD storage"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16046,7 +15985,6 @@
       "Blink Sync Module required",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16111,7 +16049,6 @@
       "Blink Sync Module required for local storage",
       "Blink Subscription Plan for cloud"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16180,7 +16117,6 @@
       "Blink Subscription for cloud",
       "popular budget EU Amazon camera"
     ],
-    "msrp_eur": 54.99,
     "sources": [
       "https://blinkforhome.com/de-de/"
     ],
@@ -16243,7 +16179,6 @@
       "wire-free installation",
       "Blink Sync Module XR for extended range"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16307,7 +16242,6 @@
       "Blink Sync Module for local USB storage",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 119.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16370,7 +16304,6 @@
       "Blink Subscription for cloud video history",
       "local storage via Sync Module"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16433,7 +16366,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16496,7 +16428,6 @@
       "Blink Sync Module required",
       "free cloud storage included at launch"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -18290,7 +18221,6 @@
       "GDPR-compliant German cloud (for EU)",
       "anthracite or white"
     ],
-    "msrp_gbp": 199.99,
     "sources": [
       "https://www.bosch-smarthome.com/uk/en/products/cameras/"
     ],
@@ -18362,7 +18292,6 @@
       "Digitec / Galaxus CH stocked",
       "very popular CH/AT premium smart home brand"
     ],
-    "msrp_chf": 229,
     "sources": [
       "https://www.bosch-smarthome.com/ch/de/"
     ],
@@ -20023,7 +19952,6 @@
       "CP Plus app",
       "₹3,500–4,500 price range"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20335,7 +20263,6 @@
       "₹3,000–5,000 price range",
       "STQC model available"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.cpplusworld.com/cp-unc-da21pl3"
     ],
@@ -20426,7 +20353,6 @@
       "IP67",
       "Made in India"
     ],
-    "msrp_inr": 6999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20661,7 +20587,6 @@
       "NVR compatible",
       "₹4,000–5,000"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20751,7 +20676,6 @@
       "most popular India outdoor bullet",
       "₹3,500–5,500 price range"
     ],
-    "msrp_inr": 4499,
     "sources": [
       "https://www.cpplusworld.com/cp-unc-ta21pl3"
     ],
@@ -20841,7 +20765,6 @@
       "IP67",
       "Made in India"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -21076,7 +20999,6 @@
       "IP66",
       "₹5,000–7,000"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -23256,7 +23178,6 @@
       "IK10",
       "budget 4K"
     ],
-    "msrp_usd": 44.99,
     "sources": [
       "https://www.dahuasecurity.com"
     ],
@@ -23508,7 +23429,6 @@
       "very popular Indian system integrators",
       "₹8,000–12,000"
     ],
-    "msrp_inr": 9999,
     "sources": [
       "https://www.dahuasecurity.com/"
     ],
@@ -24083,7 +24003,6 @@
       "IK10",
       "very popular EU CCTV installer choice"
     ],
-    "msrp_eur": 139.99,
     "sources": [
       "https://www.dahuasecurity.com/eu/"
     ],
@@ -24176,7 +24095,6 @@
       "IK10",
       "very popular UAE/KSA commercial installers"
     ],
-    "msrp_aed": 650,
     "sources": [
       "https://www.dahuasecurity.com/mena/"
     ],
@@ -25758,7 +25676,6 @@
       "IK10",
       "high value"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.dahuasecurity.com"
     ],
@@ -26395,7 +26312,6 @@
       "≈498 AED on Amazon.ae",
       "popular UAE budget 4K outdoor bullet"
     ],
-    "msrp_aed": 498,
     "sources": [
       "https://www.amazon.ae/IPC-HFW2849S-S-Network-WizSense-Full-Color-Security/dp/B0FL7XWMHM",
       "https://www.dahuasecurity.com/mena/"
@@ -26559,7 +26475,6 @@
       "popular Vietnam business + residential installers",
       "Dahua local distributors Hanoi / HCMC"
     ],
-    "msrp_vnd": 1500000,
     "sources": [
       "https://www.dahuasecurity.com/vn-vi/"
     ],
@@ -29197,7 +29112,6 @@
       "IP66",
       "widely used hotels/malls UAE & Saudi Arabia"
     ],
-    "msrp_aed": 1899,
     "sources": [
       "https://shop.acssllc.ae/product-category/dahua-camera/",
       "https://www.dahuasecurity.com/mena/"
@@ -29608,7 +29522,6 @@
       "no subscription",
       "Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/"
     ],
@@ -29672,7 +29585,6 @@
       "HomeBase local storage",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 219.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-2-pro"
     ],
@@ -29751,7 +29663,6 @@
       "HomeBase local storage",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 139.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-2c"
     ],
@@ -29814,7 +29725,6 @@
       "HomeBase local 16GB storage",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-3-pro"
     ],
@@ -29879,7 +29789,6 @@
       "IP67",
       "more affordable EufyCam 3 entry variant"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.eufy.com/products/eufycam-3c"
     ],
@@ -29942,7 +29851,6 @@
       "no subscription required",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 279.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-e330-pro"
     ],
@@ -30006,7 +29914,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 179,
     "sources": [
       "https://www.eufy.com/products/eufycam-s330-pro"
     ],
@@ -30069,7 +29976,6 @@
       "Alexa / Google"
     ],
     "release_year": 2022,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-2-pro"
     ],
@@ -30136,7 +30042,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-e220"
     ],
@@ -30198,7 +30103,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 249,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-e340"
     ],
@@ -30270,7 +30174,6 @@
       "IP67",
       "top-rated EU floodlight cam"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.eufy.com/de-de/"
     ],
@@ -30331,7 +30234,6 @@
       "real-time door status alerts",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/garage-cam-s330"
     ],
@@ -30398,7 +30300,6 @@
       "RTSP support",
       "€35–45 best-value Eufy indoor"
     ],
-    "msrp_usd": 35,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-2k-pan-tilt"
     ],
@@ -30481,7 +30382,6 @@
       "RTSP support",
       "Alexa / Google HomeKit"
     ],
-    "msrp_usd": 29.99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-c120"
     ],
@@ -30562,7 +30462,6 @@
       "HomeKit / Alexa / Google",
       "RTSP support"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-e220"
     ],
@@ -30640,7 +30539,6 @@
       "microSD card slot",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 29.99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-mini"
     ],
@@ -30703,7 +30601,6 @@
       "HomeKit / Alexa / Google",
       "RTSP support"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-s350"
     ],
@@ -30783,7 +30680,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.eufy.com/products/outdoor-cam-e210"
     ],
@@ -30843,7 +30739,6 @@
       "Alexa / Google"
     ],
     "release_year": 2023,
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s220"
     ],
@@ -30902,7 +30797,6 @@
       "Alexa / Google integration"
     ],
     "release_year": 2023,
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-3c"
     ],
@@ -30965,7 +30859,6 @@
       "Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.eufy.com/products/solocam-c210"
     ],
@@ -31026,7 +30919,6 @@
     ],
     "operating_temp_c": "-20 to 50",
     "release_year": 2022,
-    "msrp_usd": 119.99,
     "sources": [
       "https://support.eufy.com/s/article/eufy-SoloCam-E40-FAQ",
       "https://service.eufy.com/article-description/Introducing-eufy-SoloCam-E40"
@@ -31089,7 +30981,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.eufy.com/products/solocam-l20"
     ],
@@ -31152,7 +31043,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://www.eufy.com/products/solocam-l40"
     ],
@@ -31218,7 +31108,6 @@
       "Alexa / Google HomeKit",
       "popular UK Amazon choice"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.eufy.com/en-gb/"
     ],
@@ -31282,7 +31171,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 119.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s230"
     ],
@@ -31345,7 +31233,6 @@
       "local HomeBase storage",
       "Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s340"
     ],
@@ -31412,7 +31299,6 @@
       "IP67",
       "JB Hi-Fi / The Good Guys AU stocked"
     ],
-    "msrp_aud": 329.99,
     "sources": [
       "https://www.eufy.com/au-en/"
     ],
@@ -31481,7 +31367,6 @@
       "rated -20°C",
       "Best Buy Canada top pick"
     ],
-    "msrp_cad": 269.99,
     "sources": [
       "https://www.eufy.com/ca-en/"
     ],
@@ -31550,7 +31435,6 @@
       "IP67",
       "Digitec / Galaxus CH top pick no-fee camera"
     ],
-    "msrp_chf": 219,
     "sources": [
       "https://www.eufy.com/ch-de/",
       "https://www.digitec.ch/"
@@ -31621,7 +31505,6 @@
       "IP67",
       "popular EU Amazon #1 no-fee camera"
     ],
-    "msrp_eur": 199.99,
     "sources": [
       "https://www.eufy.com/de-de/"
     ],
@@ -31681,7 +31564,6 @@
       "Alexa and Google Assistant integration"
     ],
     "release_year": 2022,
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.eufy.com/products/t8124"
     ],
@@ -31741,7 +31623,6 @@
       "HomeBase 2 compatible (optional)"
     ],
     "release_year": 2022,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/video-doorbells"
     ],
@@ -31820,7 +31701,6 @@
       "two-way audio",
       "IP65"
     ],
-    "msrp_usd": 159,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-e340"
     ],
@@ -31896,7 +31776,6 @@
       "no subscription required",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-s220"
     ],
@@ -31962,7 +31841,6 @@
       "two-way audio",
       "IP65"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-s330"
     ],
@@ -32043,7 +31921,6 @@
       "EZVIZ app / Alexa / Google",
       "IP66"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.ezviz.com/product/ezviz-elife/"
     ],
@@ -32111,7 +31988,6 @@
       "pet/baby monitoring",
       "very compact €30 price"
     ],
-    "msrp_eur": 29,
     "sources": [
       "https://www.ezviz.com/product/c1c/"
     ],
@@ -32199,7 +32075,6 @@
       "Alexa / Google",
       "EZVIZ app"
     ],
-    "msrp_eur": 59,
     "sources": [
       "https://www.ezviz.com/product/c3w-pro/"
     ],
@@ -32284,7 +32159,6 @@
       "RTSP/ONVIF",
       "IP67"
     ],
-    "msrp_eur": 79,
     "sources": [
       "https://www.ezviz.com/product/c3x/"
     ],
@@ -32373,7 +32247,6 @@
       "RTSP/ONVIF",
       "night vision"
     ],
-    "msrp_gbp": 29.99,
     "sources": [
       "https://www.ezviz.com/product/c6n/"
     ],
@@ -32553,7 +32426,6 @@
       "≈99 AED ultra-budget",
       "#1 budget indoor cam Amazon.ae Noon"
     ],
-    "msrp_aed": 99,
     "sources": [
       "https://www.ezviz.com/me-en/",
       "https://www.amazon.ae/"
@@ -32643,7 +32515,6 @@
       "#1 budget indoor WiFi cam Lazada/Shopee/Tiki Vietnam",
       "≈400,000–600,000 VND price point"
     ],
-    "msrp_vnd": 499000,
     "sources": [
       "https://www.ezviz.com/vn-vi/"
     ],
@@ -32734,7 +32605,6 @@
       "RTSP/ONVIF",
       "Alexa / Google"
     ],
-    "msrp_gbp": 49.99,
     "sources": [
       "https://www.ezviz.com/product/c8c/"
     ],
@@ -32822,7 +32692,6 @@
       "H.265",
       "RTSP/ONVIF"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.ezviz.com/product/c8pf/"
     ],
@@ -32917,7 +32786,6 @@
       "Alexa / Google",
       "popular EU Amazon budget PTZ"
     ],
-    "msrp_eur": 69.99,
     "sources": [
       "https://www.ezviz.com/de-de/"
     ],
@@ -33003,7 +32871,6 @@
       "IP65",
       "H.265"
     ],
-    "msrp_eur": 79,
     "sources": [
       "https://www.ezviz.com/product/db2/"
     ],
@@ -33076,7 +32943,6 @@
       "IP65",
       "budget entry doorbell"
     ],
-    "msrp_eur": 59,
     "sources": [
       "https://www.ezviz.com/product/db2c/"
     ],
@@ -33149,7 +33015,6 @@
       "privacy shield cover",
       "H.265"
     ],
-    "msrp_eur": 39,
     "sources": [
       "https://www.ezviz.com/product/h3c/"
     ],
@@ -33241,7 +33106,6 @@
       "H.265",
       "Alexa / Google"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.ezviz.com/product/h8+pro+3k/"
     ],
@@ -33333,7 +33197,6 @@
       "Alexa/Google",
       "popular budget choice Amazon.ae / Noon UAE"
     ],
-    "msrp_aed": 299,
     "sources": [
       "https://www.ezviz.com/me-en/",
       "https://www.amazon.ae/"
@@ -33425,7 +33288,6 @@
       "RTSP/ONVIF",
       "Alexa / Google"
     ],
-    "msrp_gbp": 59.99,
     "sources": [
       "https://www.ezviz.com/product/h8c/"
     ],
@@ -33608,7 +33470,6 @@
       "RTSP/ONVIF",
       "H.265"
     ],
-    "msrp_gbp": 64.99,
     "sources": [
       "https://www.ezviz.com/product/h8c+pro+2k/"
     ],
@@ -33699,7 +33560,6 @@
       "RTSP/ONVIF",
       "H.265"
     ],
-    "msrp_gbp": 89.99,
     "sources": [
       "https://www.ezviz.com/product/h8c+pro+4k/"
     ],
@@ -33790,7 +33650,6 @@
       "popular outdoor WiFi Shopee/Lazada Vietnam",
       "≈900,000–1,200,000 VND"
     ],
-    "msrp_vnd": 999000,
     "sources": [
       "https://www.ezviz.com/vn-vi/"
     ],
@@ -35964,7 +35823,6 @@
       "no subscription",
       "₹4,500"
     ],
-    "msrp_inr": 4500,
     "sources": [
       "https://pricee.com/godrej-eve-cube-cctv-security-camera-price-in-india-90722"
     ],
@@ -36032,7 +35890,6 @@
       "no subscription",
       "₹5,500"
     ],
-    "msrp_inr": 5524,
     "sources": [
       "https://pricee.com/godrej-eve-mini-cctv-security-camera-price-in-india-90724"
     ],
@@ -36103,7 +35960,6 @@
       "no subscription required",
       "₹3,000–5,000"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.amazon.in/Godrej-Eve-Nx-PT-Security/dp/B0886XDDDF"
     ],
@@ -36167,7 +36023,6 @@
       "no subscription",
       "₹5,999"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.amazon.in/"
     ],
@@ -36229,7 +36084,6 @@
       "Nest Aware subscription for extended history",
       "Google Home app required"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_cam_battery"
     ],
@@ -36351,7 +36205,6 @@
     "dimensions_mm": "83 × 83 × 83",
     "weight_g": 398,
     "release_year": 2021,
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_cam_battery_specs"
     ],
@@ -36465,7 +36318,6 @@
       "magnetic base",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://store.google.com/product/nest_cam_indoor"
     ],
@@ -36530,7 +36382,6 @@
       "encrypted video",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -36592,7 +36443,6 @@
       "activity zones",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://store.google.com/product/nest_cam_iq"
     ],
@@ -36655,7 +36505,6 @@
       "IP66 weatherproof",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 349,
     "sources": [
       "https://store.google.com/product/nest_cam_iq_outdoor"
     ],
@@ -36718,7 +36567,6 @@
       "magnetic mount",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://store.google.com/product/nest_cam_outdoor"
     ],
@@ -36783,7 +36631,6 @@
       "encrypted video",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -36853,7 +36700,6 @@
       "Alexa / Google Home",
       "EU GDPR-compliant (Google Cloud EU)"
     ],
-    "msrp_eur": 149.99,
     "sources": [
       "https://store.google.com/de/product/nest_cam_outdoor_specs"
     ],
@@ -37016,7 +36862,6 @@
       "Alexa"
     ],
     "release_year": 2021,
-    "msrp_usd": 99.99,
     "sources": [
       "https://store.google.com/product/nest_cam_specs"
     ],
@@ -37078,7 +36923,6 @@
       "Alexa / Google Home",
       "color night vision"
     ],
-    "msrp_usd": 279.99,
     "sources": [
       "https://store.google.com/product/nest_cam_floodlight_specs"
     ],
@@ -37144,7 +36988,6 @@
       "compatible with Gen 2 backplate",
       "Google Home Premium for Gemini"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -37257,7 +37100,6 @@
       "Alexa / Google Home",
       "DXOMARK best doorbell image quality at launch"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_doorbell_wired_2nd_gen_specs"
     ],
@@ -37320,7 +37162,6 @@
       "dual-band WiFi",
       "Alexa / Google Home"
     ],
-    "msrp_gbp": 179.99,
     "sources": [
       "https://store.google.com/gb/product/nest_doorbell_wired_2nd_gen_specs"
     ],
@@ -44289,7 +44130,6 @@
       "sold via Prama Hikvision India",
       "₹5,000–8,000"
     ],
-    "msrp_inr": 6999,
     "sources": [
       "https://www.hikvision.com/in-en/"
     ],
@@ -45310,7 +45150,6 @@
       "SIRA-approved",
       "popular Dubai commercial & warehouse sites"
     ],
-    "msrp_aed": 699,
     "sources": [
       "https://hikvision-uae.ae/product/ds-2cd2047g2-lu-sl/",
       "https://www.hikvision.com/mena-en/"
@@ -46800,7 +46639,6 @@
       "popular Vietnam residential + commercial dome camera",
       "Hikvision local Vietnam distributor network"
     ],
-    "msrp_vnd": 1200000,
     "sources": [
       "https://www.hikvision.com/vn-vi/"
     ],
@@ -47151,7 +46989,6 @@
       "IK10",
       "most popular EU professional installer 4MP dome"
     ],
-    "msrp_eur": 109.99,
     "sources": [
       "https://www.hikvision.com/de-de/"
     ],
@@ -49160,7 +48997,6 @@
       "most popular AU installer IP camera (Precision Security / Hypower Security)",
       "available AU security wholesalers"
     ],
-    "msrp_aud": 219.99,
     "sources": [
       "https://www.hikvision.com/au-en/"
     ],
@@ -49255,7 +49091,6 @@
       "≈815 AED price point",
       "popular Dubai villas & retail"
     ],
-    "msrp_aed": 815,
     "sources": [
       "https://hikvision-uae.ae/product/hikvision-ds-2cd2387g2-lu/",
       "https://www.hikvision.com/mena-en/"
@@ -52047,7 +51882,6 @@
       "popular CH/AT installer market",
       "available Swiss security distributors"
     ],
-    "msrp_chf": 179,
     "sources": [
       "https://www.hikvision.com/ch-de/"
     ],
@@ -52141,7 +51975,6 @@
       "≈620 AED",
       "most popular outdoor bullet UAE/KSA installer market"
     ],
-    "msrp_aed": 620,
     "sources": [
       "https://hikvisioncameradubai.com/product/hikvision-ds-2cd2t47g2-l/",
       "https://www.hikvision.com/mena-en/"
@@ -52319,7 +52152,6 @@
       "most popular outdoor PoE camera Vietnam installers",
       "available at Điện máy Xanh / Thế Giới Di Động / Bach Khoa"
     ],
-    "msrp_vnd": 1800000,
     "sources": [
       "https://www.hikvision.com/vn-vi/"
     ],
@@ -55248,7 +55080,6 @@
       "very popular commercial India PTZ",
       "₹25,000–35,000"
     ],
-    "msrp_inr": 28999,
     "sources": [
       "https://www.hikvision.com/in-en/"
     ],
@@ -55342,7 +55173,6 @@
       "standard PTZ for malls/hotels/airports UAE & Saudi",
       "≈2,200 AED"
     ],
-    "msrp_aed": 2200,
     "sources": [
       "https://www.hikvision.com/mena-en/"
     ],
@@ -55428,7 +55258,6 @@
       "auto-tracking",
       "most affordable Hikvision PoE mini PTZ"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://www.hikvision.com/en/products/"
     ],
@@ -56163,7 +55992,6 @@
       "most affordable Hikvision-ecosystem bullet",
       "UK/EU installer favourite"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56252,7 +56080,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook upgrade"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56338,7 +56165,6 @@
       "IP67",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 52,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56425,7 +56251,6 @@
       "Hikvision NVR compatible",
       "best-value 4K bullet entry-level"
     ],
-    "msrp_usd": 59,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56514,7 +56339,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook"
     ],
-    "msrp_usd": 69,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56602,7 +56426,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook varifocal"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56688,7 +56511,6 @@
       "IP67",
       "most affordable HiLook WiFi outdoor cam"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56772,7 +56594,6 @@
       "H.265+",
       "IP67"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56859,7 +56680,6 @@
       "Hikvision NVR compatible",
       "budget UK/EU installer dome"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56946,7 +56766,6 @@
       "IP67",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57033,7 +56852,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57120,7 +56938,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57208,7 +57025,6 @@
       "Hikvision NVR compatible",
       "most popular UK budget turret"
     ],
-    "msrp_usd": 47,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57294,7 +57110,6 @@
       "IP67",
       "formerly UK bestselling HiLook model"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57381,7 +57196,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57469,7 +57283,6 @@
       "Hikvision NVR compatible",
       "4K upgrade HiLook turret"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57559,7 +57372,6 @@
       "Hikvision NVR compatible",
       "best-value 4K turret with hybrid light"
     ],
-    "msrp_usd": 75,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57647,7 +57459,6 @@
       "Hikvision NVR compatible",
       "most affordable HiLook PTZ"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57731,7 +57542,6 @@
       "IP66",
       "budget analog upgrade path for legacy coax systems"
     ],
-    "msrp_usd": 35,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57794,7 +57604,6 @@
       "IK10",
       "most affordable HiLook camera for coax upgrades"
     ],
-    "msrp_usd": 33,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57851,7 +57660,6 @@
     "markets": [
       "UK"
     ],
-    "msrp_gbp": 119,
     "power_source": [
       "usb"
     ]
@@ -57914,7 +57722,6 @@
       "designed by Yves Béhar",
       "UK market leader in smart home"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -57970,7 +57777,6 @@
     "markets": [
       "UK"
     ],
-    "msrp_gbp": 99,
     "power_source": [
       "usb"
     ]
@@ -58034,7 +57840,6 @@
       "UK British Gas brand recognition",
       "30-day cloud storage subscription"
     ],
-    "msrp_gbp": 119.99,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -58096,7 +57901,6 @@
       "30-day cloud subscription",
       "IP65"
     ],
-    "msrp_gbp": 149,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -58166,7 +57970,6 @@
       "preferred enterprise/government India",
       "₹8,000–15,000"
     ],
-    "msrp_inr": 10999,
     "sources": [
       "https://www.honeywell.com/en-us/company/india"
     ],
@@ -58255,7 +58058,6 @@
       "preferred enterprise/government India",
       "₹10,000–16,000"
     ],
-    "msrp_inr": 13999,
     "sources": [
       "https://www.honeywell.com/en-us/company/india"
     ],
@@ -58417,7 +58219,6 @@
       "Alexa / Google",
       "two-way audio"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.honeywellhome.com/"
     ],
@@ -59107,7 +58908,6 @@
       "Alexa",
       "₹5,000–7,000 popular India outdoor"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59251,7 +59051,6 @@
       "Alexa",
       "₹7,000–9,000 best outdoor India PTZ"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59345,7 +59144,6 @@
       "≈399 AED",
       "value outdoor PTZ"
     ],
-    "msrp_aed": 399,
     "sources": [
       "https://www.imoulife.com/me-en/",
       "https://www.amazon.ae/"
@@ -59717,7 +59515,6 @@
       "Alexa / Google",
       "₹2,500–4,000 best-value India indoor camera"
     ],
-    "msrp_inr": 2999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59807,7 +59604,6 @@
       "≈350,000–500,000 VND",
       "top-selling Shopee Vietnam indoor camera 2024"
     ],
-    "msrp_vnd": 399000,
     "sources": [
       "https://www.imoulife.com/vn-vi/"
     ],
@@ -59899,7 +59695,6 @@
       "Alexa",
       "₹3,500–5,000"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59990,7 +59785,6 @@
       "Alexa",
       "≈199 AED budget indoor cam Noon/Amazon.ae"
     ],
-    "msrp_aed": 199,
     "sources": [
       "https://www.imoulife.com/me-en/"
     ],
@@ -60832,7 +60626,6 @@
       "popular Vietnam small business / apartment buildings",
       "≈450,000–700,000 VND"
     ],
-    "msrp_vnd": 550000,
     "sources": [
       "https://kbvisionvietnam.com/"
     ],
@@ -60925,7 +60718,6 @@
       "available Bach Khoa / ITC Telecom Vietnam",
       "≈900,000–1,300,000 VND"
     ],
-    "msrp_vnd": 1100000,
     "sources": [
       "https://kbvisionvietnam.com/"
     ],
@@ -62135,7 +61927,6 @@
       "two-way audio",
       "cloud storage"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.laviewusa.com/products/laview-security-cameras-4pc"
     ],
@@ -62182,7 +61973,6 @@
       "color + IR night vision",
       "two-way audio"
     ],
-    "msrp_usd": 18,
     "sources": [
       "https://www.laviewusa.com/products/l2-light-bulb-camera-4g"
     ],
@@ -62238,7 +62028,6 @@
       "50-day battery / 365-day with solar",
       "no subscription required for local storage"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.laviewusa.com/products/n3-outdoor-camera"
     ],
@@ -62286,7 +62075,6 @@
       "solar compatible",
       "motion detection"
     ],
-    "msrp_usd": 70,
     "sources": [
       "https://www.laviewusa.com/products/copy-of-r12b-outdoor-camera-1"
     ],
@@ -62333,7 +62121,6 @@
       "color night vision",
       "real-time alerts"
     ],
-    "msrp_usd": 130,
     "sources": [
       "https://www.laviewusa.com/products/r18-outdoor-360-camera-copy"
     ],
@@ -62386,7 +62173,6 @@
       "Alexa/Google compatible",
       "no subscription required for local storage"
     ],
-    "msrp_usd": 80,
     "sources": [
       "https://www.laviewusa.com/products/r28-wireless-outdoor-camera"
     ],
@@ -62586,7 +62372,6 @@
       "Alexa",
       "rated -40°C Canadian winters"
     ],
-    "msrp_cad": 149.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -62904,7 +62689,6 @@
       "NVR compatible",
       "no monthly fees"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.lorex.com/products/e893ab-4k-ip-wired-bullet-smart-deterrence"
     ],
@@ -63135,7 +62919,6 @@
       "ONVIF/RTSP",
       "Costco Canada bestseller"
     ],
-    "msrp_cad": 199.99,
     "sources": [
       "https://www.lorex.ca/products/4k-8mp-nocturnal-motorized-varifocal-smart-ip-bullet-security-camera"
     ],
@@ -63308,7 +63091,6 @@
       "no subscription",
       "popular Canada home security bundle"
     ],
-    "msrp_cad": 189.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63471,7 +63253,6 @@
       "H.265",
       "basic affordable IP camera"
     ],
-    "msrp_usd": 60,
     "sources": [
       "https://www.lorex.com/products/2k-ip-turret-camera"
     ],
@@ -63555,7 +63336,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.lorex.com/blogs/products/u471aa-series"
     ],
@@ -63622,7 +63402,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.lorex.com/products/2k-floodlight-camera"
     ],
@@ -63749,7 +63528,6 @@
       "Alexa / Google",
       "no monthly fees"
     ],
-    "msrp_cad": 79,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63818,7 +63596,6 @@
       "Lorex Home app",
       "Alexa / Google"
     ],
-    "msrp_cad": 139.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63938,7 +63715,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.lorex.com/products/w891uad-e-4k-dual-lens-wi-fi-camera"
     ],
@@ -64577,7 +64353,6 @@
       "German support Conrad/Lupus-Electronics.de",
       "€80–120"
     ],
-    "msrp_eur": 99,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64671,7 +64446,6 @@
       "German brand",
       "€80–120"
     ],
-    "msrp_eur": 109,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64764,7 +64538,6 @@
       "entry-level LUPUS PoE camera",
       "€80–100"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64858,7 +64631,6 @@
       "German brand",
       "€120–150"
     ],
-    "msrp_eur": 139,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64950,7 +64722,6 @@
       "baby / pet monitoring",
       "€50–80"
     ],
-    "msrp_eur": 69,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65045,7 +64816,6 @@
       "entry PoE dome",
       "€80–100"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65141,7 +64911,6 @@
       "DSGVO-compliant no cloud",
       "€150–200"
     ],
-    "msrp_eur": 169,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65235,7 +65004,6 @@
       "DSGVO local-first",
       "€100–130"
     ],
-    "msrp_eur": 119,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65419,7 +65187,6 @@
       "DSGVO local",
       "€130–160"
     ],
-    "msrp_eur": 149,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65514,7 +65281,6 @@
       "DSGVO local-first",
       "€160–200"
     ],
-    "msrp_eur": 179,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65609,7 +65375,6 @@
       "flagship LUPUS outdoor PoE",
       "€300–350"
     ],
-    "msrp_eur": 329,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65705,7 +65470,6 @@
       "DSGVO local-first",
       "€200–250"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65800,7 +65564,6 @@
       "DSGVO local",
       "€150–200"
     ],
-    "msrp_eur": 179,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65894,7 +65657,6 @@
       "DSGVO local-first",
       "€150–180"
     ],
-    "msrp_eur": 169,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65990,7 +65752,6 @@
       "new 2024 DE model",
       "€200–250"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66086,7 +65847,6 @@
       "DSGVO local-first",
       "€250–300"
     ],
-    "msrp_eur": 279,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66181,7 +65941,6 @@
       "DSGVO local storage",
       "€400–500 price range"
     ],
-    "msrp_eur": 449,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66276,7 +66035,6 @@
       "flagship LUPUS PTZ",
       "€500–600"
     ],
-    "msrp_eur": 549,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66371,7 +66129,6 @@
       "DSGVO local",
       "€350–450"
     ],
-    "msrp_eur": 399,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -68755,7 +68512,6 @@
       "100% local data",
       "French brand privacy focus"
     ],
-    "msrp_gbp": 179.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -68824,7 +68580,6 @@
       "two-way audio",
       "very popular privacy-conscious AT/CH buyers"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://www.netatmo.com/at-de/"
     ],
@@ -68897,7 +68652,6 @@
       "100% local data processing",
       "French brand privacy focus"
     ],
-    "msrp_gbp": 199.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -68972,7 +68726,6 @@
       "GDPR-compliant (French company, EU data)",
       "IP66"
     ],
-    "msrp_eur": 229.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -69042,7 +68795,6 @@
       "GDPR EU data",
       "IP66"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -69114,7 +68866,6 @@
       "165° wide FOV",
       "GDPR-compliant EU data"
     ],
-    "msrp_eur": 149,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -70331,7 +70082,6 @@
       "Alexa",
       "Made in India Hero Group"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70393,7 +70143,6 @@
       "Made in India Hero Group",
       "₹4,999"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70466,7 +70215,6 @@
       "Alexa compatible",
       "₹3,990–5,200"
     ],
-    "msrp_inr": 3990,
     "sources": [
       "https://www.quboworld.com/products/smart-cam-360-3mp"
     ],
@@ -70537,7 +70285,6 @@
       "Alexa",
       "Made in India"
     ],
-    "msrp_inr": 5499,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70593,7 +70340,6 @@
     "sources": [
       "https://reolink.com/product/altas-pt-ultra/"
     ],
-    "msrp_usd": 159,
     "aliases": [
       "B660"
     ],
@@ -70649,7 +70395,6 @@
     "sources": [
       "https://reolink.com/product/argus-2/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "battery",
       "solar"
@@ -70703,7 +70448,6 @@
     "sources": [
       "https://reolink.com/product/argus-2e/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "battery",
       "solar"
@@ -70757,7 +70501,6 @@
     "sources": [
       "https://reolink.com/product/argus-3/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "battery",
       "solar"
@@ -70933,7 +70676,6 @@
       "outlasted Arlo Pro 5 in AU long-term battery tests",
       "AU$99–129"
     ],
-    "msrp_aud": 129.99,
     "sources": [
       "https://reolink.com/au/",
       "https://www.safewise.com/au/best-wireless-security-cameras/"
@@ -71186,7 +70928,6 @@
       "Alexa / Google",
       "available Amazon.at / Conrad AT"
     ],
-    "msrp_eur": 149.99,
     "sources": [
       "https://reolink.com/at/",
       "https://www.amazon.at/"
@@ -71264,7 +71005,6 @@
     "sources": [
       "https://reolink.com/product/argus-5-pro/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "battery",
       "solar"
@@ -71399,7 +71139,6 @@
     "sources": [
       "https://reolink.com/product/argus-eco/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "battery",
       "solar"
@@ -71450,7 +71189,6 @@
       "solar compatible",
       "no subscription"
     ],
-    "msrp_usd": 97,
     "sources": [
       "https://reolink.com/product/argus-eco-ultra/"
     ],
@@ -71515,7 +71253,6 @@
       "Power-Efficient Series"
     ],
     "release_notes": "Launched June 2026 alongside OMVI Series.",
-    "msrp_usd": 49.99,
     "sources": [
       "https://securityjournaluk.com/reolink-launches-new-cameras/"
     ],
@@ -71588,7 +71325,6 @@
     "sources": [
       "https://reolink.com/product/argus-pro/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery"
     ]
@@ -71640,7 +71376,6 @@
     "sources": [
       "https://reolink.com/product/argus-pt/"
     ],
-    "msrp_usd": 59,
     "power_source": [
       "battery",
       "solar"
@@ -71693,7 +71428,6 @@
     "sources": [
       "https://reolink.com/product/argus-pt-2k/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "battery",
       "solar"
@@ -71757,7 +71491,6 @@
       "solar optional",
       "IP66"
     ],
-    "msrp_usd": 139,
     "sources": [
       "https://reolink.com/product/argus-pt-ultra/"
     ],
@@ -71914,7 +71647,6 @@
     "sources": [
       "https://reolink.com/product/b1200/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe"
     ],
@@ -71984,7 +71716,6 @@
     "sources": [
       "https://reolink.com/product/b400/"
     ],
-    "msrp_usd": 19,
     "power_source": [
       "poe"
     ],
@@ -72054,7 +71785,6 @@
     "sources": [
       "https://reolink.com/product/b500/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "poe"
     ],
@@ -72124,7 +71854,6 @@
     "sources": [
       "https://reolink.com/product/b800/"
     ],
-    "msrp_usd": 29,
     "power_source": [
       "poe"
     ],
@@ -72203,7 +71932,6 @@
       "dual warning (light + siren)",
       "no subscription"
     ],
-    "msrp_usd": 72,
     "sources": [
       "https://reolink.com/product/cx410/"
     ],
@@ -72550,7 +72278,6 @@
     "sources": [
       "https://reolink.com/product/d1200/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe"
     ],
@@ -72620,7 +72347,6 @@
     "sources": [
       "https://reolink.com/product/d400/"
     ],
-    "msrp_usd": 19,
     "power_source": [
       "poe"
     ],
@@ -72690,7 +72416,6 @@
     "sources": [
       "https://reolink.com/product/d500/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "poe"
     ],
@@ -72760,7 +72485,6 @@
     "sources": [
       "https://reolink.com/product/d800/"
     ],
-    "msrp_usd": 29,
     "power_source": [
       "poe"
     ],
@@ -72836,7 +72560,6 @@
       "solar compatible",
       "no subscription"
     ],
-    "msrp_usd": 170,
     "sources": [
       "https://reolink.com/product/reolink-duo/"
     ],
@@ -72893,7 +72616,6 @@
     "sources": [
       "https://reolink.com/product/reolink-duo-2-lte/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -73422,7 +73144,6 @@
     "sources": [
       "https://reolink.com/product/reolink-duo-4g/"
     ],
-    "msrp_usd": 119,
     "power_source": [
       "battery",
       "solar"
@@ -73553,7 +73274,6 @@
     "sources": [
       "https://reolink.com/product/e1/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "usb"
     ]
@@ -73606,7 +73326,6 @@
     "sources": [
       "https://reolink.com/product/e1-outdoor-cx/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -73764,7 +73483,6 @@
       "WiFi 6",
       "no subscription"
     ],
-    "msrp_usd": 110,
     "sources": [
       "https://reolink.com/product/e1-outdoor-pro/"
     ],
@@ -73840,7 +73558,6 @@
     "sources": [
       "https://reolink.com/product/e1-outdoor/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -73917,7 +73634,6 @@
       "dual-band WiFi",
       "no subscription"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://reolink.com/product/e1-pro/"
     ],
@@ -74002,7 +73718,6 @@
       "RTSP",
       "Consumer Reports tested 2024"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://reolink.com/product/reolink-e1-pro/"
     ],
@@ -74078,7 +73793,6 @@
     "sources": [
       "https://reolink.com/product/e1-zoom/"
     ],
-    "msrp_usd": 45,
     "power_source": [
       "usb"
     ],
@@ -74152,7 +73866,6 @@
     "sources": [
       "https://reolink.com/product/elite-floodlight-wifi/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "ac-mains"
     ],
@@ -74229,7 +73942,6 @@
       "no subscription"
     ],
     "release_year": 2025,
-    "msrp_usd": 188.99,
     "sources": [
       "https://slickdeals.net/f/18802744"
     ],
@@ -74312,7 +74024,6 @@
       "Bluetooth",
       "no subscription"
     ],
-    "msrp_usd": 160,
     "sources": [
       "https://reolink.com/product/elite-wifi/"
     ],
@@ -74467,7 +74178,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery",
       "solar"
@@ -74520,7 +74230,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt/"
     ],
-    "msrp_usd": 99,
     "power_source": [
       "battery",
       "solar"
@@ -74574,7 +74283,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt-plus/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "battery",
       "solar"
@@ -74627,7 +74335,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt-ultra/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -74682,7 +74389,6 @@
       "no cloud required",
       "NVR hub — not a camera"
     ],
-    "msrp_usd": 69,
     "sources": [
       "https://reolink.com/product/home-hub/"
     ],
@@ -74737,7 +74443,6 @@
     "sources": [
       "https://reolink.com/product/keen-ranger-pt/"
     ],
-    "msrp_usd": 159,
     "power_source": [
       "battery",
       "solar"
@@ -74794,7 +74499,6 @@
     "sources": [
       "https://reolink.com/product/reolink-lumus/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "dc"
     ],
@@ -74873,7 +74577,6 @@
       "no subscription"
     ],
     "release_year": 2025,
-    "msrp_usd": 299.99,
     "sources": [
       "https://reolink.com/product/omvi-3i-poe/"
     ],
@@ -74957,7 +74660,6 @@
       "perimeter protection",
       "no subscription"
     ],
-    "msrp_usd": 319.99,
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
@@ -75042,7 +74744,6 @@
       "iF DESIGN AWARD 2026",
       "CES 2026 Innovation Award Honoree"
     ],
-    "msrp_usd": 499.99,
     "sources": [
       "https://www.prnewswire.com/news-releases/reolink-redefines-full-coverage-smart-security-with-the-triple-lens-omvi-series-and-reolink-x-qualcomm-power-efficient-series-cameras-302786356.html"
     ],
@@ -75119,7 +74820,6 @@
     "sources": [
       "https://reolink.com/product/p340/"
     ],
-    "msrp_usd": 59,
     "power_source": [
       "poe",
       "dc"
@@ -75198,7 +74898,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 150,
     "sources": [
       "https://reolink.com/product/p430/"
     ],
@@ -75386,7 +75085,6 @@
       "IP65",
       "works anywhere with cellular signal — farms/remote areas"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://reolink.com/product/reolink-go-plus/"
     ],
@@ -75445,7 +75143,6 @@
     "sources": [
       "https://reolink.com/product/rlc-1210a/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "poe",
       "dc"
@@ -75620,7 +75317,6 @@
     "sources": [
       "https://reolink.com/product/rlc-1220a/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "poe",
       "dc"
@@ -75855,7 +75551,6 @@
     "sources": [
       "https://reolink.com/product/rlc-410/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76087,7 +75782,6 @@
     "sources": [
       "https://reolink.com/product/rlc-422/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "poe",
       "dc"
@@ -76160,7 +75854,6 @@
     "sources": [
       "https://reolink.com/product/rlc-423/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "poe",
       "dc"
@@ -76335,7 +76028,6 @@
     "sources": [
       "https://reolink.com/product/rlc-510wa/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -76407,7 +76099,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76480,7 +76171,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511w/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -76554,7 +76244,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511wa/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -76625,7 +76314,6 @@
     "sources": [
       "https://reolink.com/product/rlc-520/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76811,7 +76499,6 @@
       "IP67",
       "IK10"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://reolink.com/product/rlc-520a/"
     ],
@@ -76886,7 +76573,6 @@
     "sources": [
       "https://reolink.com/product/rlc-522/"
     ],
-    "msrp_usd": 45,
     "power_source": [
       "poe",
       "dc"
@@ -76961,7 +76647,6 @@
     "sources": [
       "https://reolink.com/product/rlc-523wa/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -77193,7 +76878,6 @@
     "sources": [
       "https://reolink.com/product/rlc-542wa/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "dc"
     ],
@@ -77381,7 +77065,6 @@
       "₹6,000–9,000 value 4K India",
       "Amazon India popular"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://reolink.com/in/"
     ],
@@ -77459,7 +77142,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 120,
     "sources": [
       "https://reolink.com/product/rlc-810wa/"
     ],
@@ -77643,7 +77325,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 160,
     "sources": [
       "https://reolink.com/product/rlc-811wa/"
     ],
@@ -78331,7 +78012,6 @@
       "IP67",
       "available Amazon AU / Officeworks"
     ],
-    "msrp_aud": 109.99,
     "sources": [
       "https://reolink.com/au/"
     ],
@@ -78423,7 +78103,6 @@
       "IP67 rated -10°C to +55°C",
       "available Home Depot Canada / Amazon.ca"
     ],
-    "msrp_cad": 79.99,
     "sources": [
       "https://reolink.com/ca/",
       "https://www.amazon.ca/"
@@ -78517,7 +78196,6 @@
       "IP67",
       "Digitec / Amazon.ch popular"
     ],
-    "msrp_chf": 99,
     "sources": [
       "https://reolink.com/ch/",
       "https://www.digitec.ch/"
@@ -78613,7 +78291,6 @@
       "RTSP/ONVIF Frigate/Home Assistant compatible",
       "IP67"
     ],
-    "msrp_eur": 79.99,
     "sources": [
       "https://reolink.com/eu/product/rlc-823a/"
     ],
@@ -78707,7 +78384,6 @@
       "≈349 AED Amazon.ae",
       "popular no-fee 4K UAE"
     ],
-    "msrp_aed": 349,
     "sources": [
       "https://reolink.com/me-en/",
       "https://www.amazon.ae/"
@@ -78792,7 +78468,6 @@
       "RTSP/ONVIF",
       "IP67"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://reolink.com/"
     ],
@@ -79493,7 +79168,6 @@
       "active deterrence",
       "no subscription"
     ],
-    "msrp_usd": 44.99,
     "sources": [
       "https://reolink.com/product/rlc-840a/"
     ],
@@ -80055,7 +79729,6 @@
     "sources": [
       "https://reolink.com/product/reolink-trackmix-lte/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -80174,7 +79847,6 @@
       "spotlight color night vision",
       "no subscription"
     ],
-    "msrp_usd": 161,
     "sources": [
       "https://reolink.com/product/reolink-trackmix-poe/"
     ],
@@ -80259,7 +79931,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 190,
     "sources": [
       "https://reolink.com/product/reolink-trackmix-wifi/"
     ],
@@ -80334,7 +80005,6 @@
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
-    "msrp_usd": 129,
     "power_source": [
       "battery"
     ],
@@ -80502,7 +80172,6 @@
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery"
     ],
@@ -80561,7 +80230,6 @@
     "sources": [
       "https://reolink.com/product/reolink-video-doorbell-wifi/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "ac-mains"
     ],
@@ -80660,7 +80328,6 @@
       "Alexa",
       "Ring Alarm system integration"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://ring.com/products/alarm-security-cam-pro"
     ],
@@ -80724,7 +80391,6 @@
       "Alexa integration",
       "Ring Protect plan for cloud video"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://ring.com/products/battery-video-doorbell-pro"
     ],
@@ -80787,7 +80453,6 @@
       "Alexa",
       "popular enterprise/commercial buildings"
     ],
-    "msrp_usd": 349,
     "sources": [
       "https://ring.com/products/doorbell-elite"
     ],
@@ -80849,7 +80514,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/floodlight-cam-wired-plus"
     ],
@@ -80908,7 +80572,6 @@
       "Alexa integration"
     ],
     "release_year": 2021,
-    "msrp_usd": 249.99,
     "sources": [
       "https://ring.com/products/floodlight-cam-wired-pro"
     ],
@@ -80966,7 +80629,6 @@
       "Ring subscription for cloud video"
     ],
     "release_year": 2022,
-    "msrp_usd": 59.99,
     "sources": [
       "https://ring.com/products/indoor-cam"
     ],
@@ -81031,7 +80693,6 @@
       "Ring Protect plan for cloud video",
       "Alexa"
     ],
-    "msrp_gbp": 44.99,
     "sources": [
       "https://ring.com/en-gb/"
     ],
@@ -81093,7 +80754,6 @@
       "Alexa",
       "most affordable Ring camera"
     ],
-    "msrp_usd": 44,
     "sources": [
       "https://ring.com/products/indoor-cam"
     ],
@@ -81150,7 +80810,6 @@
       "Ring subscription for cloud video"
     ],
     "release_year": 2023,
-    "msrp_usd": 79.99,
     "sources": [
       "https://ring.com/products/outdoor-cam"
     ],
@@ -81209,7 +80868,6 @@
       "Ring Protect for cloud video",
       "Alexa"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://ring.com/products/pan-tilt-indoor-cam"
     ],
@@ -81271,7 +80929,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://ring.com/products/peephole-cam"
     ],
@@ -81332,7 +80989,6 @@
       "Alexa",
       "IP55"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://ring.com/products/spotlight-cam-battery"
     ],
@@ -81391,7 +81047,6 @@
       "Ring subscription for cloud video history"
     ],
     "release_year": 2022,
-    "msrp_usd": 149.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-battery"
     ],
@@ -81459,7 +81114,6 @@
       "Alexa / Amazon",
       "IP55 EU version"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://ring.com/de-de/"
     ],
@@ -81522,7 +81176,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-plus-plug-in"
     ],
@@ -81584,7 +81237,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-plus-solar"
     ],
@@ -81648,7 +81300,6 @@
       "person/vehicle/package/motion alerts",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-pro"
     ],
@@ -81710,7 +81361,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/stick-up-cam-battery"
     ],
@@ -81775,7 +81425,6 @@
       "person/motion detection",
       "IP55 weatherproof"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://ring.com/en-gb/"
     ],
@@ -81837,7 +81486,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/stick-up-cam-plug-in"
     ],
@@ -81900,7 +81548,6 @@
       "Ring Protect for cloud video",
       "Alexa"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://ring.com/products/stick-up-security-camera"
     ],
@@ -81962,7 +81609,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/video-doorbell-gen-2"
     ],
@@ -82023,7 +81669,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 229.99,
     "sources": [
       "https://ring.com/products/video-doorbell-3-plus"
     ],
@@ -82086,7 +81731,6 @@
     ],
     "operating_temp_c": "-20 to 48",
     "release_year": 2021,
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/gb/en/support/articles/uc381/Learn-About-Video-Doorbell-4"
     ],
@@ -82159,7 +81803,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 64.99,
     "sources": [
       "https://ring.com/products/video-doorbell-wired"
     ],
@@ -82715,7 +82358,6 @@
       "SimpliSafe Smart Alarm System integration",
       "no long-term contract"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82776,7 +82418,6 @@
       "no long-term contract",
       "IP65"
     ],
-    "msrp_usd": 119,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82835,7 +82476,6 @@
       "SimpliSafe ecosystem",
       "no long-term contract"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82907,7 +82547,6 @@
       "GDPR-compliant French-hosted cloud",
       "Alexa / Google"
     ],
-    "msrp_eur": 129.99,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -82969,7 +82608,6 @@
       "GDPR-compliant EU cloud",
       "Alexa / Google"
     ],
-    "msrp_eur": 199,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -83042,7 +82680,6 @@
       "Alexa / Google",
       "IP55"
     ],
-    "msrp_eur": 229.99,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -83117,7 +82754,6 @@
       "local storage only (GDPR-friendly)",
       "very popular DE market \"WAF camera\""
     ],
-    "msrp_eur": 319.99,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -83182,7 +82818,6 @@
       "AI person/vehicle/animal detection",
       "IP44"
     ],
-    "msrp_eur": 359,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -83256,7 +82891,6 @@
       "GDPR-friendly no cloud mandatory",
       "high aesthetic WAF design"
     ],
-    "msrp_eur": 399.99,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -85330,7 +84964,6 @@
       "AU",
       "US"
     ],
-    "msrp_aud": 79,
     "power_source": [
       "battery",
       "ac-mains"
@@ -85573,7 +85206,6 @@
       "AU",
       "US"
     ],
-    "msrp_aud": 749,
     "power_source": [
       "poe",
       "dc"
@@ -85662,7 +85294,6 @@
       "JB Hi-Fi / Bunnings Australia stocked",
       "as seen on The Block AU"
     ],
-    "msrp_aud": 699.99,
     "sources": [
       "https://au.swann.com/swnvk-8advanx4b/"
     ],
@@ -85736,7 +85367,6 @@
       "IP66",
       "flagship Swann AU model 2025"
     ],
-    "msrp_aud": 1099.99,
     "sources": [
       "https://au.swann.com/swnvk-mr4kprosd4/"
     ],
@@ -85814,7 +85444,6 @@
       "multiple award-winner 2024",
       "perfect for rural AU properties / farms / large blocks"
     ],
-    "msrp_aud": 799.99,
     "sources": [
       "https://au.swann.com/swnvk-mr4ksd2/"
     ],
@@ -85882,7 +85511,6 @@
       "IP66",
       "requires Swann DVR"
     ],
-    "msrp_gbp": 39.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -85949,7 +85577,6 @@
       "IP66",
       "requires Swann DVR recorder"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86017,7 +85644,6 @@
       "Alexa / Google",
       "no hub required"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86088,7 +85714,6 @@
       "no DVR required",
       "RTSP stream"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86299,7 +85924,6 @@
       "NDAA compliant",
       "~$200 MSRP"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.synology.com/en-us/store/BC500"
     ],
@@ -86384,7 +86008,6 @@
       "NDAA compliant",
       "instant search"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.synology.com/en-us/store/BC500"
     ],
@@ -86544,7 +86167,6 @@
       "NDAA/TAA compliant",
       "modular licensing"
     ],
-    "msrp_usd": 299.99,
     "sources": [
       "https://www.synology.com/en-us/products/BC800Z"
     ],
@@ -86999,7 +86621,6 @@
       "NDAA compliant",
       "~$200 MSRP"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.synology.com/en-eu/products/TC500"
     ],
@@ -87084,7 +86705,6 @@
       "NDAA compliant",
       "seamless NAS integration"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.synology.com/en-us/store/TC500"
     ],
@@ -87236,7 +86856,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2020,
-    "msrp_usd": 17.99,
     "power_source": [
       "usb"
     ],
@@ -87317,7 +86936,6 @@
       "most affordable Tapo indoor camera",
       "RTSP support"
     ],
-    "msrp_usd": 17,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c100/"
     ],
@@ -87399,7 +87017,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 19.99,
     "power_source": [
       "usb"
     ],
@@ -87483,7 +87100,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 29.99,
     "power_source": [
       "usb"
     ],
@@ -87563,7 +87179,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "budget indoor camera 2024"
     ],
-    "msrp_usd": 24,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c120/"
     ],
@@ -87725,7 +87340,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 39.99,
     "power_source": [
       "usb"
     ],
@@ -87884,7 +87498,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2020,
-    "msrp_usd": 19.99,
     "power_source": [
       "usb"
     ],
@@ -87965,7 +87578,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2021,
-    "msrp_usd": 23.99,
     "power_source": [
       "usb"
     ],
@@ -88052,7 +87664,6 @@
       "RTSP/ONVIF",
       "₹2,500–3,500 best value India indoor cam"
     ],
-    "msrp_inr": 2699,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -88233,7 +87844,6 @@
       "≈109 AED on Amazon.ae / Jarir KSA",
       "#1 budget indoor UAE/KSA home camera"
     ],
-    "msrp_aed": 109,
     "sources": [
       "https://www.tapo.com/me-en/",
       "https://www.jarir.com/"
@@ -88324,7 +87934,6 @@
       "Shopee/Lazada Vietnam top-rated indoor cam",
       "≈500,000–800,000 VND"
     ],
-    "msrp_vnd": 649000,
     "sources": [
       "https://www.tp-link.com/vn/"
     ],
@@ -88412,7 +88021,6 @@
       "HybridCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 49.99,
     "power_source": [
       "usb"
     ],
@@ -88494,7 +88102,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 29.99,
     "power_source": [
       "usb"
     ],
@@ -88576,7 +88183,6 @@
       "RTSP/ONVIF",
       "Tapo app / Alexa / Google / HomeKit"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c222/"
     ],
@@ -88662,7 +88268,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 34.99,
     "power_source": [
       "usb"
     ],
@@ -88751,7 +88356,6 @@
       "budget Digitec CH bestseller indoor cam",
       "CHF 49–59"
     ],
-    "msrp_chf": 59,
     "sources": [
       "https://www.tapo.com/ch-de/",
       "https://www.digitec.ch/"
@@ -88845,7 +88449,6 @@
       "RTSP/ONVIF",
       "top-rated EU Amazon indoor cam"
     ],
-    "msrp_eur": 44.99,
     "sources": [
       "https://www.tapo.com/de/"
     ],
@@ -88928,7 +88531,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 39.99,
     "power_source": [
       "usb"
     ],
@@ -89011,7 +88613,6 @@
       "HybridCam Duo"
     ],
     "release_year": 2025,
-    "msrp_usd": 59.99,
     "power_source": [
       "usb"
     ],
@@ -89095,7 +88696,6 @@
       "RoomCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 79.99,
     "power_source": [
       "usb"
     ],
@@ -89176,7 +88776,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2021,
-    "msrp_usd": 29.99,
     "power_source": [
       "dc"
     ],
@@ -89349,7 +88948,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 39.99,
     "power_source": [
       "dc"
     ],
@@ -89437,7 +89035,6 @@
       "IP67",
       "≈169 AED popular outdoor UAE/KSA Amazon.ae"
     ],
-    "msrp_aed": 169,
     "sources": [
       "https://www.tapo.com/me-en/"
     ],
@@ -89528,7 +89125,6 @@
       "ColorPro Outdoor Camera"
     ],
     "release_year": 2024,
-    "msrp_usd": 59.99,
     "power_source": [
       "dc"
     ],
@@ -89616,7 +89212,6 @@
       "Canadian Tire & Best Buy stocked",
       "CAD$59.99"
     ],
-    "msrp_cad": 59.99,
     "sources": [
       "https://www.tapo.com/ca-en/"
     ],
@@ -89706,7 +89301,6 @@
       "RTSP/ONVIF",
       "₹4,000–5,500 popular India outdoor WiFi cam"
     ],
-    "msrp_inr": 4299,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -89950,7 +89544,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 39.99,
     "power_source": [
       "battery",
       "solar"
@@ -90031,7 +89624,6 @@
       "solar panel compatible",
       "no subscription"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.tapo.com/en/product/smart-camera/tapo-c420/"
     ],
@@ -90119,7 +89711,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 59.99,
     "power_source": [
       "battery",
       "solar"
@@ -90203,7 +89794,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "IP67"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c440/"
     ],
@@ -90292,7 +89882,6 @@
       "MagCam 4K Solar"
     ],
     "release_year": 2025,
-    "msrp_usd": 89.99,
     "power_source": [
       "battery",
       "solar"
@@ -90375,7 +89964,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 34.99,
     "power_source": [
       "usb"
     ],
@@ -90465,7 +90053,6 @@
       "IP65",
       "budget EU Amazon outdoor cam"
     ],
-    "msrp_eur": 29.99,
     "sources": [
       "https://www.tapo.com/de/"
     ],
@@ -90550,7 +90137,6 @@
       "IP65",
       "budget outdoor PTZ"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c500/"
     ],
@@ -90635,7 +90221,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 44.99,
     "power_source": [
       "usb"
     ],
@@ -90721,7 +90306,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 59.99,
     "power_source": [
       "dc"
     ],
@@ -90805,7 +90389,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 69.99,
     "power_source": [
       "dc"
     ],
@@ -90971,7 +90554,6 @@
       "VistaCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 99.99,
     "power_source": [
       "dc"
     ],
@@ -91135,7 +90717,6 @@
       "activity zones",
       "no subscription"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://us.store.tapo.com/"
     ],
@@ -91220,7 +90801,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-c660-kit/"
     ],
@@ -91390,7 +90970,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 79.99,
     "power_source": [
       "ac-mains"
     ],
@@ -91478,7 +91057,6 @@
       "RTSP/ONVIF",
       "₹5,000–7,000 popular India outdoor PTZ WiFi"
     ],
-    "msrp_inr": 5499,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -91564,7 +91142,6 @@
       "RTSP/ONVIF",
       "Tapo app / Alexa / Google / HomeKit"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c720/"
     ],
@@ -91726,7 +91303,6 @@
       "privacy shutter",
       "no subscription"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-c840/"
     ],
@@ -91869,7 +91445,6 @@
       "Alexa / Google",
       "no subscription"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-d225/"
     ],
@@ -91954,7 +91529,6 @@
       "no subscription",
       "requires Tapo H200 hub"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-d230s1/"
     ],
@@ -92027,7 +91601,6 @@
       "HomeKit / Alexa / Google",
       "free cloud storage"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://www.tapo.com/en/product/smart-doorbell/tapo-d235/"
     ],
@@ -92276,7 +91849,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "IP44"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-tc82/"
     ],
@@ -94965,7 +94537,6 @@
       "UniFi Protect ecosystem",
       "built-in mic and speaker"
     ],
-    "msrp_usd": 499,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-ai-360"
     ],
@@ -95202,7 +94773,6 @@
       "UniFi Protect ecosystem"
     ],
     "release_year": 2024,
-    "msrp_usd": 999,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-dslr"
     ],
@@ -95286,7 +94856,6 @@
       "two-way audio"
     ],
     "release_year": 2024,
-    "msrp_usd": 499,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro"
     ],
@@ -95371,7 +94940,6 @@
       "two-way audio"
     ],
     "release_year": 2024,
-    "msrp_usd": 499,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro-white"
     ],
@@ -95525,7 +95093,6 @@
       "UniFi Protect ecosystem",
       "infrared LEDs for night vision"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-bullet"
     ],
@@ -95604,7 +95171,6 @@
       "EFL 4 mm lens",
       "infrared night vision"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-flex"
     ],
@@ -95682,7 +95248,6 @@
       "compact form factor",
       "infrared night vision"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-ins"
     ],
@@ -95761,7 +95326,6 @@
       "UniFi Protect ecosystem",
       "infrared night vision"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-pro"
     ],
@@ -95999,7 +95563,6 @@
       "UniFi Protect ecosystem"
     ],
     "release_year": 2022,
-    "msrp_usd": 199,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-doorbell"
     ],
@@ -96319,7 +95882,6 @@
       "UniFi Protect ecosystem",
       "auto-tracking"
     ],
-    "msrp_usd": 1499,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g4-ptz"
     ],
@@ -96635,7 +96197,6 @@
       "UniFi Protect ecosystem",
       "infrared night vision"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g5-flex"
     ],
@@ -96794,7 +96355,6 @@
       "built-in mic"
     ],
     "release_year": 2024,
-    "msrp_usd": 99,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g5-turret"
     ],
@@ -97690,7 +97250,6 @@
       "IK08",
       "competitive MENA value vs Hikvision/Dahua"
     ],
-    "msrp_aed": 599,
     "sources": [
       "https://www.uniview.com/me-en/"
     ],
@@ -98287,7 +97846,6 @@
       "-40°C to +60°C",
       "popular US enterprise/government/K-12 schools"
     ],
-    "msrp_usd": 999,
     "sources": [
       "https://www.verkada.com/security-cameras/outdoor-cameras/"
     ],
@@ -98358,7 +97916,6 @@
       "annual per-camera license pricing model",
       "popular US healthcare/education/enterprise"
     ],
-    "msrp_usd": 849,
     "sources": [
       "https://www.verkada.com/security-cameras/indoor-dome-cameras/"
     ],
@@ -98422,7 +97979,6 @@
       "zero-touch provisioning",
       "IP66"
     ],
-    "msrp_usd": 999,
     "sources": [
       "https://www.verkada.com/"
     ],
@@ -99655,7 +99211,6 @@
       "no subscription required for basic",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 100,
     "sources": [
       "https://www.wyze.com/products/wyze-battery-cam-pro"
     ],
@@ -99724,7 +99279,6 @@
       "no subscription required",
       "Alexa / Google"
     ],
-    "msrp_usd": 149.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-floodlight-pro"
     ],
@@ -99804,7 +99358,6 @@
       "no subscription for basic features",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 24,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-og"
     ],
@@ -99885,7 +99438,6 @@
       "no subscription for basic features",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 32,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-og"
     ],
@@ -99966,7 +99518,6 @@
       "solar optional",
       "Alexa / Google"
     ],
-    "msrp_usd": 59,
     "sources": [
       "https://www.wyze.com/"
     ],
@@ -100038,7 +99589,6 @@
       "no subscription required",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 49.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-outdoor"
     ],
@@ -100112,7 +99662,6 @@
       "no subscription required",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 34,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pan"
     ],
@@ -100183,7 +99732,6 @@
       "24/7 recording (microSD)",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 37.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pan"
     ],
@@ -100264,7 +99812,6 @@
       "continuous recording (microSD)",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 26,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100335,7 +99882,6 @@
       "Alexa / Google Home",
       "RTSP support"
     ],
-    "msrp_usd": 35.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100419,7 +99965,6 @@
       "Alexa / Google Home",
       "RTSP"
     ],
-    "msrp_usd": 59.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pro"
     ],
@@ -100505,7 +100050,6 @@
       "Alexa / Google Home",
       "RTSP support"
     ],
-    "msrp_usd": 35.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100586,7 +100130,6 @@
       "no subscription required for basic",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 60,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-floodlight"
     ],
@@ -100656,7 +100199,6 @@
       "built-in chime",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 49.98,
     "sources": [
       "https://www.wyze.com/products/wyze-doorbell-pro"
     ],
@@ -100724,7 +100266,6 @@
       "built-in chime",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.wyze.com/products/wyze-video-doorbell-v2"
     ],
@@ -100799,7 +100340,6 @@
       "no monthly fees",
       "solar panel optional"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -100868,7 +100408,6 @@
       "Amazon Alexa certified",
       "IP65"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -100992,7 +100531,6 @@
       "activity zones",
       "UK brand trust factor"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101060,7 +100598,6 @@
       "Alexa compatible",
       "activity zones"
     ],
-    "msrp_gbp": 59.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101229,7 +100766,6 @@
       "Yale Home View App",
       "entry-level budget Yale indoor cam"
     ],
-    "msrp_gbp": 49.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101303,7 +100839,6 @@
       "Zebronics Smart app",
       "₹1,500–2,500 ultra-budget India"
     ],
-    "msrp_inr": 1799,
     "sources": [
       "https://www.zebronics.com/"
     ],
@@ -101367,7 +100902,6 @@
       "no subscription",
       "₹2,499"
     ],
-    "msrp_inr": 2499,
     "sources": [
       "https://www.zebronics.com/"
     ],
@@ -101421,7 +100955,6 @@
     "markets": [
       "IN"
     ],
-    "msrp_inr": 3499,
     "power_source": [
       "dc"
     ]
@@ -101475,7 +101008,6 @@
     "markets": [
       "IN"
     ],
-    "msrp_inr": 1499,
     "power_source": [
       "usb"
     ]

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -133,7 +133,6 @@
       "IP66",
       "German brand"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -224,7 +223,6 @@
       "IP66",
       "Austrian consumer favourite Conrad/MediaMarkt"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/at/"
     ],
@@ -387,7 +385,6 @@
       "IP66",
       "German brand"
     ],
-    "msrp_eur": 189.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -479,7 +476,6 @@
       "no mandatory subscription",
       "German brand"
     ],
-    "msrp_eur": 219.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -569,7 +565,6 @@
       "IP65",
       "German brand"
     ],
-    "msrp_eur": 199.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -709,7 +704,6 @@
       "IP67",
       "ONVIF/RTSP"
     ],
-    "msrp_eur": 299.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -875,7 +869,6 @@
       "IK10",
       "German engineering brand"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.abus.com/"
     ],
@@ -972,7 +965,6 @@
       "no mandatory cloud",
       "GDPR compliant"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.abus.com/at/"
     ],
@@ -2403,7 +2395,6 @@
       "IK07",
       "EU professional alarm market"
     ],
-    "msrp_eur": 199,
     "sources": [
       "https://ajax.systems/products/"
     ],
@@ -2473,7 +2464,6 @@
       "professional installer market",
       "IK09 tamper resistant"
     ],
-    "msrp_gbp": 249.99,
     "sources": [
       "https://ajax.systems/products/outdoorcam/"
     ],
@@ -2541,7 +2531,6 @@
       "IP65",
       "no subscription required"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://amcrest.com/products/video-doorbells/ad410"
     ],
@@ -3216,7 +3205,6 @@
       "Amcrest View app",
       "IP67"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3303,7 +3291,6 @@
       "Blue Iris compatible",
       "IP67"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3721,7 +3708,6 @@
       "Blue Iris compatible",
       "built-in mic & speaker"
     ],
-    "msrp_usd": 69.99,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -3890,7 +3876,6 @@
       "IP67",
       "affordable 4K PTZ"
     ],
-    "msrp_usd": 119,
     "sources": [
       "https://amcrest.com/"
     ],
@@ -4520,7 +4505,6 @@
       "IP67",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/ac500"
     ],
@@ -4610,7 +4594,6 @@
       "IP67",
       "IK08"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.annke.com/blogs/press/annke-reveals-next-gen-4k-surveillance-camera-lead-by-the-ac800-featuring-ai-active-deterrence-two-way-talk-and-color-night-vision"
     ],
@@ -4864,7 +4847,6 @@
       "Alexa / Google",
       "no subscription"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://www.annke.com/products/c500"
     ],
@@ -5024,7 +5006,6 @@
       "IK08",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/c800"
     ],
@@ -5185,7 +5166,6 @@
       "IK10",
       "RTSP/ONVIF"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.annke.com/products/c800"
     ],
@@ -5343,7 +5323,6 @@
       "H.265+",
       "IP67"
     ],
-    "msrp_usd": 69.99,
     "sources": [
       "https://www.annke.com/products/c800x"
     ],
@@ -5582,7 +5561,6 @@
       "IP67",
       "ONVIF compatible"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.annke.com/"
     ],
@@ -6257,7 +6235,6 @@
       "Alexa / Google",
       "Matter compatible"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://eu.aqara.com/en-eu/products/camera-hub-g3"
     ],
@@ -6334,7 +6311,6 @@
       "first shown IFA 2024 Berlin",
       "IP65 / -30°C"
     ],
-    "msrp_eur": 139.99,
     "sources": [
       "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro"
     ],
@@ -6412,7 +6388,6 @@
       "available Digitec / Galaxus CH",
       "popular Swiss HomeKit users"
     ],
-    "msrp_chf": 149,
     "sources": [
       "https://eu.aqara.com/en-eu/products/aqara-camera-hub-g5-pro",
       "https://www.digitec.ch/"
@@ -6480,7 +6455,6 @@
       "cry detection alerts",
       "Arlo app"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://us.arlo.com/products/arlo-baby-monitor"
     ],
@@ -6541,7 +6515,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-indoor-camera"
     ],
@@ -6602,7 +6575,6 @@
       "Arlo Secure plan for cloud"
     ],
     "release_year": 2022,
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-indoor.html"
     ],
@@ -6665,7 +6637,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-2nd-gen"
     ],
@@ -6731,7 +6702,6 @@
       "IP65",
       "improved battery life vs Gen 2"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
     ],
@@ -6794,7 +6764,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-spotlight"
     ],
@@ -6857,7 +6826,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-outdoor.html"
     ],
@@ -6921,7 +6889,6 @@
       "IP65",
       "ideal for remote installs"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-xl-v2"
     ],
@@ -6981,7 +6948,6 @@
       "Alexa / Google / HomeKit"
     ],
     "release_year": 2021,
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.arlo.com/cameras/essential/arlo-essential-xl-spotlight.html"
     ],
@@ -7043,7 +7009,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 249,
     "sources": [
       "https://us.arlo.com/"
     ],
@@ -7107,7 +7072,6 @@
       "Arlo Secure for cloud",
       "works anywhere with cellular signal"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.arlo.com/cameras/go/arlo-go-2.html"
     ],
@@ -7169,7 +7133,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-indoor-plug-in"
     ],
@@ -7231,7 +7194,6 @@
       "Arlo Secure plan",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://us.arlo.com/products/arlo-pro-3"
     ],
@@ -7293,7 +7255,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://us.arlo.com/products/arlo-pro-3-floodlight"
     ],
@@ -7356,7 +7317,6 @@
       "Arlo Secure subscription for cloud history"
     ],
     "release_year": 2021,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.arlo.com/asia/cameras/pro/arlo-pro-4.html"
     ],
@@ -7417,7 +7377,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://www.arlo.com/cameras/pro/arlo-pro-4-spotlight-camera.html"
     ],
@@ -7481,7 +7440,6 @@
       "Arlo Secure plan for cloud history"
     ],
     "release_year": 2023,
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.arlo.com/cameras/pro/arlo-pro-5s.html"
     ],
@@ -7546,7 +7504,6 @@
       "IP65",
       "Arlo flagship 2025"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://us.arlo.com/products/arlo-essential-battery-3rd-gen"
     ],
@@ -7613,7 +7570,6 @@
       "IP65 rated AU conditions",
       "JB Hi-Fi / Harvey Norman stocked"
     ],
-    "msrp_aud": 259.99,
     "sources": [
       "https://www.arlo.com/en-au/"
     ],
@@ -7681,7 +7637,6 @@
       "rated -20°C",
       "Best Buy Canada stocked"
     ],
-    "msrp_cad": 219.99,
     "sources": [
       "https://www.arlo.com/en-ca/"
     ],
@@ -7751,7 +7706,6 @@
       "Arlo Secure plan",
       "EU-compliant cloud storage"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://www.arlo.com/de-de/"
     ],
@@ -7818,7 +7772,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan"
     ],
-    "msrp_gbp": 149.99,
     "sources": [
       "https://www.arlo.com/en-gb/"
     ],
@@ -7882,7 +7835,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://us.arlo.com/products/arlo-security-light"
     ],
@@ -7944,7 +7896,6 @@
       "Arlo Secure plan",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://us.arlo.com/products/arlo-solar-panel-cam"
     ],
@@ -8008,7 +7959,6 @@
       "Arlo Secure plan",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 299.99,
     "sources": [
       "https://us.arlo.com/products/arlo-ultra"
     ],
@@ -8071,7 +8021,6 @@
       "Arlo Secure plan",
       "IP65"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://www.arlo.com/cameras/ultra/arlo-ultra-2-spotlight-camera.html"
     ],
@@ -8134,7 +8083,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://www.arlo.com/cameras/doorbells/"
     ],
@@ -8198,7 +8146,6 @@
       "Arlo Secure plan",
       "IP55"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://us.arlo.com/products/arlo-doorbell-wired-2nd-gen"
     ],
@@ -8261,7 +8208,6 @@
       "Apple HomeKit / Google / Alexa",
       "Arlo Secure plan for cloud storage"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.arlo.com/"
     ],
@@ -15557,7 +15503,6 @@
       "Blink Sync Module required",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15618,7 +15563,6 @@
       "Blink Sync Module for local USB storage",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 34.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15680,7 +15624,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud storage"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15794,7 +15737,6 @@
       "IP54",
       "Alexa / Fire TV"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15856,7 +15798,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15918,7 +15859,6 @@
       "Blink Subscription for cloud",
       "IP54"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -15982,7 +15922,6 @@
       "Alexa / Fire TV",
       "Sync Module for local MicroSD storage"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16046,7 +15985,6 @@
       "Blink Sync Module required",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16111,7 +16049,6 @@
       "Blink Sync Module required for local storage",
       "Blink Subscription Plan for cloud"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16180,7 +16117,6 @@
       "Blink Subscription for cloud",
       "popular budget EU Amazon camera"
     ],
-    "msrp_eur": 54.99,
     "sources": [
       "https://blinkforhome.com/de-de/"
     ],
@@ -16243,7 +16179,6 @@
       "wire-free installation",
       "Blink Sync Module XR for extended range"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16307,7 +16242,6 @@
       "Blink Sync Module for local USB storage",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 119.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16370,7 +16304,6 @@
       "Blink Subscription for cloud video history",
       "local storage via Sync Module"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16433,7 +16366,6 @@
       "Alexa / Fire TV",
       "Blink Subscription for cloud"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -16496,7 +16428,6 @@
       "Blink Sync Module required",
       "free cloud storage included at launch"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://blinkforhome.com/products"
     ],
@@ -18290,7 +18221,6 @@
       "GDPR-compliant German cloud (for EU)",
       "anthracite or white"
     ],
-    "msrp_gbp": 199.99,
     "sources": [
       "https://www.bosch-smarthome.com/uk/en/products/cameras/"
     ],
@@ -18362,7 +18292,6 @@
       "Digitec / Galaxus CH stocked",
       "very popular CH/AT premium smart home brand"
     ],
-    "msrp_chf": 229,
     "sources": [
       "https://www.bosch-smarthome.com/ch/de/"
     ],
@@ -20023,7 +19952,6 @@
       "CP Plus app",
       "₹3,500–4,500 price range"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20335,7 +20263,6 @@
       "₹3,000–5,000 price range",
       "STQC model available"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.cpplusworld.com/cp-unc-da21pl3"
     ],
@@ -20426,7 +20353,6 @@
       "IP67",
       "Made in India"
     ],
-    "msrp_inr": 6999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20661,7 +20587,6 @@
       "NVR compatible",
       "₹4,000–5,000"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -20751,7 +20676,6 @@
       "most popular India outdoor bullet",
       "₹3,500–5,500 price range"
     ],
-    "msrp_inr": 4499,
     "sources": [
       "https://www.cpplusworld.com/cp-unc-ta21pl3"
     ],
@@ -20841,7 +20765,6 @@
       "IP67",
       "Made in India"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -21076,7 +20999,6 @@
       "IP66",
       "₹5,000–7,000"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.cpplusworld.com/"
     ],
@@ -23256,7 +23178,6 @@
       "IK10",
       "budget 4K"
     ],
-    "msrp_usd": 44.99,
     "sources": [
       "https://www.dahuasecurity.com"
     ],
@@ -23508,7 +23429,6 @@
       "very popular Indian system integrators",
       "₹8,000–12,000"
     ],
-    "msrp_inr": 9999,
     "sources": [
       "https://www.dahuasecurity.com/"
     ],
@@ -24083,7 +24003,6 @@
       "IK10",
       "very popular EU CCTV installer choice"
     ],
-    "msrp_eur": 139.99,
     "sources": [
       "https://www.dahuasecurity.com/eu/"
     ],
@@ -24176,7 +24095,6 @@
       "IK10",
       "very popular UAE/KSA commercial installers"
     ],
-    "msrp_aed": 650,
     "sources": [
       "https://www.dahuasecurity.com/mena/"
     ],
@@ -25758,7 +25676,6 @@
       "IK10",
       "high value"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.dahuasecurity.com"
     ],
@@ -26395,7 +26312,6 @@
       "≈498 AED on Amazon.ae",
       "popular UAE budget 4K outdoor bullet"
     ],
-    "msrp_aed": 498,
     "sources": [
       "https://www.amazon.ae/IPC-HFW2849S-S-Network-WizSense-Full-Color-Security/dp/B0FL7XWMHM",
       "https://www.dahuasecurity.com/mena/"
@@ -26559,7 +26475,6 @@
       "popular Vietnam business + residential installers",
       "Dahua local distributors Hanoi / HCMC"
     ],
-    "msrp_vnd": 1500000,
     "sources": [
       "https://www.dahuasecurity.com/vn-vi/"
     ],
@@ -29197,7 +29112,6 @@
       "IP66",
       "widely used hotels/malls UAE & Saudi Arabia"
     ],
-    "msrp_aed": 1899,
     "sources": [
       "https://shop.acssllc.ae/product-category/dahua-camera/",
       "https://www.dahuasecurity.com/mena/"
@@ -29608,7 +29522,6 @@
       "no subscription",
       "Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/"
     ],
@@ -29672,7 +29585,6 @@
       "HomeBase local storage",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 219.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-2-pro"
     ],
@@ -29751,7 +29663,6 @@
       "HomeBase local storage",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 139.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-2c"
     ],
@@ -29814,7 +29725,6 @@
       "HomeBase local 16GB storage",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 249.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-3-pro"
     ],
@@ -29879,7 +29789,6 @@
       "IP67",
       "more affordable EufyCam 3 entry variant"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.eufy.com/products/eufycam-3c"
     ],
@@ -29942,7 +29851,6 @@
       "no subscription required",
       "Apple HomeKit / Alexa / Google"
     ],
-    "msrp_usd": 279.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-e330-pro"
     ],
@@ -30006,7 +29914,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 179,
     "sources": [
       "https://www.eufy.com/products/eufycam-s330-pro"
     ],
@@ -30069,7 +29976,6 @@
       "Alexa / Google"
     ],
     "release_year": 2022,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-2-pro"
     ],
@@ -30136,7 +30042,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-e220"
     ],
@@ -30198,7 +30103,6 @@
       "HomeKit / Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 249,
     "sources": [
       "https://www.eufy.com/products/floodlight-cam-e340"
     ],
@@ -30270,7 +30174,6 @@
       "IP67",
       "top-rated EU floodlight cam"
     ],
-    "msrp_eur": 249.99,
     "sources": [
       "https://www.eufy.com/de-de/"
     ],
@@ -30331,7 +30234,6 @@
       "real-time door status alerts",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/garage-cam-s330"
     ],
@@ -30398,7 +30300,6 @@
       "RTSP support",
       "€35–45 best-value Eufy indoor"
     ],
-    "msrp_usd": 35,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-2k-pan-tilt"
     ],
@@ -30481,7 +30382,6 @@
       "RTSP support",
       "Alexa / Google HomeKit"
     ],
-    "msrp_usd": 29.99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-c120"
     ],
@@ -30562,7 +30462,6 @@
       "HomeKit / Alexa / Google",
       "RTSP support"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-e220"
     ],
@@ -30640,7 +30539,6 @@
       "microSD card slot",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 29.99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-mini"
     ],
@@ -30703,7 +30601,6 @@
       "HomeKit / Alexa / Google",
       "RTSP support"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://www.eufy.com/products/indoor-cam-s350"
     ],
@@ -30783,7 +30680,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.eufy.com/products/outdoor-cam-e210"
     ],
@@ -30843,7 +30739,6 @@
       "Alexa / Google"
     ],
     "release_year": 2023,
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s220"
     ],
@@ -30902,7 +30797,6 @@
       "Alexa / Google integration"
     ],
     "release_year": 2023,
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.eufy.com/products/eufycam-3c"
     ],
@@ -30965,7 +30859,6 @@
       "Alexa / Google",
       "IP67"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.eufy.com/products/solocam-c210"
     ],
@@ -31026,7 +30919,6 @@
     ],
     "operating_temp_c": "-20 to 50",
     "release_year": 2022,
-    "msrp_usd": 119.99,
     "sources": [
       "https://support.eufy.com/s/article/eufy-SoloCam-E40-FAQ",
       "https://service.eufy.com/article-description/Introducing-eufy-SoloCam-E40"
@@ -31089,7 +30981,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 39.99,
     "sources": [
       "https://www.eufy.com/products/solocam-l20"
     ],
@@ -31152,7 +31043,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://www.eufy.com/products/solocam-l40"
     ],
@@ -31218,7 +31108,6 @@
       "Alexa / Google HomeKit",
       "popular UK Amazon choice"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.eufy.com/en-gb/"
     ],
@@ -31282,7 +31171,6 @@
       "IP67 weatherproof",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 119.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s230"
     ],
@@ -31345,7 +31233,6 @@
       "local HomeBase storage",
       "Alexa / Google"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/products/solocam-s340"
     ],
@@ -31412,7 +31299,6 @@
       "IP67",
       "JB Hi-Fi / The Good Guys AU stocked"
     ],
-    "msrp_aud": 329.99,
     "sources": [
       "https://www.eufy.com/au-en/"
     ],
@@ -31481,7 +31367,6 @@
       "rated -20°C",
       "Best Buy Canada top pick"
     ],
-    "msrp_cad": 269.99,
     "sources": [
       "https://www.eufy.com/ca-en/"
     ],
@@ -31550,7 +31435,6 @@
       "IP67",
       "Digitec / Galaxus CH top pick no-fee camera"
     ],
-    "msrp_chf": 219,
     "sources": [
       "https://www.eufy.com/ch-de/",
       "https://www.digitec.ch/"
@@ -31621,7 +31505,6 @@
       "IP67",
       "popular EU Amazon #1 no-fee camera"
     ],
-    "msrp_eur": 199.99,
     "sources": [
       "https://www.eufy.com/de-de/"
     ],
@@ -31681,7 +31564,6 @@
       "Alexa and Google Assistant integration"
     ],
     "release_year": 2022,
-    "msrp_usd": 129.99,
     "sources": [
       "https://www.eufy.com/products/t8124"
     ],
@@ -31741,7 +31623,6 @@
       "HomeBase 2 compatible (optional)"
     ],
     "release_year": 2022,
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.eufy.com/video-doorbells"
     ],
@@ -31820,7 +31701,6 @@
       "two-way audio",
       "IP65"
     ],
-    "msrp_usd": 159,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-e340"
     ],
@@ -31896,7 +31776,6 @@
       "no subscription required",
       "Alexa / Google Assistant"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-s220"
     ],
@@ -31962,7 +31841,6 @@
       "two-way audio",
       "IP65"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.eufy.com/products/video-doorbell-s330"
     ],
@@ -32043,7 +31921,6 @@
       "EZVIZ app / Alexa / Google",
       "IP66"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.ezviz.com/product/ezviz-elife/"
     ],
@@ -32111,7 +31988,6 @@
       "pet/baby monitoring",
       "very compact €30 price"
     ],
-    "msrp_eur": 29,
     "sources": [
       "https://www.ezviz.com/product/c1c/"
     ],
@@ -32199,7 +32075,6 @@
       "Alexa / Google",
       "EZVIZ app"
     ],
-    "msrp_eur": 59,
     "sources": [
       "https://www.ezviz.com/product/c3w-pro/"
     ],
@@ -32284,7 +32159,6 @@
       "RTSP/ONVIF",
       "IP67"
     ],
-    "msrp_eur": 79,
     "sources": [
       "https://www.ezviz.com/product/c3x/"
     ],
@@ -32373,7 +32247,6 @@
       "RTSP/ONVIF",
       "night vision"
     ],
-    "msrp_gbp": 29.99,
     "sources": [
       "https://www.ezviz.com/product/c6n/"
     ],
@@ -32553,7 +32426,6 @@
       "≈99 AED ultra-budget",
       "#1 budget indoor cam Amazon.ae Noon"
     ],
-    "msrp_aed": 99,
     "sources": [
       "https://www.ezviz.com/me-en/",
       "https://www.amazon.ae/"
@@ -32643,7 +32515,6 @@
       "#1 budget indoor WiFi cam Lazada/Shopee/Tiki Vietnam",
       "≈400,000–600,000 VND price point"
     ],
-    "msrp_vnd": 499000,
     "sources": [
       "https://www.ezviz.com/vn-vi/"
     ],
@@ -32734,7 +32605,6 @@
       "RTSP/ONVIF",
       "Alexa / Google"
     ],
-    "msrp_gbp": 49.99,
     "sources": [
       "https://www.ezviz.com/product/c8c/"
     ],
@@ -32822,7 +32692,6 @@
       "H.265",
       "RTSP/ONVIF"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.ezviz.com/product/c8pf/"
     ],
@@ -32917,7 +32786,6 @@
       "Alexa / Google",
       "popular EU Amazon budget PTZ"
     ],
-    "msrp_eur": 69.99,
     "sources": [
       "https://www.ezviz.com/de-de/"
     ],
@@ -33003,7 +32871,6 @@
       "IP65",
       "H.265"
     ],
-    "msrp_eur": 79,
     "sources": [
       "https://www.ezviz.com/product/db2/"
     ],
@@ -33076,7 +32943,6 @@
       "IP65",
       "budget entry doorbell"
     ],
-    "msrp_eur": 59,
     "sources": [
       "https://www.ezviz.com/product/db2c/"
     ],
@@ -33149,7 +33015,6 @@
       "privacy shield cover",
       "H.265"
     ],
-    "msrp_eur": 39,
     "sources": [
       "https://www.ezviz.com/product/h3c/"
     ],
@@ -33241,7 +33106,6 @@
       "H.265",
       "Alexa / Google"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.ezviz.com/product/h8+pro+3k/"
     ],
@@ -33333,7 +33197,6 @@
       "Alexa/Google",
       "popular budget choice Amazon.ae / Noon UAE"
     ],
-    "msrp_aed": 299,
     "sources": [
       "https://www.ezviz.com/me-en/",
       "https://www.amazon.ae/"
@@ -33425,7 +33288,6 @@
       "RTSP/ONVIF",
       "Alexa / Google"
     ],
-    "msrp_gbp": 59.99,
     "sources": [
       "https://www.ezviz.com/product/h8c/"
     ],
@@ -33608,7 +33470,6 @@
       "RTSP/ONVIF",
       "H.265"
     ],
-    "msrp_gbp": 64.99,
     "sources": [
       "https://www.ezviz.com/product/h8c+pro+2k/"
     ],
@@ -33699,7 +33560,6 @@
       "RTSP/ONVIF",
       "H.265"
     ],
-    "msrp_gbp": 89.99,
     "sources": [
       "https://www.ezviz.com/product/h8c+pro+4k/"
     ],
@@ -33790,7 +33650,6 @@
       "popular outdoor WiFi Shopee/Lazada Vietnam",
       "≈900,000–1,200,000 VND"
     ],
-    "msrp_vnd": 999000,
     "sources": [
       "https://www.ezviz.com/vn-vi/"
     ],
@@ -35964,7 +35823,6 @@
       "no subscription",
       "₹4,500"
     ],
-    "msrp_inr": 4500,
     "sources": [
       "https://pricee.com/godrej-eve-cube-cctv-security-camera-price-in-india-90722"
     ],
@@ -36032,7 +35890,6 @@
       "no subscription",
       "₹5,500"
     ],
-    "msrp_inr": 5524,
     "sources": [
       "https://pricee.com/godrej-eve-mini-cctv-security-camera-price-in-india-90724"
     ],
@@ -36103,7 +35960,6 @@
       "no subscription required",
       "₹3,000–5,000"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.amazon.in/Godrej-Eve-Nx-PT-Security/dp/B0886XDDDF"
     ],
@@ -36167,7 +36023,6 @@
       "no subscription",
       "₹5,999"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.amazon.in/"
     ],
@@ -36229,7 +36084,6 @@
       "Nest Aware subscription for extended history",
       "Google Home app required"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_cam_battery"
     ],
@@ -36351,7 +36205,6 @@
     "dimensions_mm": "83 × 83 × 83",
     "weight_g": 398,
     "release_year": 2021,
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_cam_battery_specs"
     ],
@@ -36465,7 +36318,6 @@
       "magnetic base",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://store.google.com/product/nest_cam_indoor"
     ],
@@ -36530,7 +36382,6 @@
       "encrypted video",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -36592,7 +36443,6 @@
       "activity zones",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://store.google.com/product/nest_cam_iq"
     ],
@@ -36655,7 +36505,6 @@
       "IP66 weatherproof",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 349,
     "sources": [
       "https://store.google.com/product/nest_cam_iq_outdoor"
     ],
@@ -36718,7 +36567,6 @@
       "magnetic mount",
       "Nest app / Google Home"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://store.google.com/product/nest_cam_outdoor"
     ],
@@ -36783,7 +36631,6 @@
       "encrypted video",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -36853,7 +36700,6 @@
       "Alexa / Google Home",
       "EU GDPR-compliant (Google Cloud EU)"
     ],
-    "msrp_eur": 149.99,
     "sources": [
       "https://store.google.com/de/product/nest_cam_outdoor_specs"
     ],
@@ -37016,7 +36862,6 @@
       "Alexa"
     ],
     "release_year": 2021,
-    "msrp_usd": 99.99,
     "sources": [
       "https://store.google.com/product/nest_cam_specs"
     ],
@@ -37078,7 +36923,6 @@
       "Alexa / Google Home",
       "color night vision"
     ],
-    "msrp_usd": 279.99,
     "sources": [
       "https://store.google.com/product/nest_cam_floodlight_specs"
     ],
@@ -37144,7 +36988,6 @@
       "compatible with Gen 2 backplate",
       "Google Home Premium for Gemini"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://9to5google.com/2025/10/01/google-nest-camera-refresh-2025-2k-resolution/"
     ],
@@ -37257,7 +37100,6 @@
       "Alexa / Google Home",
       "DXOMARK best doorbell image quality at launch"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://store.google.com/product/nest_doorbell_wired_2nd_gen_specs"
     ],
@@ -37320,7 +37162,6 @@
       "dual-band WiFi",
       "Alexa / Google Home"
     ],
-    "msrp_gbp": 179.99,
     "sources": [
       "https://store.google.com/gb/product/nest_doorbell_wired_2nd_gen_specs"
     ],
@@ -44289,7 +44130,6 @@
       "sold via Prama Hikvision India",
       "₹5,000–8,000"
     ],
-    "msrp_inr": 6999,
     "sources": [
       "https://www.hikvision.com/in-en/"
     ],
@@ -45310,7 +45150,6 @@
       "SIRA-approved",
       "popular Dubai commercial & warehouse sites"
     ],
-    "msrp_aed": 699,
     "sources": [
       "https://hikvision-uae.ae/product/ds-2cd2047g2-lu-sl/",
       "https://www.hikvision.com/mena-en/"
@@ -46800,7 +46639,6 @@
       "popular Vietnam residential + commercial dome camera",
       "Hikvision local Vietnam distributor network"
     ],
-    "msrp_vnd": 1200000,
     "sources": [
       "https://www.hikvision.com/vn-vi/"
     ],
@@ -47151,7 +46989,6 @@
       "IK10",
       "most popular EU professional installer 4MP dome"
     ],
-    "msrp_eur": 109.99,
     "sources": [
       "https://www.hikvision.com/de-de/"
     ],
@@ -49160,7 +48997,6 @@
       "most popular AU installer IP camera (Precision Security / Hypower Security)",
       "available AU security wholesalers"
     ],
-    "msrp_aud": 219.99,
     "sources": [
       "https://www.hikvision.com/au-en/"
     ],
@@ -49255,7 +49091,6 @@
       "≈815 AED price point",
       "popular Dubai villas & retail"
     ],
-    "msrp_aed": 815,
     "sources": [
       "https://hikvision-uae.ae/product/hikvision-ds-2cd2387g2-lu/",
       "https://www.hikvision.com/mena-en/"
@@ -52047,7 +51882,6 @@
       "popular CH/AT installer market",
       "available Swiss security distributors"
     ],
-    "msrp_chf": 179,
     "sources": [
       "https://www.hikvision.com/ch-de/"
     ],
@@ -52141,7 +51975,6 @@
       "≈620 AED",
       "most popular outdoor bullet UAE/KSA installer market"
     ],
-    "msrp_aed": 620,
     "sources": [
       "https://hikvisioncameradubai.com/product/hikvision-ds-2cd2t47g2-l/",
       "https://www.hikvision.com/mena-en/"
@@ -52319,7 +52152,6 @@
       "most popular outdoor PoE camera Vietnam installers",
       "available at Điện máy Xanh / Thế Giới Di Động / Bach Khoa"
     ],
-    "msrp_vnd": 1800000,
     "sources": [
       "https://www.hikvision.com/vn-vi/"
     ],
@@ -55248,7 +55080,6 @@
       "very popular commercial India PTZ",
       "₹25,000–35,000"
     ],
-    "msrp_inr": 28999,
     "sources": [
       "https://www.hikvision.com/in-en/"
     ],
@@ -55342,7 +55173,6 @@
       "standard PTZ for malls/hotels/airports UAE & Saudi",
       "≈2,200 AED"
     ],
-    "msrp_aed": 2200,
     "sources": [
       "https://www.hikvision.com/mena-en/"
     ],
@@ -55428,7 +55258,6 @@
       "auto-tracking",
       "most affordable Hikvision PoE mini PTZ"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://www.hikvision.com/en/products/"
     ],
@@ -56163,7 +55992,6 @@
       "most affordable Hikvision-ecosystem bullet",
       "UK/EU installer favourite"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56252,7 +56080,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook upgrade"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56338,7 +56165,6 @@
       "IP67",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 52,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56425,7 +56251,6 @@
       "Hikvision NVR compatible",
       "best-value 4K bullet entry-level"
     ],
-    "msrp_usd": 59,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56514,7 +56339,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook"
     ],
-    "msrp_usd": 69,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56602,7 +56426,6 @@
       "Hikvision NVR compatible",
       "mid-range HiLook varifocal"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56688,7 +56511,6 @@
       "IP67",
       "most affordable HiLook WiFi outdoor cam"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56772,7 +56594,6 @@
       "H.265+",
       "IP67"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56859,7 +56680,6 @@
       "Hikvision NVR compatible",
       "budget UK/EU installer dome"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -56946,7 +56766,6 @@
       "IP67",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57033,7 +56852,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57120,7 +56938,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57208,7 +57025,6 @@
       "Hikvision NVR compatible",
       "most popular UK budget turret"
     ],
-    "msrp_usd": 47,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57294,7 +57110,6 @@
       "IP67",
       "formerly UK bestselling HiLook model"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57381,7 +57196,6 @@
       "IK10",
       "Hikvision NVR compatible"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57469,7 +57283,6 @@
       "Hikvision NVR compatible",
       "4K upgrade HiLook turret"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57559,7 +57372,6 @@
       "Hikvision NVR compatible",
       "best-value 4K turret with hybrid light"
     ],
-    "msrp_usd": 75,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57647,7 +57459,6 @@
       "Hikvision NVR compatible",
       "most affordable HiLook PTZ"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57731,7 +57542,6 @@
       "IP66",
       "budget analog upgrade path for legacy coax systems"
     ],
-    "msrp_usd": 35,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57794,7 +57604,6 @@
       "IK10",
       "most affordable HiLook camera for coax upgrades"
     ],
-    "msrp_usd": 33,
     "sources": [
       "https://www.hikvision.com/en/products/HiLook-IP-Products/"
     ],
@@ -57851,7 +57660,6 @@
     "markets": [
       "UK"
     ],
-    "msrp_gbp": 119,
     "power_source": [
       "usb"
     ]
@@ -57914,7 +57722,6 @@
       "designed by Yves Béhar",
       "UK market leader in smart home"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -57970,7 +57777,6 @@
     "markets": [
       "UK"
     ],
-    "msrp_gbp": 99,
     "power_source": [
       "usb"
     ]
@@ -58034,7 +57840,6 @@
       "UK British Gas brand recognition",
       "30-day cloud storage subscription"
     ],
-    "msrp_gbp": 119.99,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -58096,7 +57901,6 @@
       "30-day cloud subscription",
       "IP65"
     ],
-    "msrp_gbp": 149,
     "sources": [
       "https://www.hivehome.com/"
     ],
@@ -58166,7 +57970,6 @@
       "preferred enterprise/government India",
       "₹8,000–15,000"
     ],
-    "msrp_inr": 10999,
     "sources": [
       "https://www.honeywell.com/en-us/company/india"
     ],
@@ -58255,7 +58058,6 @@
       "preferred enterprise/government India",
       "₹10,000–16,000"
     ],
-    "msrp_inr": 13999,
     "sources": [
       "https://www.honeywell.com/en-us/company/india"
     ],
@@ -58417,7 +58219,6 @@
       "Alexa / Google",
       "two-way audio"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.honeywellhome.com/"
     ],
@@ -59107,7 +58908,6 @@
       "Alexa",
       "₹5,000–7,000 popular India outdoor"
     ],
-    "msrp_inr": 5999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59251,7 +59051,6 @@
       "Alexa",
       "₹7,000–9,000 best outdoor India PTZ"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59345,7 +59144,6 @@
       "≈399 AED",
       "value outdoor PTZ"
     ],
-    "msrp_aed": 399,
     "sources": [
       "https://www.imoulife.com/me-en/",
       "https://www.amazon.ae/"
@@ -59717,7 +59515,6 @@
       "Alexa / Google",
       "₹2,500–4,000 best-value India indoor camera"
     ],
-    "msrp_inr": 2999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59807,7 +59604,6 @@
       "≈350,000–500,000 VND",
       "top-selling Shopee Vietnam indoor camera 2024"
     ],
-    "msrp_vnd": 399000,
     "sources": [
       "https://www.imoulife.com/vn-vi/"
     ],
@@ -59899,7 +59695,6 @@
       "Alexa",
       "₹3,500–5,000"
     ],
-    "msrp_inr": 3999,
     "sources": [
       "https://www.imoulife.com/"
     ],
@@ -59990,7 +59785,6 @@
       "Alexa",
       "≈199 AED budget indoor cam Noon/Amazon.ae"
     ],
-    "msrp_aed": 199,
     "sources": [
       "https://www.imoulife.com/me-en/"
     ],
@@ -60832,7 +60626,6 @@
       "popular Vietnam small business / apartment buildings",
       "≈450,000–700,000 VND"
     ],
-    "msrp_vnd": 550000,
     "sources": [
       "https://kbvisionvietnam.com/"
     ],
@@ -60925,7 +60718,6 @@
       "available Bach Khoa / ITC Telecom Vietnam",
       "≈900,000–1,300,000 VND"
     ],
-    "msrp_vnd": 1100000,
     "sources": [
       "https://kbvisionvietnam.com/"
     ],
@@ -62135,7 +61927,6 @@
       "two-way audio",
       "cloud storage"
     ],
-    "msrp_usd": 45,
     "sources": [
       "https://www.laviewusa.com/products/laview-security-cameras-4pc"
     ],
@@ -62182,7 +61973,6 @@
       "color + IR night vision",
       "two-way audio"
     ],
-    "msrp_usd": 18,
     "sources": [
       "https://www.laviewusa.com/products/l2-light-bulb-camera-4g"
     ],
@@ -62238,7 +62028,6 @@
       "50-day battery / 365-day with solar",
       "no subscription required for local storage"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.laviewusa.com/products/n3-outdoor-camera"
     ],
@@ -62286,7 +62075,6 @@
       "solar compatible",
       "motion detection"
     ],
-    "msrp_usd": 70,
     "sources": [
       "https://www.laviewusa.com/products/copy-of-r12b-outdoor-camera-1"
     ],
@@ -62333,7 +62121,6 @@
       "color night vision",
       "real-time alerts"
     ],
-    "msrp_usd": 130,
     "sources": [
       "https://www.laviewusa.com/products/r18-outdoor-360-camera-copy"
     ],
@@ -62386,7 +62173,6 @@
       "Alexa/Google compatible",
       "no subscription required for local storage"
     ],
-    "msrp_usd": 80,
     "sources": [
       "https://www.laviewusa.com/products/r28-wireless-outdoor-camera"
     ],
@@ -62586,7 +62372,6 @@
       "Alexa",
       "rated -40°C Canadian winters"
     ],
-    "msrp_cad": 149.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -62904,7 +62689,6 @@
       "NVR compatible",
       "no monthly fees"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.lorex.com/products/e893ab-4k-ip-wired-bullet-smart-deterrence"
     ],
@@ -63135,7 +62919,6 @@
       "ONVIF/RTSP",
       "Costco Canada bestseller"
     ],
-    "msrp_cad": 199.99,
     "sources": [
       "https://www.lorex.ca/products/4k-8mp-nocturnal-motorized-varifocal-smart-ip-bullet-security-camera"
     ],
@@ -63308,7 +63091,6 @@
       "no subscription",
       "popular Canada home security bundle"
     ],
-    "msrp_cad": 189.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63471,7 +63253,6 @@
       "H.265",
       "basic affordable IP camera"
     ],
-    "msrp_usd": 60,
     "sources": [
       "https://www.lorex.com/products/2k-ip-turret-camera"
     ],
@@ -63555,7 +63336,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.lorex.com/blogs/products/u471aa-series"
     ],
@@ -63622,7 +63402,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://www.lorex.com/products/2k-floodlight-camera"
     ],
@@ -63749,7 +63528,6 @@
       "Alexa / Google",
       "no monthly fees"
     ],
-    "msrp_cad": 79,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63818,7 +63596,6 @@
       "Lorex Home app",
       "Alexa / Google"
     ],
-    "msrp_cad": 139.99,
     "sources": [
       "https://www.lorex.ca/"
     ],
@@ -63938,7 +63715,6 @@
       "no monthly fees",
       "Alexa / Google"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.lorex.com/products/w891uad-e-4k-dual-lens-wi-fi-camera"
     ],
@@ -64577,7 +64353,6 @@
       "German support Conrad/Lupus-Electronics.de",
       "€80–120"
     ],
-    "msrp_eur": 99,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64671,7 +64446,6 @@
       "German brand",
       "€80–120"
     ],
-    "msrp_eur": 109,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64764,7 +64538,6 @@
       "entry-level LUPUS PoE camera",
       "€80–100"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64858,7 +64631,6 @@
       "German brand",
       "€120–150"
     ],
-    "msrp_eur": 139,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -64950,7 +64722,6 @@
       "baby / pet monitoring",
       "€50–80"
     ],
-    "msrp_eur": 69,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65045,7 +64816,6 @@
       "entry PoE dome",
       "€80–100"
     ],
-    "msrp_eur": 89,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65141,7 +64911,6 @@
       "DSGVO-compliant no cloud",
       "€150–200"
     ],
-    "msrp_eur": 169,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65235,7 +65004,6 @@
       "DSGVO local-first",
       "€100–130"
     ],
-    "msrp_eur": 119,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65419,7 +65187,6 @@
       "DSGVO local",
       "€130–160"
     ],
-    "msrp_eur": 149,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65514,7 +65281,6 @@
       "DSGVO local-first",
       "€160–200"
     ],
-    "msrp_eur": 179,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65609,7 +65375,6 @@
       "flagship LUPUS outdoor PoE",
       "€300–350"
     ],
-    "msrp_eur": 329,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65705,7 +65470,6 @@
       "DSGVO local-first",
       "€200–250"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65800,7 +65564,6 @@
       "DSGVO local",
       "€150–200"
     ],
-    "msrp_eur": 179,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65894,7 +65657,6 @@
       "DSGVO local-first",
       "€150–180"
     ],
-    "msrp_eur": 169,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -65990,7 +65752,6 @@
       "new 2024 DE model",
       "€200–250"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66086,7 +65847,6 @@
       "DSGVO local-first",
       "€250–300"
     ],
-    "msrp_eur": 279,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66181,7 +65941,6 @@
       "DSGVO local storage",
       "€400–500 price range"
     ],
-    "msrp_eur": 449,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66276,7 +66035,6 @@
       "flagship LUPUS PTZ",
       "€500–600"
     ],
-    "msrp_eur": 549,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -66371,7 +66129,6 @@
       "DSGVO local",
       "€350–450"
     ],
-    "msrp_eur": 399,
     "sources": [
       "https://www.lupus-electronics.de/"
     ],
@@ -68755,7 +68512,6 @@
       "100% local data",
       "French brand privacy focus"
     ],
-    "msrp_gbp": 179.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -68824,7 +68580,6 @@
       "two-way audio",
       "very popular privacy-conscious AT/CH buyers"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://www.netatmo.com/at-de/"
     ],
@@ -68897,7 +68652,6 @@
       "100% local data processing",
       "French brand privacy focus"
     ],
-    "msrp_gbp": 199.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -68972,7 +68726,6 @@
       "GDPR-compliant (French company, EU data)",
       "IP66"
     ],
-    "msrp_eur": 229.99,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -69042,7 +68795,6 @@
       "GDPR EU data",
       "IP66"
     ],
-    "msrp_eur": 229,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -69114,7 +68866,6 @@
       "165° wide FOV",
       "GDPR-compliant EU data"
     ],
-    "msrp_eur": 149,
     "sources": [
       "https://www.netatmo.com/"
     ],
@@ -70331,7 +70082,6 @@
       "Alexa",
       "Made in India Hero Group"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70393,7 +70143,6 @@
       "Made in India Hero Group",
       "₹4,999"
     ],
-    "msrp_inr": 4999,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70466,7 +70215,6 @@
       "Alexa compatible",
       "₹3,990–5,200"
     ],
-    "msrp_inr": 3990,
     "sources": [
       "https://www.quboworld.com/products/smart-cam-360-3mp"
     ],
@@ -70537,7 +70285,6 @@
       "Alexa",
       "Made in India"
     ],
-    "msrp_inr": 5499,
     "sources": [
       "https://www.quboworld.com/"
     ],
@@ -70593,7 +70340,6 @@
     "sources": [
       "https://reolink.com/product/altas-pt-ultra/"
     ],
-    "msrp_usd": 159,
     "aliases": [
       "B660"
     ],
@@ -70649,7 +70395,6 @@
     "sources": [
       "https://reolink.com/product/argus-2/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "battery",
       "solar"
@@ -70703,7 +70448,6 @@
     "sources": [
       "https://reolink.com/product/argus-2e/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "battery",
       "solar"
@@ -70757,7 +70501,6 @@
     "sources": [
       "https://reolink.com/product/argus-3/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "battery",
       "solar"
@@ -70933,7 +70676,6 @@
       "outlasted Arlo Pro 5 in AU long-term battery tests",
       "AU$99–129"
     ],
-    "msrp_aud": 129.99,
     "sources": [
       "https://reolink.com/au/",
       "https://www.safewise.com/au/best-wireless-security-cameras/"
@@ -71186,7 +70928,6 @@
       "Alexa / Google",
       "available Amazon.at / Conrad AT"
     ],
-    "msrp_eur": 149.99,
     "sources": [
       "https://reolink.com/at/",
       "https://www.amazon.at/"
@@ -71264,7 +71005,6 @@
     "sources": [
       "https://reolink.com/product/argus-5-pro/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "battery",
       "solar"
@@ -71399,7 +71139,6 @@
     "sources": [
       "https://reolink.com/product/argus-eco/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "battery",
       "solar"
@@ -71450,7 +71189,6 @@
       "solar compatible",
       "no subscription"
     ],
-    "msrp_usd": 97,
     "sources": [
       "https://reolink.com/product/argus-eco-ultra/"
     ],
@@ -71515,7 +71253,6 @@
       "Power-Efficient Series"
     ],
     "release_notes": "Launched June 2026 alongside OMVI Series.",
-    "msrp_usd": 49.99,
     "sources": [
       "https://securityjournaluk.com/reolink-launches-new-cameras/"
     ],
@@ -71588,7 +71325,6 @@
     "sources": [
       "https://reolink.com/product/argus-pro/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery"
     ]
@@ -71640,7 +71376,6 @@
     "sources": [
       "https://reolink.com/product/argus-pt/"
     ],
-    "msrp_usd": 59,
     "power_source": [
       "battery",
       "solar"
@@ -71693,7 +71428,6 @@
     "sources": [
       "https://reolink.com/product/argus-pt-2k/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "battery",
       "solar"
@@ -71757,7 +71491,6 @@
       "solar optional",
       "IP66"
     ],
-    "msrp_usd": 139,
     "sources": [
       "https://reolink.com/product/argus-pt-ultra/"
     ],
@@ -71914,7 +71647,6 @@
     "sources": [
       "https://reolink.com/product/b1200/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe"
     ],
@@ -71984,7 +71716,6 @@
     "sources": [
       "https://reolink.com/product/b400/"
     ],
-    "msrp_usd": 19,
     "power_source": [
       "poe"
     ],
@@ -72054,7 +71785,6 @@
     "sources": [
       "https://reolink.com/product/b500/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "poe"
     ],
@@ -72124,7 +71854,6 @@
     "sources": [
       "https://reolink.com/product/b800/"
     ],
-    "msrp_usd": 29,
     "power_source": [
       "poe"
     ],
@@ -72203,7 +71932,6 @@
       "dual warning (light + siren)",
       "no subscription"
     ],
-    "msrp_usd": 72,
     "sources": [
       "https://reolink.com/product/cx410/"
     ],
@@ -72550,7 +72278,6 @@
     "sources": [
       "https://reolink.com/product/d1200/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe"
     ],
@@ -72620,7 +72347,6 @@
     "sources": [
       "https://reolink.com/product/d400/"
     ],
-    "msrp_usd": 19,
     "power_source": [
       "poe"
     ],
@@ -72690,7 +72416,6 @@
     "sources": [
       "https://reolink.com/product/d500/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "poe"
     ],
@@ -72760,7 +72485,6 @@
     "sources": [
       "https://reolink.com/product/d800/"
     ],
-    "msrp_usd": 29,
     "power_source": [
       "poe"
     ],
@@ -72836,7 +72560,6 @@
       "solar compatible",
       "no subscription"
     ],
-    "msrp_usd": 170,
     "sources": [
       "https://reolink.com/product/reolink-duo/"
     ],
@@ -72893,7 +72616,6 @@
     "sources": [
       "https://reolink.com/product/reolink-duo-2-lte/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -73422,7 +73144,6 @@
     "sources": [
       "https://reolink.com/product/reolink-duo-4g/"
     ],
-    "msrp_usd": 119,
     "power_source": [
       "battery",
       "solar"
@@ -73553,7 +73274,6 @@
     "sources": [
       "https://reolink.com/product/e1/"
     ],
-    "msrp_usd": 25,
     "power_source": [
       "usb"
     ]
@@ -73606,7 +73326,6 @@
     "sources": [
       "https://reolink.com/product/e1-outdoor-cx/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -73764,7 +73483,6 @@
       "WiFi 6",
       "no subscription"
     ],
-    "msrp_usd": 110,
     "sources": [
       "https://reolink.com/product/e1-outdoor-pro/"
     ],
@@ -73840,7 +73558,6 @@
     "sources": [
       "https://reolink.com/product/e1-outdoor/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -73917,7 +73634,6 @@
       "dual-band WiFi",
       "no subscription"
     ],
-    "msrp_usd": 55,
     "sources": [
       "https://reolink.com/product/e1-pro/"
     ],
@@ -74002,7 +73718,6 @@
       "RTSP",
       "Consumer Reports tested 2024"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://reolink.com/product/reolink-e1-pro/"
     ],
@@ -74078,7 +73793,6 @@
     "sources": [
       "https://reolink.com/product/e1-zoom/"
     ],
-    "msrp_usd": 45,
     "power_source": [
       "usb"
     ],
@@ -74152,7 +73866,6 @@
     "sources": [
       "https://reolink.com/product/elite-floodlight-wifi/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "ac-mains"
     ],
@@ -74229,7 +73942,6 @@
       "no subscription"
     ],
     "release_year": 2025,
-    "msrp_usd": 188.99,
     "sources": [
       "https://slickdeals.net/f/18802744"
     ],
@@ -74312,7 +74024,6 @@
       "Bluetooth",
       "no subscription"
     ],
-    "msrp_usd": 160,
     "sources": [
       "https://reolink.com/product/elite-wifi/"
     ],
@@ -74467,7 +74178,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery",
       "solar"
@@ -74520,7 +74230,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt/"
     ],
-    "msrp_usd": 99,
     "power_source": [
       "battery",
       "solar"
@@ -74574,7 +74283,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt-plus/"
     ],
-    "msrp_usd": 109,
     "power_source": [
       "battery",
       "solar"
@@ -74627,7 +74335,6 @@
     "sources": [
       "https://reolink.com/product/reolink-go-pt-ultra/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -74682,7 +74389,6 @@
       "no cloud required",
       "NVR hub — not a camera"
     ],
-    "msrp_usd": 69,
     "sources": [
       "https://reolink.com/product/home-hub/"
     ],
@@ -74737,7 +74443,6 @@
     "sources": [
       "https://reolink.com/product/keen-ranger-pt/"
     ],
-    "msrp_usd": 159,
     "power_source": [
       "battery",
       "solar"
@@ -74794,7 +74499,6 @@
     "sources": [
       "https://reolink.com/product/reolink-lumus/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "dc"
     ],
@@ -74873,7 +74577,6 @@
       "no subscription"
     ],
     "release_year": 2025,
-    "msrp_usd": 299.99,
     "sources": [
       "https://reolink.com/product/omvi-3i-poe/"
     ],
@@ -74957,7 +74660,6 @@
       "perimeter protection",
       "no subscription"
     ],
-    "msrp_usd": 319.99,
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
@@ -75042,7 +74744,6 @@
       "iF DESIGN AWARD 2026",
       "CES 2026 Innovation Award Honoree"
     ],
-    "msrp_usd": 499.99,
     "sources": [
       "https://www.prnewswire.com/news-releases/reolink-redefines-full-coverage-smart-security-with-the-triple-lens-omvi-series-and-reolink-x-qualcomm-power-efficient-series-cameras-302786356.html"
     ],
@@ -75119,7 +74820,6 @@
     "sources": [
       "https://reolink.com/product/p340/"
     ],
-    "msrp_usd": 59,
     "power_source": [
       "poe",
       "dc"
@@ -75198,7 +74898,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 150,
     "sources": [
       "https://reolink.com/product/p430/"
     ],
@@ -75386,7 +75085,6 @@
       "IP65",
       "works anywhere with cellular signal — farms/remote areas"
     ],
-    "msrp_usd": 129,
     "sources": [
       "https://reolink.com/product/reolink-go-plus/"
     ],
@@ -75445,7 +75143,6 @@
     "sources": [
       "https://reolink.com/product/rlc-1210a/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "poe",
       "dc"
@@ -75620,7 +75317,6 @@
     "sources": [
       "https://reolink.com/product/rlc-1220a/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "poe",
       "dc"
@@ -75855,7 +75551,6 @@
     "sources": [
       "https://reolink.com/product/rlc-410/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76087,7 +75782,6 @@
     "sources": [
       "https://reolink.com/product/rlc-422/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "poe",
       "dc"
@@ -76160,7 +75854,6 @@
     "sources": [
       "https://reolink.com/product/rlc-423/"
     ],
-    "msrp_usd": 49,
     "power_source": [
       "poe",
       "dc"
@@ -76335,7 +76028,6 @@
     "sources": [
       "https://reolink.com/product/rlc-510wa/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -76407,7 +76099,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76480,7 +76171,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511w/"
     ],
-    "msrp_usd": 39,
     "power_source": [
       "dc"
     ],
@@ -76554,7 +76244,6 @@
     "sources": [
       "https://reolink.com/product/rlc-511wa/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -76625,7 +76314,6 @@
     "sources": [
       "https://reolink.com/product/rlc-520/"
     ],
-    "msrp_usd": 35,
     "power_source": [
       "poe",
       "dc"
@@ -76811,7 +76499,6 @@
       "IP67",
       "IK10"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://reolink.com/product/rlc-520a/"
     ],
@@ -76886,7 +76573,6 @@
     "sources": [
       "https://reolink.com/product/rlc-522/"
     ],
-    "msrp_usd": 45,
     "power_source": [
       "poe",
       "dc"
@@ -76961,7 +76647,6 @@
     "sources": [
       "https://reolink.com/product/rlc-523wa/"
     ],
-    "msrp_usd": 69,
     "power_source": [
       "dc"
     ],
@@ -77193,7 +76878,6 @@
     "sources": [
       "https://reolink.com/product/rlc-542wa/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "dc"
     ],
@@ -77381,7 +77065,6 @@
       "₹6,000–9,000 value 4K India",
       "Amazon India popular"
     ],
-    "msrp_inr": 7499,
     "sources": [
       "https://reolink.com/in/"
     ],
@@ -77459,7 +77142,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 120,
     "sources": [
       "https://reolink.com/product/rlc-810wa/"
     ],
@@ -77643,7 +77325,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 160,
     "sources": [
       "https://reolink.com/product/rlc-811wa/"
     ],
@@ -78331,7 +78012,6 @@
       "IP67",
       "available Amazon AU / Officeworks"
     ],
-    "msrp_aud": 109.99,
     "sources": [
       "https://reolink.com/au/"
     ],
@@ -78423,7 +78103,6 @@
       "IP67 rated -10°C to +55°C",
       "available Home Depot Canada / Amazon.ca"
     ],
-    "msrp_cad": 79.99,
     "sources": [
       "https://reolink.com/ca/",
       "https://www.amazon.ca/"
@@ -78517,7 +78196,6 @@
       "IP67",
       "Digitec / Amazon.ch popular"
     ],
-    "msrp_chf": 99,
     "sources": [
       "https://reolink.com/ch/",
       "https://www.digitec.ch/"
@@ -78613,7 +78291,6 @@
       "RTSP/ONVIF Frigate/Home Assistant compatible",
       "IP67"
     ],
-    "msrp_eur": 79.99,
     "sources": [
       "https://reolink.com/eu/product/rlc-823a/"
     ],
@@ -78707,7 +78384,6 @@
       "≈349 AED Amazon.ae",
       "popular no-fee 4K UAE"
     ],
-    "msrp_aed": 349,
     "sources": [
       "https://reolink.com/me-en/",
       "https://www.amazon.ae/"
@@ -78792,7 +78468,6 @@
       "RTSP/ONVIF",
       "IP67"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://reolink.com/"
     ],
@@ -79493,7 +79168,6 @@
       "active deterrence",
       "no subscription"
     ],
-    "msrp_usd": 44.99,
     "sources": [
       "https://reolink.com/product/rlc-840a/"
     ],
@@ -80055,7 +79729,6 @@
     "sources": [
       "https://reolink.com/product/reolink-trackmix-lte/"
     ],
-    "msrp_usd": 149,
     "power_source": [
       "battery",
       "solar"
@@ -80174,7 +79847,6 @@
       "spotlight color night vision",
       "no subscription"
     ],
-    "msrp_usd": 161,
     "sources": [
       "https://reolink.com/product/reolink-trackmix-poe/"
     ],
@@ -80259,7 +79931,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 190,
     "sources": [
       "https://reolink.com/product/reolink-trackmix-wifi/"
     ],
@@ -80334,7 +80005,6 @@
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
-    "msrp_usd": 129,
     "power_source": [
       "battery"
     ],
@@ -80502,7 +80172,6 @@
     "sources": [
       "https://reolink.com/blog/reolink-new-products-at-ces/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "battery"
     ],
@@ -80561,7 +80230,6 @@
     "sources": [
       "https://reolink.com/product/reolink-video-doorbell-wifi/"
     ],
-    "msrp_usd": 79,
     "power_source": [
       "ac-mains"
     ],
@@ -80660,7 +80328,6 @@
       "Alexa",
       "Ring Alarm system integration"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://ring.com/products/alarm-security-cam-pro"
     ],
@@ -80724,7 +80391,6 @@
       "Alexa integration",
       "Ring Protect plan for cloud video"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://ring.com/products/battery-video-doorbell-pro"
     ],
@@ -80787,7 +80453,6 @@
       "Alexa",
       "popular enterprise/commercial buildings"
     ],
-    "msrp_usd": 349,
     "sources": [
       "https://ring.com/products/doorbell-elite"
     ],
@@ -80849,7 +80514,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/floodlight-cam-wired-plus"
     ],
@@ -80908,7 +80572,6 @@
       "Alexa integration"
     ],
     "release_year": 2021,
-    "msrp_usd": 249.99,
     "sources": [
       "https://ring.com/products/floodlight-cam-wired-pro"
     ],
@@ -80966,7 +80629,6 @@
       "Ring subscription for cloud video"
     ],
     "release_year": 2022,
-    "msrp_usd": 59.99,
     "sources": [
       "https://ring.com/products/indoor-cam"
     ],
@@ -81031,7 +80693,6 @@
       "Ring Protect plan for cloud video",
       "Alexa"
     ],
-    "msrp_gbp": 44.99,
     "sources": [
       "https://ring.com/en-gb/"
     ],
@@ -81093,7 +80754,6 @@
       "Alexa",
       "most affordable Ring camera"
     ],
-    "msrp_usd": 44,
     "sources": [
       "https://ring.com/products/indoor-cam"
     ],
@@ -81150,7 +80810,6 @@
       "Ring subscription for cloud video"
     ],
     "release_year": 2023,
-    "msrp_usd": 79.99,
     "sources": [
       "https://ring.com/products/outdoor-cam"
     ],
@@ -81209,7 +80868,6 @@
       "Ring Protect for cloud video",
       "Alexa"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://ring.com/products/pan-tilt-indoor-cam"
     ],
@@ -81271,7 +80929,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 129.99,
     "sources": [
       "https://ring.com/products/peephole-cam"
     ],
@@ -81332,7 +80989,6 @@
       "Alexa",
       "IP55"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://ring.com/products/spotlight-cam-battery"
     ],
@@ -81391,7 +81047,6 @@
       "Ring subscription for cloud video history"
     ],
     "release_year": 2022,
-    "msrp_usd": 149.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-battery"
     ],
@@ -81459,7 +81114,6 @@
       "Alexa / Amazon",
       "IP55 EU version"
     ],
-    "msrp_eur": 179.99,
     "sources": [
       "https://ring.com/de-de/"
     ],
@@ -81522,7 +81176,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-plus-plug-in"
     ],
@@ -81584,7 +81237,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-plus-solar"
     ],
@@ -81648,7 +81300,6 @@
       "person/vehicle/package/motion alerts",
       "Alexa integration"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://ring.com/products/spotlight-cam-pro"
     ],
@@ -81710,7 +81361,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/stick-up-cam-battery"
     ],
@@ -81775,7 +81425,6 @@
       "person/motion detection",
       "IP55 weatherproof"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://ring.com/en-gb/"
     ],
@@ -81837,7 +81486,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/stick-up-cam-plug-in"
     ],
@@ -81900,7 +81548,6 @@
       "Ring Protect for cloud video",
       "Alexa"
     ],
-    "msrp_usd": 179.99,
     "sources": [
       "https://ring.com/products/stick-up-security-camera"
     ],
@@ -81962,7 +81609,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/products/video-doorbell-gen-2"
     ],
@@ -82023,7 +81669,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 229.99,
     "sources": [
       "https://ring.com/products/video-doorbell-3-plus"
     ],
@@ -82086,7 +81731,6 @@
     ],
     "operating_temp_c": "-20 to 48",
     "release_year": 2021,
-    "msrp_usd": 99.99,
     "sources": [
       "https://ring.com/gb/en/support/articles/uc381/Learn-About-Video-Doorbell-4"
     ],
@@ -82159,7 +81803,6 @@
       "Ring Protect plan",
       "Alexa integration"
     ],
-    "msrp_usd": 64.99,
     "sources": [
       "https://ring.com/products/video-doorbell-wired"
     ],
@@ -82715,7 +82358,6 @@
       "SimpliSafe Smart Alarm System integration",
       "no long-term contract"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82776,7 +82418,6 @@
       "no long-term contract",
       "IP65"
     ],
-    "msrp_usd": 119,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82835,7 +82476,6 @@
       "SimpliSafe ecosystem",
       "no long-term contract"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://simplisafe.com/cameras"
     ],
@@ -82907,7 +82547,6 @@
       "GDPR-compliant French-hosted cloud",
       "Alexa / Google"
     ],
-    "msrp_eur": 129.99,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -82969,7 +82608,6 @@
       "GDPR-compliant EU cloud",
       "Alexa / Google"
     ],
-    "msrp_eur": 199,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -83042,7 +82680,6 @@
       "Alexa / Google",
       "IP55"
     ],
-    "msrp_eur": 229.99,
     "sources": [
       "https://www.somfy.fr/"
     ],
@@ -83117,7 +82754,6 @@
       "local storage only (GDPR-friendly)",
       "very popular DE market \"WAF camera\""
     ],
-    "msrp_eur": 319.99,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -83182,7 +82818,6 @@
       "AI person/vehicle/animal detection",
       "IP44"
     ],
-    "msrp_eur": 359,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -83256,7 +82891,6 @@
       "GDPR-friendly no cloud mandatory",
       "high aesthetic WAF design"
     ],
-    "msrp_eur": 399.99,
     "sources": [
       "https://www.steinel.de/"
     ],
@@ -85330,7 +84964,6 @@
       "AU",
       "US"
     ],
-    "msrp_aud": 79,
     "power_source": [
       "battery",
       "ac-mains"
@@ -85573,7 +85206,6 @@
       "AU",
       "US"
     ],
-    "msrp_aud": 749,
     "power_source": [
       "poe",
       "dc"
@@ -85662,7 +85294,6 @@
       "JB Hi-Fi / Bunnings Australia stocked",
       "as seen on The Block AU"
     ],
-    "msrp_aud": 699.99,
     "sources": [
       "https://au.swann.com/swnvk-8advanx4b/"
     ],
@@ -85736,7 +85367,6 @@
       "IP66",
       "flagship Swann AU model 2025"
     ],
-    "msrp_aud": 1099.99,
     "sources": [
       "https://au.swann.com/swnvk-mr4kprosd4/"
     ],
@@ -85814,7 +85444,6 @@
       "multiple award-winner 2024",
       "perfect for rural AU properties / farms / large blocks"
     ],
-    "msrp_aud": 799.99,
     "sources": [
       "https://au.swann.com/swnvk-mr4ksd2/"
     ],
@@ -85882,7 +85511,6 @@
       "IP66",
       "requires Swann DVR"
     ],
-    "msrp_gbp": 39.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -85949,7 +85577,6 @@
       "IP66",
       "requires Swann DVR recorder"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86017,7 +85644,6 @@
       "Alexa / Google",
       "no hub required"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86088,7 +85714,6 @@
       "no DVR required",
       "RTSP stream"
     ],
-    "msrp_gbp": 69.99,
     "sources": [
       "https://www.swann.com/"
     ],
@@ -86299,7 +85924,6 @@
       "NDAA compliant",
       "~$200 MSRP"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.synology.com/en-us/store/BC500"
     ],
@@ -86384,7 +86008,6 @@
       "NDAA compliant",
       "instant search"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.synology.com/en-us/store/BC500"
     ],
@@ -86544,7 +86167,6 @@
       "NDAA/TAA compliant",
       "modular licensing"
     ],
-    "msrp_usd": 299.99,
     "sources": [
       "https://www.synology.com/en-us/products/BC800Z"
     ],
@@ -86999,7 +86621,6 @@
       "NDAA compliant",
       "~$200 MSRP"
     ],
-    "msrp_usd": 199.99,
     "sources": [
       "https://www.synology.com/en-eu/products/TC500"
     ],
@@ -87084,7 +86705,6 @@
       "NDAA compliant",
       "seamless NAS integration"
     ],
-    "msrp_usd": 199,
     "sources": [
       "https://www.synology.com/en-us/store/TC500"
     ],
@@ -87236,7 +86856,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2020,
-    "msrp_usd": 17.99,
     "power_source": [
       "usb"
     ],
@@ -87317,7 +86936,6 @@
       "most affordable Tapo indoor camera",
       "RTSP support"
     ],
-    "msrp_usd": 17,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c100/"
     ],
@@ -87399,7 +87017,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 19.99,
     "power_source": [
       "usb"
     ],
@@ -87483,7 +87100,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 29.99,
     "power_source": [
       "usb"
     ],
@@ -87563,7 +87179,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "budget indoor camera 2024"
     ],
-    "msrp_usd": 24,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c120/"
     ],
@@ -87725,7 +87340,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 39.99,
     "power_source": [
       "usb"
     ],
@@ -87884,7 +87498,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2020,
-    "msrp_usd": 19.99,
     "power_source": [
       "usb"
     ],
@@ -87965,7 +87578,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2021,
-    "msrp_usd": 23.99,
     "power_source": [
       "usb"
     ],
@@ -88052,7 +87664,6 @@
       "RTSP/ONVIF",
       "₹2,500–3,500 best value India indoor cam"
     ],
-    "msrp_inr": 2699,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -88233,7 +87844,6 @@
       "≈109 AED on Amazon.ae / Jarir KSA",
       "#1 budget indoor UAE/KSA home camera"
     ],
-    "msrp_aed": 109,
     "sources": [
       "https://www.tapo.com/me-en/",
       "https://www.jarir.com/"
@@ -88324,7 +87934,6 @@
       "Shopee/Lazada Vietnam top-rated indoor cam",
       "≈500,000–800,000 VND"
     ],
-    "msrp_vnd": 649000,
     "sources": [
       "https://www.tp-link.com/vn/"
     ],
@@ -88412,7 +88021,6 @@
       "HybridCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 49.99,
     "power_source": [
       "usb"
     ],
@@ -88494,7 +88102,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 29.99,
     "power_source": [
       "usb"
     ],
@@ -88576,7 +88183,6 @@
       "RTSP/ONVIF",
       "Tapo app / Alexa / Google / HomeKit"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://www.tapo.com/en/product/indoor-camera/tapo-c222/"
     ],
@@ -88662,7 +88268,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 34.99,
     "power_source": [
       "usb"
     ],
@@ -88751,7 +88356,6 @@
       "budget Digitec CH bestseller indoor cam",
       "CHF 49–59"
     ],
-    "msrp_chf": 59,
     "sources": [
       "https://www.tapo.com/ch-de/",
       "https://www.digitec.ch/"
@@ -88845,7 +88449,6 @@
       "RTSP/ONVIF",
       "top-rated EU Amazon indoor cam"
     ],
-    "msrp_eur": 44.99,
     "sources": [
       "https://www.tapo.com/de/"
     ],
@@ -88928,7 +88531,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 39.99,
     "power_source": [
       "usb"
     ],
@@ -89011,7 +88613,6 @@
       "HybridCam Duo"
     ],
     "release_year": 2025,
-    "msrp_usd": 59.99,
     "power_source": [
       "usb"
     ],
@@ -89095,7 +88696,6 @@
       "RoomCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 79.99,
     "power_source": [
       "usb"
     ],
@@ -89176,7 +88776,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2021,
-    "msrp_usd": 29.99,
     "power_source": [
       "dc"
     ],
@@ -89349,7 +88948,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 39.99,
     "power_source": [
       "dc"
     ],
@@ -89437,7 +89035,6 @@
       "IP67",
       "≈169 AED popular outdoor UAE/KSA Amazon.ae"
     ],
-    "msrp_aed": 169,
     "sources": [
       "https://www.tapo.com/me-en/"
     ],
@@ -89528,7 +89125,6 @@
       "ColorPro Outdoor Camera"
     ],
     "release_year": 2024,
-    "msrp_usd": 59.99,
     "power_source": [
       "dc"
     ],
@@ -89616,7 +89212,6 @@
       "Canadian Tire & Best Buy stocked",
       "CAD$59.99"
     ],
-    "msrp_cad": 59.99,
     "sources": [
       "https://www.tapo.com/ca-en/"
     ],
@@ -89706,7 +89301,6 @@
       "RTSP/ONVIF",
       "₹4,000–5,500 popular India outdoor WiFi cam"
     ],
-    "msrp_inr": 4299,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -89950,7 +89544,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 39.99,
     "power_source": [
       "battery",
       "solar"
@@ -90031,7 +89624,6 @@
       "solar panel compatible",
       "no subscription"
     ],
-    "msrp_usd": 49.99,
     "sources": [
       "https://www.tapo.com/en/product/smart-camera/tapo-c420/"
     ],
@@ -90119,7 +89711,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 59.99,
     "power_source": [
       "battery",
       "solar"
@@ -90203,7 +89794,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "IP67"
     ],
-    "msrp_usd": 39,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c440/"
     ],
@@ -90292,7 +89882,6 @@
       "MagCam 4K Solar"
     ],
     "release_year": 2025,
-    "msrp_usd": 89.99,
     "power_source": [
       "battery",
       "solar"
@@ -90375,7 +89964,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2022,
-    "msrp_usd": 34.99,
     "power_source": [
       "usb"
     ],
@@ -90465,7 +90053,6 @@
       "IP65",
       "budget EU Amazon outdoor cam"
     ],
-    "msrp_eur": 29.99,
     "sources": [
       "https://www.tapo.com/de/"
     ],
@@ -90550,7 +90137,6 @@
       "IP65",
       "budget outdoor PTZ"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c500/"
     ],
@@ -90635,7 +90221,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 44.99,
     "power_source": [
       "usb"
     ],
@@ -90721,7 +90306,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2023,
-    "msrp_usd": 59.99,
     "power_source": [
       "dc"
     ],
@@ -90805,7 +90389,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 69.99,
     "power_source": [
       "dc"
     ],
@@ -90971,7 +90554,6 @@
       "VistaCam 360"
     ],
     "release_year": 2025,
-    "msrp_usd": 99.99,
     "power_source": [
       "dc"
     ],
@@ -91135,7 +90717,6 @@
       "activity zones",
       "no subscription"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://us.store.tapo.com/"
     ],
@@ -91220,7 +90801,6 @@
       "time-lapse",
       "no subscription"
     ],
-    "msrp_usd": 149.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-c660-kit/"
     ],
@@ -91390,7 +90970,6 @@
       "https://www.tapo.com/"
     ],
     "release_year": 2024,
-    "msrp_usd": 79.99,
     "power_source": [
       "ac-mains"
     ],
@@ -91478,7 +91057,6 @@
       "RTSP/ONVIF",
       "₹5,000–7,000 popular India outdoor PTZ WiFi"
     ],
-    "msrp_inr": 5499,
     "sources": [
       "https://www.tapo.com/in/"
     ],
@@ -91564,7 +91142,6 @@
       "RTSP/ONVIF",
       "Tapo app / Alexa / Google / HomeKit"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-c720/"
     ],
@@ -91726,7 +91303,6 @@
       "privacy shutter",
       "no subscription"
     ],
-    "msrp_usd": 59.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-c840/"
     ],
@@ -91869,7 +91445,6 @@
       "Alexa / Google",
       "no subscription"
     ],
-    "msrp_usd": 79.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-d225/"
     ],
@@ -91954,7 +91529,6 @@
       "no subscription",
       "requires Tapo H200 hub"
     ],
-    "msrp_usd": 89.99,
     "sources": [
       "https://www.tapo.com/us/product/smart-camera/tapo-d230s1/"
     ],
@@ -92027,7 +91601,6 @@
       "HomeKit / Alexa / Google",
       "free cloud storage"
     ],
-    "msrp_usd": 89,
     "sources": [
       "https://www.tapo.com/en/product/smart-doorbell/tapo-d235/"
     ],
@@ -92276,7 +91849,6 @@
       "Tapo app / Alexa / Google / HomeKit",
       "IP44"
     ],
-    "msrp_usd": 49,
     "sources": [
       "https://www.tapo.com/en/product/outdoor-camera/tapo-tc82/"
     ],
@@ -94965,7 +94537,6 @@
       "UniFi Protect ecosystem",
       "built-in mic and speaker"
     ],
-    "msrp_usd": 499,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-ai-360"
     ],
@@ -95202,7 +94773,6 @@
       "UniFi Protect ecosystem"
     ],
     "release_year": 2024,
-    "msrp_usd": 999,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-dslr"
     ],
@@ -95286,7 +94856,6 @@
       "two-way audio"
     ],
     "release_year": 2024,
-    "msrp_usd": 499,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro"
     ],
@@ -95371,7 +94940,6 @@
       "two-way audio"
     ],
     "release_year": 2024,
-    "msrp_usd": 499,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-ai-pro-white"
     ],
@@ -95525,7 +95093,6 @@
       "UniFi Protect ecosystem",
       "infrared LEDs for night vision"
     ],
-    "msrp_usd": 149,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-bullet"
     ],
@@ -95604,7 +95171,6 @@
       "EFL 4 mm lens",
       "infrared night vision"
     ],
-    "msrp_usd": 79,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-flex"
     ],
@@ -95682,7 +95248,6 @@
       "compact form factor",
       "infrared night vision"
     ],
-    "msrp_usd": 29,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-ins"
     ],
@@ -95761,7 +95326,6 @@
       "UniFi Protect ecosystem",
       "infrared night vision"
     ],
-    "msrp_usd": 299,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g3-pro"
     ],
@@ -95999,7 +95563,6 @@
       "UniFi Protect ecosystem"
     ],
     "release_year": 2022,
-    "msrp_usd": 199,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-doorbell"
     ],
@@ -96319,7 +95882,6 @@
       "UniFi Protect ecosystem",
       "auto-tracking"
     ],
-    "msrp_usd": 1499,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g4-ptz"
     ],
@@ -96635,7 +96197,6 @@
       "UniFi Protect ecosystem",
       "infrared night vision"
     ],
-    "msrp_usd": 99,
     "sources": [
       "https://store.ui.com/us/en/products/uvc-g5-flex"
     ],
@@ -96794,7 +96355,6 @@
       "built-in mic"
     ],
     "release_year": 2024,
-    "msrp_usd": 99,
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g5-turret"
     ],
@@ -97690,7 +97250,6 @@
       "IK08",
       "competitive MENA value vs Hikvision/Dahua"
     ],
-    "msrp_aed": 599,
     "sources": [
       "https://www.uniview.com/me-en/"
     ],
@@ -98287,7 +97846,6 @@
       "-40°C to +60°C",
       "popular US enterprise/government/K-12 schools"
     ],
-    "msrp_usd": 999,
     "sources": [
       "https://www.verkada.com/security-cameras/outdoor-cameras/"
     ],
@@ -98358,7 +97916,6 @@
       "annual per-camera license pricing model",
       "popular US healthcare/education/enterprise"
     ],
-    "msrp_usd": 849,
     "sources": [
       "https://www.verkada.com/security-cameras/indoor-dome-cameras/"
     ],
@@ -98422,7 +97979,6 @@
       "zero-touch provisioning",
       "IP66"
     ],
-    "msrp_usd": 999,
     "sources": [
       "https://www.verkada.com/"
     ],
@@ -99655,7 +99211,6 @@
       "no subscription required for basic",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 100,
     "sources": [
       "https://www.wyze.com/products/wyze-battery-cam-pro"
     ],
@@ -99724,7 +99279,6 @@
       "no subscription required",
       "Alexa / Google"
     ],
-    "msrp_usd": 149.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-floodlight-pro"
     ],
@@ -99804,7 +99358,6 @@
       "no subscription for basic features",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 24,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-og"
     ],
@@ -99885,7 +99438,6 @@
       "no subscription for basic features",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 32,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-og"
     ],
@@ -99966,7 +99518,6 @@
       "solar optional",
       "Alexa / Google"
     ],
-    "msrp_usd": 59,
     "sources": [
       "https://www.wyze.com/"
     ],
@@ -100038,7 +99589,6 @@
       "no subscription required",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 49.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-outdoor"
     ],
@@ -100112,7 +99662,6 @@
       "no subscription required",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 34,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pan"
     ],
@@ -100183,7 +99732,6 @@
       "24/7 recording (microSD)",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 37.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pan"
     ],
@@ -100264,7 +99812,6 @@
       "continuous recording (microSD)",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 26,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100335,7 +99882,6 @@
       "Alexa / Google Home",
       "RTSP support"
     ],
-    "msrp_usd": 35.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100419,7 +99965,6 @@
       "Alexa / Google Home",
       "RTSP"
     ],
-    "msrp_usd": 59.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-pro"
     ],
@@ -100505,7 +100050,6 @@
       "Alexa / Google Home",
       "RTSP support"
     ],
-    "msrp_usd": 35.98,
     "sources": [
       "https://www.wyze.com/products/wyze-cam"
     ],
@@ -100586,7 +100130,6 @@
       "no subscription required for basic",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 60,
     "sources": [
       "https://www.wyze.com/products/wyze-cam-floodlight"
     ],
@@ -100656,7 +100199,6 @@
       "built-in chime",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 49.98,
     "sources": [
       "https://www.wyze.com/products/wyze-doorbell-pro"
     ],
@@ -100724,7 +100266,6 @@
       "built-in chime",
       "Alexa / Google Home"
     ],
-    "msrp_usd": 50,
     "sources": [
       "https://www.wyze.com/products/wyze-video-doorbell-v2"
     ],
@@ -100799,7 +100340,6 @@
       "no monthly fees",
       "solar panel optional"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -100868,7 +100408,6 @@
       "Amazon Alexa certified",
       "IP65"
     ],
-    "msrp_gbp": 99.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -100992,7 +100531,6 @@
       "activity zones",
       "UK brand trust factor"
     ],
-    "msrp_gbp": 79.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101060,7 +100598,6 @@
       "Alexa compatible",
       "activity zones"
     ],
-    "msrp_gbp": 59.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101229,7 +100766,6 @@
       "Yale Home View App",
       "entry-level budget Yale indoor cam"
     ],
-    "msrp_gbp": 49.99,
     "sources": [
       "https://www.yale.co.uk/"
     ],
@@ -101303,7 +100839,6 @@
       "Zebronics Smart app",
       "₹1,500–2,500 ultra-budget India"
     ],
-    "msrp_inr": 1799,
     "sources": [
       "https://www.zebronics.com/"
     ],
@@ -101367,7 +100902,6 @@
       "no subscription",
       "₹2,499"
     ],
-    "msrp_inr": 2499,
     "sources": [
       "https://www.zebronics.com/"
     ],
@@ -101421,7 +100955,6 @@
     "markets": [
       "IN"
     ],
-    "msrp_inr": 3499,
     "power_source": [
       "dc"
     ]
@@ -101475,7 +101008,6 @@
     "markets": [
       "IN"
     ],
-    "msrp_inr": 1499,
     "power_source": [
       "usb"
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -98,7 +98,7 @@
     },
     "video": {
       "type": "object",
-      "description": "Codec, FPS, and streaming capabilities.",
+      "description": "Stream capabilities — what the camera outputs (codecs, FPS, per-stream specs). This is spec metadata; the RTSP URLs to actually use live under configs.frigate.* (rtsp_url_template, best_substream). Optional and backfilled opportunistically.",
       "additionalProperties": false,
       "properties": {
         "codecs": {
@@ -133,7 +133,7 @@
               }
             }
           },
-          "description": "Per-stream resolution/fps/codec breakdown."
+          "description": "Per-stream capability breakdown (name/resolution/fps/codec) — what each stream outputs. Distinct from configs.frigate.best_substream, which is the RTSP URL to use."
         }
       }
     },
@@ -293,41 +293,6 @@
       "type": "string",
       "description": "System on Chip (SoC), e.g. Ingenic T31 (for Thingino/OpenIPC compatibility)."
     },
-    "msrp_usd": {
-      "type": "number"
-    },
-    "msrp_eur": {
-      "type": "number",
-      "description": "MSRP in EUR."
-    },
-    "msrp_gbp": {
-      "type": "number",
-      "description": "MSRP in GBP."
-    },
-    "msrp_inr": {
-      "type": "number",
-      "description": "MSRP in INR."
-    },
-    "msrp_aed": {
-      "type": "number",
-      "description": "MSRP in AED."
-    },
-    "msrp_aud": {
-      "type": "number",
-      "description": "MSRP in AUD."
-    },
-    "msrp_cad": {
-      "type": "number",
-      "description": "MSRP in CAD."
-    },
-    "msrp_vnd": {
-      "type": "number",
-      "description": "MSRP in VND."
-    },
-    "msrp_chf": {
-      "type": "number",
-      "description": "MSRP in CHF."
-    },
     "markets": {
       "type": "array",
       "items": {
@@ -381,7 +346,7 @@
             },
             "best_substream": {
               "type": "string",
-              "description": "Recommended sub-stream path."
+              "description": "Recommended sub-stream RTSP URL for Frigate's detect role (the URL to use). Distinct from video.streams[], which describes stream capabilities."
             },
             "notes": {
               "type": "string"


### PR DESCRIPTION
Removed:
- All MSRP price fields (msrp_usd + localized msrp_eur/gbp/inr/aed/aud/ cad/vnd/chf) from the schema and stripped from 468 cameras. The data was sparse (~36%, single-currency, undated) and unreliable — omitting it is more honest than publishing inaccurate prices.

Changed:
- Clarified that video.streams[] describes stream capabilities, distinct from configs.frigate.* (the RTSP URLs to use) — they complement.

Docs: README schema table + roadmap updated; JSON-Schema-in-CI marked done.

## What does this PR do?

<!-- One line summary, e.g. "Add Reolink Argus 5 Pro" or "Fix Hikvision DS-2CD2387G2-LU night vision range" -->

---

## Checklist

### For new cameras
- [ ] JSON file is under `cameras/<brand-slug>/<model-slug>.json`
- [ ] `id` is a unique lowercase slug matching the file path
- [ ] `brand`, `model`, `type`, `resolution` are all present
- [ ] At least one URL in `sources` (manufacturer datasheet or reputable retailer)
- [ ] `npm run build` passes locally with no errors

### For corrections
- [ ] Include a source URL confirming the correct value
- [ ] `npm run build` passes locally with no errors

### For schema / tooling changes
- [ ] Existing cameras still validate (`npm run build`)
- [ ] Updated `docs/glossary.md` if new fields were added

---

## Source(s)

<!-- Paste the URL(s) you used to verify the specs -->

---

## Notes

<!-- Anything a reviewer should know: regional variants, known discrepancies between markets, uncertain fields left blank, etc. -->
