### PR TITLE
v1.12.0: add Frigate/Home Assistant configs for 195 Bosch + ABUS cameras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.12.0] — 2026-06-29
+
+### Added
+
+- **Integration configs (Frigate + Home Assistant) for 195 cameras** that supported RTSP/ONVIF but had none, using verified per-OEM RTSP patterns:
+  - **137 Bosch** (FLEXIDOME / DINION / AUTODOME / MIC) — Bosch's official `rtsp://…:554/?inst=1` (main) / `?inst=2` (sub) scheme, per Bosch's "RTSP usage with Bosch Video IP Devices" doc.
+  - **58 ABUS Performance Line** (IPCA/IPCB/IPCS + 8 PoE TVIP) — Hikvision-OEM `…/Streaming/Channels/101` (main) / `102` (sub); ABUS TVIP82561 shares an official manual with the IPCS84511, confirming the platform.
+  - All marked `verified: false` with sourced notes (derived from the OEM family / official scheme, not individually bench-tested). "No config" cameras with RTSP/ONVIF dropped from 203 → 7.
+- Added vertical field-of-view to ABUS IPCA54512A (110° H / 57° V) and the firstmall.de source.
+
+### Changed
+
+- No camera count change — still **1,577 cameras** across **68 brands**. Cameras with integration configs: **1,303**.
+
+---
+
 ## [1.11.0] — 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | 4K / 8MP+ | 464 |
 | 4–5MP | 688 |
 | 1080p–2MP | 397 |
+| With integration configs (Frigate / Home Assistant) | 1,303 |
 
 ### All 68 brands
 

--- a/cameras/abus/ipca34512a.json
+++ b/cameras/abus/ipca34512a.json
@@ -77,5 +77,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipca34512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-Black-2.8-mm-IR-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca34512b.json
+++ b/cameras/abus/ipca34512b.json
@@ -84,5 +84,25 @@
     "https://www.expert-security.de/abus-ipca34512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-mini-tube-4-MPx-4-mm-IR-WL",
     "https://alarm-technik.eu/en/products/ip-mini-tube-4-mpx-4-mm-ir-wl-abus-ipca34512b"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca34612a.json
+++ b/cameras/abus/ipca34612a.json
@@ -81,5 +81,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipca34612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.voltus.com/en/abus-ipca34612a-ip-mini-tube-4-mp-ir-wl-sw-2-8-mm.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca54512a.json
+++ b/cameras/abus/ipca54512a.json
@@ -48,7 +48,7 @@
     "aperture": "F1.0",
     "varifocal": false
   },
-  "field_of_view_deg": "110 horizontal",
+  "field_of_view_deg": "110 horizontal / 57 vertical",
   "night_vision": {
     "type": "hybrid",
     "range_m": 30
@@ -93,6 +93,27 @@
   "sources": [
     "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-2-8-mm-ir-wl-abus-ipca54512a",
-    "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-  ]
+    "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm",
+    "https://firstmall.de/ABUS-IPCA54512A-Kugeldome-Kamera-IP-4-MPx-28-mm-IR-WL-PoE-Ueberwachungskamera"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — uses Hikvision-style RTSP paths (Channels/101 main, /102 sub, /103 third). ONVIF/RTSP must be enabled in the camera web UI (Network > Integration Protocol) first. Pattern inferred from sibling IPCB/IPCA models (iSpyConnect, HA community); not individually verified on this exact model."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Use the generic ONVIF integration after enabling ONVIF (Profile S) in the camera web UI. No ABUS-specific HA integration for the Performance Line."
+    }
+  }
 }

--- a/cameras/abus/ipca54512b.json
+++ b/cameras/abus/ipca54512b.json
@@ -89,5 +89,25 @@
     "https://www.solarics.de/products/abus-abus-ipca54512a-ip-kugeldome-4-mpx-2-8-mm-ir-wl-art-ipca54512a",
     "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-4-mm-IR-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca54572a.json
+++ b/cameras/abus/ipca54572a.json
@@ -80,5 +80,25 @@
     "https://www.expert-security.de/abus-ipca54572a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://firstmall.de/ABUS-IPCA54572A-IP-Kamera-Kugeldome-4-MPx-IR-WL-mit-2WAY-Audio-Alarmierung",
     "https://fr.rs-online.com/web/p/videosurveillance-cameras/0180161"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca54581b.json
+++ b/cameras/abus/ipca54581b.json
@@ -74,5 +74,25 @@
     "https://www.expert-security.de/abus-ipca54581b-ip-thermal-kamera-4mpx.html",
     "https://alarm-technik.eu/en/products/thermal-dome-bi-spektral-4mpx-3-6-4-3-mm-abus-ipca54581b",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Dome-Bi-Spectral-4MPx-3.6-4.3-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca54612a.json
+++ b/cameras/abus/ipca54612a.json
@@ -83,5 +83,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipca54612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca54612a"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca64512a.json
+++ b/cameras/abus/ipca64512a.json
@@ -83,5 +83,25 @@
     "https://www.expert-security.de/abus-ipca64512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca64512b.json
+++ b/cameras/abus/ipca64512b.json
@@ -92,5 +92,25 @@
     "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://alarm-technik.eu/en/products/ip-tube-4-mpx-4-mm-ir-wl-abus-ipca64512b",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-IR-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca64581d.json
+++ b/cameras/abus/ipca64581d.json
@@ -83,5 +83,25 @@
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Tube-Bi-Spectral-4MPx-9.7-8-mm",
     "https://www.rexel.de/p/5075504",
     "https://www.alarm-laden.de/Thermal-Tube-Bi-Spektral-4MPx-97-8-mm-IPCA64581D"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipca64612a.json
+++ b/cameras/abus/ipca64612a.json
@@ -104,5 +104,25 @@
     "https://alarm-technik.eu/en/products/ip-tube-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca64612a",
     "https://www.expert-security.de/abus-ip-kameras.html",
     "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Tube-4-MPx-Schwarz-2.8-mm-IR-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb34511a.json
+++ b/cameras/abus/ipcb34511a.json
@@ -82,5 +82,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb34511a-ip-bullet-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-2.8mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb34511b.json
+++ b/cameras/abus/ipcb34511b.json
@@ -96,5 +96,25 @@
   ],
   "sources": [
     "https://www.expert-security.de/abus-ipcb34511b-ip-bullet-4mpx-t-n-ir-poe-ip67.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb34611a.json
+++ b/cameras/abus/ipcb34611a.json
@@ -92,5 +92,25 @@
     "https://www.expert-security.de/abus-ipcb34611a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://www.jvsg.com/cameras/abus/IPCB34611A/reolink/E1_Pro/",
     "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Mini-Tube-4-MPx-Schwarz-2.8-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb38511a.json
+++ b/cameras/abus/ipcb38511a.json
@@ -96,5 +96,25 @@
     "https://www.expert-security.de/abus-ipcb38511a-ip-bullet-4k-t-n-ir-poe-ip67.html",
     "https://alarm-technik.eu/en/products/ip-mini-tube-8-mpx-4k-2-8-mm-abus-ipcb38511a",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-8-MPx-4K-2.8-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb38511b.json
+++ b/cameras/abus/ipcb38511b.json
@@ -74,5 +74,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb38511b-ip-bullet-4k-t-n-ir-poe-ip67.html",
     "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Tube/IP-Mini-Tube-8-MPx-4K-4mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44510a.json
+++ b/cameras/abus/ipcb44510a.json
@@ -65,5 +65,25 @@
     "https://www.singular.com.cy/abus-ipcb44510a-network-surveillance-camera-dome-outdoor-indoor-vandal-poe.html",
     "https://www.abus.com/eng/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-2.8-mm",
     "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44510c.json
+++ b/cameras/abus/ipcb44510c.json
@@ -76,5 +76,25 @@
     "https://geizhals.de/abus-ip-mini-dome-4-mpx-ipcb44510c-a2135825.html",
     "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-6-mm",
     "https://www.testbericht.de/produkte/abus-ipcb44510c"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44511a.json
+++ b/cameras/abus/ipcb44511a.json
@@ -88,5 +88,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb44511a-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-2.8-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44511b.json
+++ b/cameras/abus/ipcb44511b.json
@@ -86,5 +86,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-4mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44561a.json
+++ b/cameras/abus/ipcb44561a.json
@@ -74,5 +74,25 @@
     "https://www.expert-security.de/abus-ipcb44561a-ip-dome-4mpx-t-n-ir-poe-wlan-ip67.html",
     "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-Wi-Fi-4-MPx-2.8mm",
     "https://alarm-technik.eu/en/products/ip-mini-dome-wlan-4-mpx-2-8-mm-abus-ipcb44561a"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44611a.json
+++ b/cameras/abus/ipcb44611a.json
@@ -74,5 +74,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb44611a-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-2.8-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb44611b.json
+++ b/cameras/abus/ipcb44611b.json
@@ -96,5 +96,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb44611b-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
     "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-Black-4mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb54511a.json
+++ b/cameras/abus/ipcb54511a.json
@@ -87,5 +87,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb54511a-ip-dome-4mpx-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb54511b.json
+++ b/cameras/abus/ipcb54511b.json
@@ -82,5 +82,25 @@
     "https://www.expert-security.de/abus-ipcb54511b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
     "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-4-mm-ABUS-IPCB54511B",
     "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Aussendome/IP-Kugeldome-4-MPx-4-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb54611b.json
+++ b/cameras/abus/ipcb54611b.json
@@ -75,5 +75,25 @@
     "https://www.expert-security.de/abus-ipcb54611b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
     "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-4-mm-abus-ipcb54611b",
     "https://c4.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Spherical-Dome-4-MPx-Black-4mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb58511a.json
+++ b/cameras/abus/ipcb58511a.json
@@ -97,5 +97,25 @@
     "https://www.expert-security.de/abus-ipcb58511a-ip-dome-4k-t-n-ir-poe-ip67.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
     "https://de.rs-online.com/web/p/uberwachungskamera/2728613"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb58511b.json
+++ b/cameras/abus/ipcb58511b.json
@@ -88,5 +88,25 @@
     "https://www.expert-security.de/abus-ipcb58511b-ip-dome-4k-t-n-ir-poe-ip67.html",
     "https://www.alarm-technik.eu/IP-Kugeldome-8-MPx-4-mm-ABUS-IPCB58511B",
     "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Kugeldome-8-MPx-4-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb58611a.json
+++ b/cameras/abus/ipcb58611a.json
@@ -84,5 +84,25 @@
     "https://alarm-technik.eu/en/products/ip-kugeldome-8-mpx-2-8-mm-abus-ipcb58611a",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
     "https://c1.abus.com/asc-pim-assets-01/medias/docus/26/20211027-IPCB5xx11AB_INST_DE_GB.pdf"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb64521.json
+++ b/cameras/abus/ipcb64521.json
@@ -97,5 +97,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb64521-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://geizhals.de/abus-ip-mini-tube-4-mpx-2-8-12mm-ipcb64521-a2731457.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb64621.json
+++ b/cameras/abus/ipcb64621.json
@@ -77,5 +77,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb64621-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://de.rs-online.com/web/p/uberwachungskamera/2728616"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb68521.json
+++ b/cameras/abus/ipcb68521.json
@@ -100,5 +100,25 @@
   ],
   "sources": [
     "https://www.expert-security.de/abus-ipcb68521-ip-tube-4k-t-n-ir-poe-ip67-ik10.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb68621.json
+++ b/cameras/abus/ipcb68621.json
@@ -78,5 +78,25 @@
     "https://alarm-technik.eu/en/products/ip-tube-8-mpx-4k-2-8-12mm-abus-ipcb68621",
     "https://www.abus.com/uk/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-8-MPx-Black-2.8-12mm",
     "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211027-IPCB6xx21_INST_DE_UK.pdf"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb74521.json
+++ b/cameras/abus/ipcb74521.json
@@ -100,5 +100,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb74521-ip-dome-ir-4mpx-t-n-poe-ip67-ik10.html",
     "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-4-MPX-2.8-12-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcb78521.json
+++ b/cameras/abus/ipcb78521.json
@@ -79,5 +79,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcb78521-ip-dome-4k-t-n-ir-poe-ip67-ik10.html",
     "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-8-MPx-2.8-12mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs28581a.json
+++ b/cameras/abus/ipcs28581a.json
@@ -87,5 +87,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcs28581a-ip-kamera-4k-tag-nacht-ip67.html",
     "https://www.alarm-technik.eu/IP-Panorama-Dome-8-MPx-1800-WL-ABUS-IPCS28581A"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs29512.json
+++ b/cameras/abus/ipcs29512.json
@@ -102,5 +102,25 @@
     "https://www.expert-security.de/abus-ipcs29512-ip-kamera-12mpx-t-n-ir-ip67-ik10.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-12-MPx2",
     "https://alarm-technik.eu/en/products/12-mpx-ip-fisheye-kamera-abus-ipcs29512"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 3072,
+        "height": 2304,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs34611a.json
+++ b/cameras/abus/ipcs34611a.json
@@ -96,5 +96,25 @@
     "https://www.rapidonline.com/abus-ipcs34611a-cctv-camera-4mp-day-night-ip67-mobile-access-poe-01-0215",
     "https://www.alarm-technik.eu/IP-Mini-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS34611A",
     "https://www.ispyconnect.com/camera/abus"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs54511a.json
+++ b/cameras/abus/ipcs54511a.json
@@ -73,5 +73,25 @@
     "https://geizhals.de/abus-ip-dome-kamera-4-mpx-2-8mm-ipcs54511a-a3394077.html",
     "https://www.testbericht.de/produkte/abus-ipcs54511a",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8-mm-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs54511b.json
+++ b/cameras/abus/ipcs54511b.json
@@ -81,5 +81,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcs54511b-ip-dome-4mp-t-n-weisslicht-poe-ip67.html",
     "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211208-IPCS54511AB_INST_DE_GB.pdf"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs54611a.json
+++ b/cameras/abus/ipcs54611a.json
@@ -92,5 +92,25 @@
     "https://www.expert-security.de/abus-ipcs54611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
     "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-2.8-mm-WL-ABUS-IPCS54611A",
     "https://de.rs-online.com/web/p/uberwachungskamera/2728628"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs58571a.json
+++ b/cameras/abus/ipcs58571a.json
@@ -93,5 +93,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcs58571a-ip-kamera-4k-t-n-ir-poe-ip67.html",
     "https://www.abus.com/fr/Securite-des-batiments/Videosurveillance/IP/Cameras/Camera-exterieure-dome/Dome-spherique-IP-8-MPx-2-8-mm-avec-audio-2WAY-alarme"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs64511b.json
+++ b/cameras/abus/ipcs64511b.json
@@ -91,5 +91,25 @@
     "https://www.expert-security.de/abus-ipcs64511b-ip-bullet-4mpx-t-n-weisslicht-poe.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-WL",
     "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-4-mm-WL"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs64531.json
+++ b/cameras/abus/ipcs64531.json
@@ -81,5 +81,25 @@
     "https://www.expert-security.de/abus-ipcs64531-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://alarm-technik.eu/en/products/ip-tube-4-mpx-2-8-12-mm-kennzeichen-anpr-abus-ipcs64531",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-12-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs64541.json
+++ b/cameras/abus/ipcs64541.json
@@ -99,5 +99,25 @@
   "sources": [
     "https://www.expert-security.de/abus-ipcs64541-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://www.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPX-Tele-Motorzoom-4.7-118-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 2688,
+        "height": 1520,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs64611a.json
+++ b/cameras/abus/ipcs64611a.json
@@ -68,5 +68,25 @@
     "https://www.expert-security.de/abus-ipcs64611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
     "https://www.alarm-technik.eu/IP-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS64611A",
     "https://uk.rs-online.com/web/p/cctv-cameras/2728634"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs74511a.json
+++ b/cameras/abus/ipcs74511a.json
@@ -72,5 +72,25 @@
     "https://firstmall.de/abus-ip-dome-4mpx-2-8mm-hdmi-poe-ueberwachungskamera",
     "https://www.manualslib.com/manual/4025987/Abus-Ipcs74511a.html",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Dome-4MPx-2.8mm-with-HDMI-port"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs84511.json
+++ b/cameras/abus/ipcs84511.json
@@ -92,5 +92,25 @@
     "https://www.expert-security.de/abus-ipcs84511-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
     "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/PTZ/IP-Mini-PTZ-4-MPx-4x",
     "https://www.zajadacz.de/ABUS-IP-Mini-PTZ-4-MPx-4x-IPCS84511.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs84532.json
+++ b/cameras/abus/ipcs84532.json
@@ -79,5 +79,25 @@
     "https://www.expert-security.de/abus-ipcs84532-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
     "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84532",
     "https://c1.abus.com/asc-pim-assets-01/medias/docus/30/20240508-IPCS84532_BDA_INT.pdf"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/ipcs84551.json
+++ b/cameras/abus/ipcs84551.json
@@ -109,5 +109,25 @@
     "https://www.expert-security.de/abus-ipcs84551-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
     "https://alarm-technik.eu/en/products/ip-ptz-dome-4-mpx-32x-abus-ipcs84551",
     "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-PTZ-Dome-4-MPx-32x"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip42510.json
+++ b/cameras/abus/tvip42510.json
@@ -88,5 +88,25 @@
   ],
   "sources": [
     "https://www.expert-security.de/abus-tvip42510-ip-kamera-1080p-tn-ir-poe-ip67.html"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 360,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip44510.json
+++ b/cameras/abus/tvip44510.json
@@ -88,5 +88,25 @@
   "sources": [
     "https://www.expert-security.de/abus-tvip44510-ip-kamera-1440p-tn-ir-poe-ip67-ik10.html",
     "https://www.abus.com/int/abusproductsheet.pdf/191285/eng-ZZ"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip44511.json
+++ b/cameras/abus/tvip44511.json
@@ -87,5 +87,25 @@
     "https://www.expert-security.de/abus-tvip44511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://www.sotel.co.uk/en/Computer-Drucker/Smart-Home/Haussteuerung/Alarmanlagen/ABUS-TVIP44511-security-camera-Dome-IP-security-camera-Indoor-outdoor-2688-x-1520-pixels-Ceiling.html",
     "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-mini-dome-4-MPx-4-mm"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip48511.json
+++ b/cameras/abus/tvip48511.json
@@ -100,5 +100,25 @@
   "sources": [
     "https://www.expert-security.de/abus-tvip48511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
     "https://www.abus.com/int/abusproductsheet.pdf/264068/eng-ZZ"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip62510.json
+++ b/cameras/abus/tvip62510.json
@@ -86,5 +86,25 @@
   "sources": [
     "https://www.expert-security.de/abus-tvip62510-ip-kamera-1080p-t-n-ir-poe-ip67.html",
     "https://www.abus.com/at/Sicherheit-Zuhause/Videoueberwachung/Ueberwachungskameras/Aussenkameras/2MPx-IP-PoE-Mini-Tube-kamera"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 360,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip64511.json
+++ b/cameras/abus/tvip64511.json
@@ -78,5 +78,25 @@
   "sources": [
     "https://www.expert-security.de/abus-tvip64511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
     "https://c1.abus.com/asc-pim-assets-01/medias/docus/27/20230119-TVIP6x511_INST_DE-GB.pdf"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip68511.json
+++ b/cameras/abus/tvip68511.json
@@ -79,5 +79,25 @@
   "sources": [
     "https://www.expert-security.de/abus-tvip68511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
     "https://www.alarm-technik.eu/en/products/ip-8mpx-poe-mini-tube-kamera-abus-tvip68511"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/abus/tvip82561.json
+++ b/cameras/abus/tvip82561.json
@@ -77,5 +77,25 @@
     "https://www.expert-security.de/abus-tvip82561-ip-kamera-1080p-t-n-ir-ptz-poe-ip66.html",
     "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
     "https://www.abus.com/int/Consumer/Video-surveillance/Systems-from-the-expert/Cameras/ABUS-IP-video-surveillance-2MPx-Wi-Fi-PTZ-dome-camera"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+    }
+  }
 }

--- a/cameras/bosch/fcs-8000-vfd-i.json
+++ b/cameras/bosch/fcs-8000-vfd-i.json
@@ -99,5 +99,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7504-z12br.json
+++ b/cameras/bosch/mic-7504-z12br.json
@@ -112,5 +112,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7504-z12gr.json
+++ b/cameras/bosch/mic-7504-z12gr.json
@@ -75,5 +75,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7504-z12wr.json
+++ b/cameras/bosch/mic-7504-z12wr.json
@@ -102,5 +102,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30b.json
+++ b/cameras/bosch/mic-7522-z30b.json
@@ -102,5 +102,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30br.json
+++ b/cameras/bosch/mic-7522-z30br.json
@@ -105,5 +105,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30g.json
+++ b/cameras/bosch/mic-7522-z30g.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30gr.json
+++ b/cameras/bosch/mic-7522-z30gr.json
@@ -81,5 +81,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30w.json
+++ b/cameras/bosch/mic-7522-z30w.json
@@ -99,5 +99,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-7522-z30wr.json
+++ b/cameras/bosch/mic-7522-z30wr.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30bqs.json
+++ b/cameras/bosch/mic-9502-z30bqs.json
@@ -89,5 +89,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 320,
+        "height": 240,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30bvf.json
+++ b/cameras/bosch/mic-9502-z30bvf.json
@@ -101,5 +101,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30bvf9.json
+++ b/cameras/bosch/mic-9502-z30bvf9.json
@@ -99,5 +99,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30bvs.json
+++ b/cameras/bosch/mic-9502-z30bvs.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30bvs9.json
+++ b/cameras/bosch/mic-9502-z30bvs9.json
@@ -106,5 +106,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30gqs.json
+++ b/cameras/bosch/mic-9502-z30gqs.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 320,
+        "height": 240,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30gvf.json
+++ b/cameras/bosch/mic-9502-z30gvf.json
@@ -108,5 +108,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30gvf9.json
+++ b/cameras/bosch/mic-9502-z30gvf9.json
@@ -95,5 +95,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30wqs.json
+++ b/cameras/bosch/mic-9502-z30wqs.json
@@ -86,5 +86,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 320,
+        "height": 240,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30wvf.json
+++ b/cameras/bosch/mic-9502-z30wvf.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30wvf9.json
+++ b/cameras/bosch/mic-9502-z30wvf9.json
@@ -79,5 +79,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30wvs.json
+++ b/cameras/bosch/mic-9502-z30wvs.json
@@ -106,5 +106,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9502-z30wvs9.json
+++ b/cameras/bosch/mic-9502-z30wvs9.json
@@ -103,5 +103,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30b06v.json
+++ b/cameras/bosch/mic-9803s-z30b06v.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30b14v.json
+++ b/cameras/bosch/mic-9803s-z30b14v.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30b18q.json
+++ b/cameras/bosch/mic-9803s-z30b18q.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 320,
+        "height": 240,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30b42v.json
+++ b/cameras/bosch/mic-9803s-z30b42v.json
@@ -89,5 +89,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30g06v.json
+++ b/cameras/bosch/mic-9803s-z30g06v.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30g14v.json
+++ b/cameras/bosch/mic-9803s-z30g14v.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30g18q.json
+++ b/cameras/bosch/mic-9803s-z30g18q.json
@@ -77,5 +77,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30g42v.json
+++ b/cameras/bosch/mic-9803s-z30g42v.json
@@ -94,5 +94,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30w06v.json
+++ b/cameras/bosch/mic-9803s-z30w06v.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30w14v.json
+++ b/cameras/bosch/mic-9803s-z30w14v.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30w18q.json
+++ b/cameras/bosch/mic-9803s-z30w18q.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/mic-9803s-z30w42v.json
+++ b/cameras/bosch/mic-9803s-z30w42v.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-3702-al.json
+++ b/cameras/bosch/nbe-3702-al.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-3703-al.json
+++ b/cameras/bosch/nbe-3703-al.json
@@ -75,5 +75,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-5704-al.json
+++ b/cameras/bosch/nbe-5704-al.json
@@ -95,5 +95,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7702-alx.json
+++ b/cameras/bosch/nbe-7702-alx.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7703-alx.json
+++ b/cameras/bosch/nbe-7703-alx.json
@@ -98,5 +98,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7703-alxt.json
+++ b/cameras/bosch/nbe-7703-alxt.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7704-al.json
+++ b/cameras/bosch/nbe-7704-al.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7704-alt.json
+++ b/cameras/bosch/nbe-7704-alt.json
@@ -93,5 +93,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbe-7704-alx.json
+++ b/cameras/bosch/nbe-7704-alx.json
@@ -96,5 +96,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7802-ax.json
+++ b/cameras/bosch/nbi-7802-ax.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7802-axt.json
+++ b/cameras/bosch/nbi-7802-axt.json
@@ -81,5 +81,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7803-ax.json
+++ b/cameras/bosch/nbi-7803-ax.json
@@ -86,5 +86,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7803-axt.json
+++ b/cameras/bosch/nbi-7803-axt.json
@@ -84,5 +84,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7803s-ax.json
+++ b/cameras/bosch/nbi-7803s-ax.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbi-7803s-axt.json
+++ b/cameras/bosch/nbi-7803s-axt.json
@@ -81,5 +81,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbn-63023-b.json
+++ b/cameras/bosch/nbn-63023-b.json
@@ -89,5 +89,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbn-73023-ba.json
+++ b/cameras/bosch/nbn-73023-ba.json
@@ -89,5 +89,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8700-f03qf.json
+++ b/cameras/bosch/nbt-8700-f03qf.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8700-f05qf.json
+++ b/cameras/bosch/nbt-8700-f05qf.json
@@ -92,5 +92,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8700-f09qf.json
+++ b/cameras/bosch/nbt-8700-f09qf.json
@@ -93,5 +93,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8700-f18qf.json
+++ b/cameras/bosch/nbt-8700-f18qf.json
@@ -95,5 +95,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8701-f06vf.json
+++ b/cameras/bosch/nbt-8701-f06vf.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8701-f14vf.json
+++ b/cameras/bosch/nbt-8701-f14vf.json
@@ -96,5 +96,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8701-f25vf.json
+++ b/cameras/bosch/nbt-8701-f25vf.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nbt-8701-f42vf.json
+++ b/cameras/bosch/nbt-8701-f42vf.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nce-7703-fk.json
+++ b/cameras/bosch/nce-7703-fk.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndd-7802-al.json
+++ b/cameras/bosch/ndd-7802-al.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndd-7803-al.json
+++ b/cameras/bosch/ndd-7803-al.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-3503-f02.json
+++ b/cameras/bosch/nde-3503-f02.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-3702-al.json
+++ b/cameras/bosch/nde-3702-al.json
@@ -71,5 +71,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-3703-al-io.json
+++ b/cameras/bosch/nde-3703-al-io.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-3703-al.json
+++ b/cameras/bosch/nde-3703-al.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-5702-a.json
+++ b/cameras/bosch/nde-5702-a.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-5703-a.json
+++ b/cameras/bosch/nde-5703-a.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-5704-a.json
+++ b/cameras/bosch/nde-5704-a.json
@@ -78,5 +78,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-5704-al.json
+++ b/cameras/bosch/nde-5704-al.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8702-rx.json
+++ b/cameras/bosch/nde-8702-rx.json
@@ -80,5 +80,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8702-rxl.json
+++ b/cameras/bosch/nde-8702-rxl.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8702-rxt.json
+++ b/cameras/bosch/nde-8702-rxt.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-r.json
+++ b/cameras/bosch/nde-8703-r.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-rl.json
+++ b/cameras/bosch/nde-8703-rl.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-rt.json
+++ b/cameras/bosch/nde-8703-rt.json
@@ -97,5 +97,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-rx.json
+++ b/cameras/bosch/nde-8703-rx.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-rxl.json
+++ b/cameras/bosch/nde-8703-rxl.json
@@ -98,5 +98,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8703-rxt.json
+++ b/cameras/bosch/nde-8703-rxt.json
@@ -96,5 +96,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8704-r.json
+++ b/cameras/bosch/nde-8704-r.json
@@ -78,5 +78,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8704-rl.json
+++ b/cameras/bosch/nde-8704-rl.json
@@ -108,5 +108,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 3840,
+        "height": 2160,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8704-rt.json
+++ b/cameras/bosch/nde-8704-rt.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8704-rx.json
+++ b/cameras/bosch/nde-8704-rx.json
@@ -75,5 +75,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nde-8704-rxl.json
+++ b/cameras/bosch/nde-8704-rxl.json
@@ -94,5 +94,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndi-3702-a-io.json
+++ b/cameras/bosch/ndi-3702-a-io.json
@@ -94,5 +94,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndi-3702-a.json
+++ b/cameras/bosch/ndi-3702-a.json
@@ -74,5 +74,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndi-3702-al.json
+++ b/cameras/bosch/ndi-3702-al.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndi-3703-a.json
+++ b/cameras/bosch/ndi-3703-a.json
@@ -75,5 +75,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndi-3703-al.json
+++ b/cameras/bosch/ndi-3703-al.json
@@ -72,5 +72,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndm-7702-a.json
+++ b/cameras/bosch/ndm-7702-a.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndm-7702-al.json
+++ b/cameras/bosch/ndm-7702-al.json
@@ -103,5 +103,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndm-7703-a.json
+++ b/cameras/bosch/ndm-7703-a.json
@@ -103,5 +103,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 2560,
+        "height": 1440,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-5522-z30.json
+++ b/cameras/bosch/ndp-5522-z30.json
@@ -101,5 +101,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-5522-z30c.json
+++ b/cameras/bosch/ndp-5522-z30c.json
@@ -98,5 +98,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-5522-z30csurfacemount.json
+++ b/cameras/bosch/ndp-5522-z30csurfacemount.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-5522-z30l.json
+++ b/cameras/bosch/ndp-5522-z30l.json
@@ -107,5 +107,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-5533-z30l.json
+++ b/cameras/bosch/ndp-5533-z30l.json
@@ -100,5 +100,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-7802-z40.json
+++ b/cameras/bosch/ndp-7802-z40.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-7802-z40l.json
+++ b/cameras/bosch/ndp-7802-z40l.json
@@ -95,5 +95,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndp-7804-z12l.json
+++ b/cameras/bosch/ndp-7804-z12l.json
@@ -96,5 +96,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nds-5703-f360.json
+++ b/cameras/bosch/nds-5703-f360.json
@@ -96,5 +96,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 2112,
+        "height": 2112,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nds-5704-f360.json
+++ b/cameras/bosch/nds-5704-f360.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nds-5704-f360le.json
+++ b/cameras/bosch/nds-5704-f360le.json
@@ -105,5 +105,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-5702-a.json
+++ b/cameras/bosch/ndv-5702-a.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-5703-a.json
+++ b/cameras/bosch/ndv-5703-a.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-5704-a.json
+++ b/cameras/bosch/ndv-5704-a.json
@@ -84,5 +84,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-5704-al.json
+++ b/cameras/bosch/ndv-5704-al.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-8502-r.json
+++ b/cameras/bosch/ndv-8502-r.json
@@ -91,5 +91,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-8502-rx.json
+++ b/cameras/bosch/ndv-8502-rx.json
@@ -70,5 +70,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-8503-r.json
+++ b/cameras/bosch/ndv-8503-r.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-8503-rx.json
+++ b/cameras/bosch/ndv-8503-rx.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/ndv-8504-r.json
+++ b/cameras/bosch/ndv-8504-r.json
@@ -94,5 +94,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8000-f07qs.json
+++ b/cameras/bosch/nht-8000-f07qs.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8000-f19qf.json
+++ b/cameras/bosch/nht-8000-f19qf.json
@@ -92,5 +92,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8000-f19qs.json
+++ b/cameras/bosch/nht-8000-f19qs.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f09vf.json
+++ b/cameras/bosch/nht-8001-f09vf.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f09vs.json
+++ b/cameras/bosch/nht-8001-f09vs.json
@@ -86,5 +86,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f17vf.json
+++ b/cameras/bosch/nht-8001-f17vf.json
@@ -90,5 +90,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f35vf.json
+++ b/cameras/bosch/nht-8001-f35vf.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f65vf.json
+++ b/cameras/bosch/nht-8001-f65vf.json
@@ -77,5 +77,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nht-8001-f65vs.json
+++ b/cameras/bosch/nht-8001-f65vs.json
@@ -87,5 +87,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nmm-7703-a.json
+++ b/cameras/bosch/nmm-7703-a.json
@@ -35,5 +35,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3702-f02.json
+++ b/cameras/bosch/nue-3702-f02.json
@@ -86,5 +86,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3702-f04.json
+++ b/cameras/bosch/nue-3702-f04.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3702-f06.json
+++ b/cameras/bosch/nue-3702-f06.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3703-f02.json
+++ b/cameras/bosch/nue-3703-f02.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3703-f04.json
+++ b/cameras/bosch/nue-3703-f04.json
@@ -76,5 +76,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nue-3703-f06.json
+++ b/cameras/bosch/nue-3703-f06.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3702-f02.json
+++ b/cameras/bosch/nuv-3702-f02.json
@@ -85,5 +85,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3702-f04.json
+++ b/cameras/bosch/nuv-3702-f04.json
@@ -84,5 +84,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3702-f04h.json
+++ b/cameras/bosch/nuv-3702-f04h.json
@@ -89,5 +89,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3702-f06.json
+++ b/cameras/bosch/nuv-3702-f06.json
@@ -82,5 +82,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3703-f02.json
+++ b/cameras/bosch/nuv-3703-f02.json
@@ -71,5 +71,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3703-f02h.json
+++ b/cameras/bosch/nuv-3703-f02h.json
@@ -83,5 +83,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3703-f04.json
+++ b/cameras/bosch/nuv-3703-f04.json
@@ -79,5 +79,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/cameras/bosch/nuv-3703-f06.json
+++ b/cameras/bosch/nuv-3703-f06.json
@@ -88,5 +88,25 @@
   "markets": [
     "EU",
     "global"
-  ]
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+    }
+  }
 }

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -5,7 +5,7 @@ abus-hdcc75550,ABUS,HDCC75550,dome,5MP,5,"1/2.7\"" Progressive Scan CMOS",92 to 
 abus-ipca34512a,ABUS,IPCA34512A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,false,
 abus-ipca34512b,ABUS,IPCA34512B,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","89 horizontal, 45 vertical",hybrid,IP67,false,
 abus-ipca34612a,ABUS,IPCA34612A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,false,
-abus-ipca54512a,ABUS,IPCA54512A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",110 horizontal,hybrid,IP67,false,
+abus-ipca54512a,ABUS,IPCA54512A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",110 horizontal / 57 vertical,hybrid,IP67,false,
 abus-ipca54512b,ABUS,IPCA54512B,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",95 horizontal,hybrid,IP67,false,2023
 abus-ipca54572a,ABUS,IPCA54572A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",110 horizontal,hybrid,IP67,true,
 abus-ipca54581b,ABUS,IPCA54581B,dome,4MP,4,"1/2.7"" Progressive Scan CMOS","84 horizontal / 43 vertical (optical), 50 horizontal (thermal)",ir,IP66,true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -289,7 +289,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca34512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-Black-2.8-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca34512b",
@@ -377,7 +397,27 @@
       "https://www.expert-security.de/abus-ipca34512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-mini-tube-4-MPx-4-mm-IR-WL",
       "https://alarm-technik.eu/en/products/ip-mini-tube-4-mpx-4-mm-ir-wl-abus-ipca34512b"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca34612a",
@@ -462,7 +502,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca34612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.voltus.com/en/abus-ipca34612a-ip-mini-tube-4-mp-ir-wl-sw-2-8-mm.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54512a",
@@ -514,7 +574,7 @@
       "aperture": "F1.0",
       "varifocal": false
     },
-    "field_of_view_deg": "110 horizontal",
+    "field_of_view_deg": "110 horizontal / 57 vertical",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
@@ -559,8 +619,29 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-2-8-mm-ir-wl-abus-ipca54512a",
-      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm",
+      "https://firstmall.de/ABUS-IPCA54512A-Kugeldome-Kamera-IP-4-MPx-28-mm-IR-WL-PoE-Ueberwachungskamera"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — uses Hikvision-style RTSP paths (Channels/101 main, /102 sub, /103 third). ONVIF/RTSP must be enabled in the camera web UI (Network > Integration Protocol) first. Pattern inferred from sibling IPCB/IPCA models (iSpyConnect, HA community); not individually verified on this exact model."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Use the generic ONVIF integration after enabling ONVIF (Profile S) in the camera web UI. No ABUS-specific HA integration for the Performance Line."
+      }
+    }
   },
   {
     "id": "abus-ipca54512b",
@@ -653,7 +734,27 @@
       "https://www.solarics.de/products/abus-abus-ipca54512a-ip-kugeldome-4-mpx-2-8-mm-ir-wl-art-ipca54512a",
       "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-4-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54572a",
@@ -737,7 +838,27 @@
       "https://www.expert-security.de/abus-ipca54572a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://firstmall.de/ABUS-IPCA54572A-IP-Kamera-Kugeldome-4-MPx-IR-WL-mit-2WAY-Audio-Alarmierung",
       "https://fr.rs-online.com/web/p/videosurveillance-cameras/0180161"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54581b",
@@ -815,7 +936,27 @@
       "https://www.expert-security.de/abus-ipca54581b-ip-thermal-kamera-4mpx.html",
       "https://alarm-technik.eu/en/products/thermal-dome-bi-spektral-4mpx-3-6-4-3-mm-abus-ipca54581b",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Dome-Bi-Spectral-4MPx-3.6-4.3-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54612a",
@@ -902,7 +1043,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca54612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca54612a"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64512a",
@@ -989,7 +1150,27 @@
       "https://www.expert-security.de/abus-ipca64512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64512b",
@@ -1085,7 +1266,27 @@
       "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-4-mm-ir-wl-abus-ipca64512b",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64581d",
@@ -1172,7 +1373,27 @@
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Tube-Bi-Spectral-4MPx-9.7-8-mm",
       "https://www.rexel.de/p/5075504",
       "https://www.alarm-laden.de/Thermal-Tube-Bi-Spektral-4MPx-97-8-mm-IPCA64581D"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64612a",
@@ -1280,7 +1501,27 @@
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca64612a",
       "https://www.expert-security.de/abus-ip-kameras.html",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Tube-4-MPx-Schwarz-2.8-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34511a",
@@ -1366,7 +1607,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb34511a-ip-bullet-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34511b",
@@ -1466,7 +1727,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-ipcb34511b-ip-bullet-4mpx-t-n-ir-poe-ip67.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34611a",
@@ -1562,7 +1843,27 @@
       "https://www.expert-security.de/abus-ipcb34611a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.jvsg.com/cameras/abus/IPCB34611A/reolink/E1_Pro/",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Mini-Tube-4-MPx-Schwarz-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb38511a",
@@ -1662,7 +1963,27 @@
       "https://www.expert-security.de/abus-ipcb38511a-ip-bullet-4k-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-mini-tube-8-mpx-4k-2-8-mm-abus-ipcb38511a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-8-MPx-4K-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb38511b",
@@ -1740,7 +2061,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb38511b-ip-bullet-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Tube/IP-Mini-Tube-8-MPx-4K-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44510a",
@@ -1809,7 +2150,27 @@
       "https://www.singular.com.cy/abus-ipcb44510a-network-surveillance-camera-dome-outdoor-indoor-vandal-poe.html",
       "https://www.abus.com/eng/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-2.8-mm",
       "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44510c",
@@ -1889,7 +2250,27 @@
       "https://geizhals.de/abus-ip-mini-dome-4-mpx-ipcb44510c-a2135825.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-6-mm",
       "https://www.testbericht.de/produkte/abus-ipcb44510c"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44511a",
@@ -1981,7 +2362,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44511a-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44511b",
@@ -2071,7 +2472,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44561a",
@@ -2149,7 +2570,27 @@
       "https://www.expert-security.de/abus-ipcb44561a-ip-dome-4mpx-t-n-ir-poe-wlan-ip67.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-Wi-Fi-4-MPx-2.8mm",
       "https://alarm-technik.eu/en/products/ip-mini-dome-wlan-4-mpx-2-8-mm-abus-ipcb44561a"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44611a",
@@ -2227,7 +2668,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44611a-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44611b",
@@ -2327,7 +2788,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44611b-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54511a",
@@ -2418,7 +2899,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb54511a-ip-dome-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54511b",
@@ -2504,7 +3005,27 @@
       "https://www.expert-security.de/abus-ipcb54511b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-4-mm-ABUS-IPCB54511B",
       "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Aussendome/IP-Kugeldome-4-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54611b",
@@ -2583,7 +3104,27 @@
       "https://www.expert-security.de/abus-ipcb54611b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-4-mm-abus-ipcb54611b",
       "https://c4.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Spherical-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58511a",
@@ -2684,7 +3225,27 @@
       "https://www.expert-security.de/abus-ipcb58511a-ip-dome-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728613"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58511b",
@@ -2776,7 +3337,27 @@
       "https://www.expert-security.de/abus-ipcb58511b-ip-dome-4k-t-n-ir-poe-ip67.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-8-MPx-4-mm-ABUS-IPCB58511B",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Kugeldome-8-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58611a",
@@ -2864,7 +3445,27 @@
       "https://alarm-technik.eu/en/products/ip-kugeldome-8-mpx-2-8-mm-abus-ipcb58611a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/26/20211027-IPCB5xx11AB_INST_DE_GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb64521",
@@ -2965,7 +3566,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb64521-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://geizhals.de/abus-ip-mini-tube-4-mpx-2-8-12mm-ipcb64521-a2731457.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb64621",
@@ -3046,7 +3667,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb64621-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728616"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb68521",
@@ -3150,7 +3791,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-ipcb68521-ip-tube-4k-t-n-ir-poe-ip67-ik10.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb68621",
@@ -3232,7 +3893,27 @@
       "https://alarm-technik.eu/en/products/ip-tube-8-mpx-4k-2-8-12mm-abus-ipcb68621",
       "https://www.abus.com/uk/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-8-MPx-Black-2.8-12mm",
       "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211027-IPCB6xx21_INST_DE_UK.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb74521",
@@ -3336,7 +4017,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb74521-ip-dome-ir-4mpx-t-n-poe-ip67-ik10.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-4-MPX-2.8-12-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb78521",
@@ -3419,7 +4120,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb78521-ip-dome-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-8-MPx-2.8-12mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs28581a",
@@ -3510,7 +4231,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs28581a-ip-kamera-4k-tag-nacht-ip67.html",
       "https://www.alarm-technik.eu/IP-Panorama-Dome-8-MPx-1800-WL-ABUS-IPCS28581A"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs29512",
@@ -3616,7 +4357,27 @@
       "https://www.expert-security.de/abus-ipcs29512-ip-kamera-12mpx-t-n-ir-ip67-ik10.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-12-MPx2",
       "https://alarm-technik.eu/en/products/12-mpx-ip-fisheye-kamera-abus-ipcs29512"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 3072,
+          "height": 2304,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs34611a",
@@ -3716,7 +4477,27 @@
       "https://www.rapidonline.com/abus-ipcs34611a-cctv-camera-4mp-day-night-ip67-mobile-access-poe-01-0215",
       "https://www.alarm-technik.eu/IP-Mini-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS34611A",
       "https://www.ispyconnect.com/camera/abus"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54511a",
@@ -3793,7 +4574,27 @@
       "https://geizhals.de/abus-ip-dome-kamera-4-mpx-2-8mm-ipcs54511a-a3394077.html",
       "https://www.testbericht.de/produkte/abus-ipcs54511a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8-mm-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54511b",
@@ -3878,7 +4679,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs54511b-ip-dome-4mp-t-n-weisslicht-poe-ip67.html",
       "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211208-IPCS54511AB_INST_DE_GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54611a",
@@ -3974,7 +4795,27 @@
       "https://www.expert-security.de/abus-ipcs54611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-2.8-mm-WL-ABUS-IPCS54611A",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728628"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs58571a",
@@ -4071,7 +4912,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs58571a-ip-kamera-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/fr/Securite-des-batiments/Videosurveillance/IP/Cameras/Camera-exterieure-dome/Dome-spherique-IP-8-MPx-2-8-mm-avec-audio-2WAY-alarme"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64511b",
@@ -4166,7 +5027,27 @@
       "https://www.expert-security.de/abus-ipcs64511b-ip-bullet-4mpx-t-n-weisslicht-poe.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-WL",
       "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-4-mm-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64531",
@@ -4251,7 +5132,27 @@
       "https://www.expert-security.de/abus-ipcs64531-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-2-8-12-mm-kennzeichen-anpr-abus-ipcs64531",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-12-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64541",
@@ -4354,7 +5255,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs64541-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPX-Tele-Motorzoom-4.7-118-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2688,
+          "height": 1520,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64611a",
@@ -4426,7 +5347,27 @@
       "https://www.expert-security.de/abus-ipcs64611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
       "https://www.alarm-technik.eu/IP-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS64611A",
       "https://uk.rs-online.com/web/p/cctv-cameras/2728634"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs74511a",
@@ -4502,7 +5443,27 @@
       "https://firstmall.de/abus-ip-dome-4mpx-2-8mm-hdmi-poe-ueberwachungskamera",
       "https://www.manualslib.com/manual/4025987/Abus-Ipcs74511a.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Dome-4MPx-2.8mm-with-HDMI-port"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84511",
@@ -4598,7 +5559,27 @@
       "https://www.expert-security.de/abus-ipcs84511-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/PTZ/IP-Mini-PTZ-4-MPx-4x",
       "https://www.zajadacz.de/ABUS-IP-Mini-PTZ-4-MPx-4x-IPCS84511.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84532",
@@ -4681,7 +5662,27 @@
       "https://www.expert-security.de/abus-ipcs84532-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84532",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/30/20240508-IPCS84532_BDA_INT.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84551",
@@ -4794,7 +5795,27 @@
       "https://www.expert-security.de/abus-ipcs84551-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://alarm-technik.eu/en/products/ip-ptz-dome-4-mpx-32x-abus-ipcs84551",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-PTZ-Dome-4-MPx-32x"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ppic31020",
@@ -5737,7 +6758,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-tvip42510-ip-kamera-1080p-tn-ir-poe-ip67.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip42520",
@@ -6011,7 +7052,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip44510-ip-kamera-1440p-tn-ir-poe-ip67-ik10.html",
       "https://www.abus.com/int/abusproductsheet.pdf/191285/eng-ZZ"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip44511",
@@ -6102,7 +7163,27 @@
       "https://www.expert-security.de/abus-tvip44511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://www.sotel.co.uk/en/Computer-Drucker/Smart-Home/Haussteuerung/Alarmanlagen/ABUS-TVIP44511-security-camera-Dome-IP-security-camera-Indoor-outdoor-2688-x-1520-pixels-Ceiling.html",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-mini-dome-4-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip48511",
@@ -6206,7 +7287,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip48511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/int/abusproductsheet.pdf/264068/eng-ZZ"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip62510",
@@ -6296,7 +7397,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip62510-ip-kamera-1080p-t-n-ir-poe-ip67.html",
       "https://www.abus.com/at/Sicherheit-Zuhause/Videoueberwachung/Ueberwachungskameras/Aussenkameras/2MPx-IP-PoE-Mini-Tube-kamera"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip62562",
@@ -6462,7 +7583,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip64511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/27/20230119-TVIP6x511_INST_DE-GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip68511",
@@ -6545,7 +7686,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip68511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.alarm-technik.eu/en/products/ip-8mpx-poe-mini-tube-kamera-abus-tvip68511"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip82561",
@@ -6626,7 +7787,27 @@
       "https://www.expert-security.de/abus-tvip82561-ip-kamera-1080p-t-n-ir-ptz-poe-ip66.html",
       "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
       "https://www.abus.com/int/Consumer/Video-surveillance/Systems-from-the-expert/Cameras/ABUS-IP-video-surveillance-2MPx-Wi-Fi-PTZ-dome-camera"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "acti-a416",
@@ -21948,7 +23129,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-flexidome-5100i-mena",
@@ -22235,7 +23436,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7504-z12gr",
@@ -22314,7 +23535,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7504-z12wr",
@@ -22420,7 +23661,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30b",
@@ -22526,7 +23787,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30br",
@@ -22635,7 +23916,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30g",
@@ -22736,7 +24037,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30gr",
@@ -22821,7 +24142,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30w",
@@ -22924,7 +24265,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30wr",
@@ -23018,7 +24379,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bqs",
@@ -23111,7 +24492,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvf",
@@ -23216,7 +24617,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvf9",
@@ -23319,7 +24740,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvs",
@@ -23411,7 +24852,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvs9",
@@ -23521,7 +24982,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gqs",
@@ -23622,7 +25103,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gvf",
@@ -23734,7 +25235,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gvf9",
@@ -23833,7 +25354,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wqs",
@@ -23923,7 +25464,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvf",
@@ -24015,7 +25576,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvf9",
@@ -24098,7 +25679,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvs",
@@ -24208,7 +25809,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvs9",
@@ -24315,7 +25936,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b06v",
@@ -24410,7 +26051,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b14v",
@@ -24502,7 +26163,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b18q",
@@ -24593,7 +26274,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b42v",
@@ -24686,7 +26387,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g06v",
@@ -24775,7 +26496,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g14v",
@@ -24859,7 +26600,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g18q",
@@ -24940,7 +26701,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g42v",
@@ -25038,7 +26819,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w06v",
@@ -25118,7 +26919,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w14v",
@@ -25205,7 +27026,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w18q",
@@ -25299,7 +27140,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w42v",
@@ -25393,7 +27254,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-3702-al",
@@ -25477,7 +27358,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-3703-al",
@@ -25556,7 +27457,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-5702-al",
@@ -25820,7 +27741,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7702-alx",
@@ -25921,7 +27862,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7702-alxt",
@@ -26190,7 +28151,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7703-alxt",
@@ -26270,7 +28251,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-al",
@@ -26354,7 +28355,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-alt",
@@ -26451,7 +28472,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-alx",
@@ -26551,7 +28592,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7802-ax",
@@ -26646,7 +28707,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7802-axt",
@@ -26731,7 +28812,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803-ax",
@@ -26821,7 +28922,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803-axt",
@@ -26909,7 +29030,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803s-ax",
@@ -27004,7 +29145,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803s-axt",
@@ -27089,7 +29250,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-63023-b",
@@ -27182,7 +29363,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-73023-ba",
@@ -27275,7 +29476,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-9122-p",
@@ -27449,7 +29670,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f05qf",
@@ -27545,7 +29786,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f09qf",
@@ -27642,7 +29903,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f18qf",
@@ -27741,7 +30022,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f06vf",
@@ -27827,7 +30128,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f14vf",
@@ -27927,7 +30248,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f25vf",
@@ -28028,7 +30369,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f42vf",
@@ -28114,7 +30475,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nce-7703-fk",
@@ -28198,7 +30579,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndc-8502-r-ooh",
@@ -28372,7 +30773,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndd-7803-al",
@@ -28466,7 +30887,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3503-f02",
@@ -28561,7 +31002,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3702-al",
@@ -28636,7 +31097,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3703-al",
@@ -28716,7 +31197,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3703-al-io",
@@ -28808,7 +31309,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5503-al",
@@ -28976,7 +31497,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5702-al",
@@ -29152,7 +31693,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5703-al",
@@ -29316,7 +31877,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5704-al",
@@ -29400,7 +31981,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-7703-al",
@@ -29733,7 +32334,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8702-rxl",
@@ -29813,7 +32434,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8702-rxt",
@@ -29904,7 +32545,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-r",
@@ -30005,7 +32666,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rl",
@@ -30091,7 +32772,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rt",
@@ -30192,7 +32893,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rx",
@@ -30286,7 +33007,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rxl",
@@ -30388,7 +33129,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rxt",
@@ -30488,7 +33249,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-r",
@@ -30570,7 +33351,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rl",
@@ -30682,7 +33483,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 3840,
+          "height": 2160,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rt",
@@ -30768,7 +33589,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rx",
@@ -30847,7 +33688,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rxl",
@@ -30945,7 +33806,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-a",
@@ -31023,7 +33904,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-a-io",
@@ -31121,7 +34022,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-al",
@@ -31212,7 +34133,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3703-a",
@@ -31291,7 +34232,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3703-al",
@@ -31367,7 +34328,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7702-a",
@@ -31453,7 +34434,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7702-al",
@@ -31560,7 +34561,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7703-a",
@@ -31667,7 +34688,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2560,
+          "height": 1440,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7703-al",
@@ -31850,7 +34891,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30c",
@@ -31952,7 +35013,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30csurfacemount",
@@ -32047,7 +35128,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30l",
@@ -32158,7 +35259,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5533-z30l",
@@ -32262,7 +35383,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7802-z40",
@@ -32356,7 +35497,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7802-z40l",
@@ -32455,7 +35616,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7804-z12l",
@@ -32555,7 +35736,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5703-f360",
@@ -32655,7 +35856,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2112,
+          "height": 2112,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5703-f360le",
@@ -32812,7 +36033,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5704-f360le",
@@ -32921,7 +36162,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5702-a",
@@ -33016,7 +36277,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5702-al",
@@ -33185,7 +36466,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5703-al",
@@ -33355,7 +36656,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5704-al",
@@ -33447,7 +36768,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8502-r",
@@ -33542,7 +36883,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8502-rx",
@@ -33616,7 +36977,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8503-r",
@@ -33710,7 +37091,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8503-rx",
@@ -33801,7 +37202,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8504-r",
@@ -33899,7 +37320,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f07qs",
@@ -33988,7 +37429,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f19qf",
@@ -34084,7 +37545,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f19qs",
@@ -34164,7 +37645,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f09vf",
@@ -34255,7 +37756,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f09vs",
@@ -34345,7 +37866,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f17vf",
@@ -34439,7 +37980,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f35vf",
@@ -34526,7 +38087,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f65vf",
@@ -34607,7 +38188,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f65vs",
@@ -34698,7 +38299,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nmm-7703-a",
@@ -34737,7 +38358,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nmm-7703-al",
@@ -35028,7 +38669,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3702-f04",
@@ -35117,7 +38778,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3702-f06",
@@ -35206,7 +38887,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-al",
@@ -35375,7 +39076,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-f04",
@@ -35455,7 +39176,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-f06",
@@ -35542,7 +39283,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f02",
@@ -35631,7 +39392,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f04",
@@ -35719,7 +39500,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f04h",
@@ -35812,7 +39613,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f06",
@@ -35898,7 +39719,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f02",
@@ -35973,7 +39814,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f02h",
@@ -36060,7 +39921,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f04",
@@ -36143,7 +40024,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f06",
@@ -36235,7 +40136,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-smart-home-outdoor-cam-2",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -289,7 +289,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca34512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-Black-2.8-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca34512b",
@@ -377,7 +397,27 @@
       "https://www.expert-security.de/abus-ipca34512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-mini-tube-4-MPx-4-mm-IR-WL",
       "https://alarm-technik.eu/en/products/ip-mini-tube-4-mpx-4-mm-ir-wl-abus-ipca34512b"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca34612a",
@@ -462,7 +502,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca34612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.voltus.com/en/abus-ipca34612a-ip-mini-tube-4-mp-ir-wl-sw-2-8-mm.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54512a",
@@ -514,7 +574,7 @@
       "aperture": "F1.0",
       "varifocal": false
     },
-    "field_of_view_deg": "110 horizontal",
+    "field_of_view_deg": "110 horizontal / 57 vertical",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
@@ -559,8 +619,29 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-2-8-mm-ir-wl-abus-ipca54512a",
-      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm",
+      "https://firstmall.de/ABUS-IPCA54512A-Kugeldome-Kamera-IP-4-MPx-28-mm-IR-WL-PoE-Ueberwachungskamera"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — uses Hikvision-style RTSP paths (Channels/101 main, /102 sub, /103 third). ONVIF/RTSP must be enabled in the camera web UI (Network > Integration Protocol) first. Pattern inferred from sibling IPCB/IPCA models (iSpyConnect, HA community); not individually verified on this exact model."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Use the generic ONVIF integration after enabling ONVIF (Profile S) in the camera web UI. No ABUS-specific HA integration for the Performance Line."
+      }
+    }
   },
   {
     "id": "abus-ipca54512b",
@@ -653,7 +734,27 @@
       "https://www.solarics.de/products/abus-abus-ipca54512a-ip-kugeldome-4-mpx-2-8-mm-ir-wl-art-ipca54512a",
       "https://www.expert-security.de/abus-ipca54512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-4-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54572a",
@@ -737,7 +838,27 @@
       "https://www.expert-security.de/abus-ipca54572a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://firstmall.de/ABUS-IPCA54572A-IP-Kamera-Kugeldome-4-MPx-IR-WL-mit-2WAY-Audio-Alarmierung",
       "https://fr.rs-online.com/web/p/videosurveillance-cameras/0180161"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54581b",
@@ -815,7 +936,27 @@
       "https://www.expert-security.de/abus-ipca54581b-ip-thermal-kamera-4mpx.html",
       "https://alarm-technik.eu/en/products/thermal-dome-bi-spektral-4mpx-3-6-4-3-mm-abus-ipca54581b",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Dome-Bi-Spectral-4MPx-3.6-4.3-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca54612a",
@@ -902,7 +1043,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipca54612a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca54612a"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64512a",
@@ -989,7 +1150,27 @@
       "https://www.expert-security.de/abus-ipca64512a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64512b",
@@ -1085,7 +1266,27 @@
       "https://www.expert-security.de/abus-ipca64512b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-4-mm-ir-wl-abus-ipca64512b",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64581d",
@@ -1172,7 +1373,27 @@
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Thermal-Tube-Bi-Spectral-4MPx-9.7-8-mm",
       "https://www.rexel.de/p/5075504",
       "https://www.alarm-laden.de/Thermal-Tube-Bi-Spektral-4MPx-97-8-mm-IPCA64581D"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipca64612a",
@@ -1280,7 +1501,27 @@
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-schwarz-2-8-mm-ir-wl-abus-ipca64612a",
       "https://www.expert-security.de/abus-ip-kameras.html",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Tube-4-MPx-Schwarz-2.8-mm-IR-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34511a",
@@ -1366,7 +1607,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb34511a-ip-bullet-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34511b",
@@ -1466,7 +1727,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-ipcb34511b-ip-bullet-4mpx-t-n-ir-poe-ip67.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb34611a",
@@ -1562,7 +1843,27 @@
       "https://www.expert-security.de/abus-ipcb34611a-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://www.jvsg.com/cameras/abus/IPCB34611A/reolink/E1_Pro/",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Mini-Tube-4-MPx-Schwarz-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb38511a",
@@ -1662,7 +1963,27 @@
       "https://www.expert-security.de/abus-ipcb38511a-ip-bullet-4k-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-mini-tube-8-mpx-4k-2-8-mm-abus-ipcb38511a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Tube-8-MPx-4K-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb38511b",
@@ -1740,7 +2061,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb38511b-ip-bullet-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Tube/IP-Mini-Tube-8-MPx-4K-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44510a",
@@ -1809,7 +2150,27 @@
       "https://www.singular.com.cy/abus-ipcb44510a-network-surveillance-camera-dome-outdoor-indoor-vandal-poe.html",
       "https://www.abus.com/eng/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-2.8-mm",
       "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44510c",
@@ -1889,7 +2250,27 @@
       "https://geizhals.de/abus-ip-mini-dome-4-mpx-ipcb44510c-a2135825.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-6-mm",
       "https://www.testbericht.de/produkte/abus-ipcb44510c"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44511a",
@@ -1981,7 +2362,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44511a-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44511b",
@@ -2071,7 +2472,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44511b-ip-dome-4mpx-t-n-ir-poe-ip67-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44561a",
@@ -2149,7 +2570,27 @@
       "https://www.expert-security.de/abus-ipcb44561a-ip-dome-4mpx-t-n-ir-poe-wlan-ip67.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-Wi-Fi-4-MPx-2.8mm",
       "https://alarm-technik.eu/en/products/ip-mini-dome-wlan-4-mpx-2-8-mm-abus-ipcb44561a"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44611a",
@@ -2227,7 +2668,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44611a-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Mini-Dome-4-MPx-Black-2.8-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb44611b",
@@ -2327,7 +2788,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb44611b-ip-dome-4mpx-t-n-ir-poe-ip66-ik08.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Indoor-dome/IP-Mini-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54511a",
@@ -2418,7 +2899,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb54511a-ip-dome-4mpx-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54511b",
@@ -2504,7 +3005,27 @@
       "https://www.expert-security.de/abus-ipcb54511b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-4-mm-ABUS-IPCB54511B",
       "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Aussendome/IP-Kugeldome-4-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb54611b",
@@ -2583,7 +3104,27 @@
       "https://www.expert-security.de/abus-ipcb54611b-ip-kamera-4mpx-t-n-ir-poe-ip67.html",
       "https://alarm-technik.eu/en/products/ip-kugeldome-4-mpx-4-mm-abus-ipcb54611b",
       "https://c4.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Spherical-Dome-4-MPx-Black-4mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58511a",
@@ -2684,7 +3225,27 @@
       "https://www.expert-security.de/abus-ipcb58511a-ip-dome-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728613"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58511b",
@@ -2776,7 +3337,27 @@
       "https://www.expert-security.de/abus-ipcb58511b-ip-dome-4k-t-n-ir-poe-ip67.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-8-MPx-4-mm-ABUS-IPCB58511B",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-Kugeldome-8-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb58611a",
@@ -2864,7 +3445,27 @@
       "https://alarm-technik.eu/en/products/ip-kugeldome-8-mpx-2-8-mm-abus-ipcb58611a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-8-MPx-2.8mm",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/26/20211027-IPCB5xx11AB_INST_DE_GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb64521",
@@ -2965,7 +3566,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb64521-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://geizhals.de/abus-ip-mini-tube-4-mpx-2-8-12mm-ipcb64521-a2731457.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb64621",
@@ -3046,7 +3667,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb64621-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728616"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb68521",
@@ -3150,7 +3791,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-ipcb68521-ip-tube-4k-t-n-ir-poe-ip67-ik10.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb68621",
@@ -3232,7 +3893,27 @@
       "https://alarm-technik.eu/en/products/ip-tube-8-mpx-4k-2-8-12mm-abus-ipcb68621",
       "https://www.abus.com/uk/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-8-MPx-Black-2.8-12mm",
       "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211027-IPCB6xx21_INST_DE_UK.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb74521",
@@ -3336,7 +4017,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb74521-ip-dome-ir-4mpx-t-n-poe-ip67-ik10.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-4-MPX-2.8-12-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcb78521",
@@ -3419,7 +4120,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcb78521-ip-dome-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/eng/Commercial-Security/Video-Surveillance/IP/Cameras/Outdoor-dome/IP-Dome-8-MPx-2.8-12mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs28581a",
@@ -3510,7 +4231,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs28581a-ip-kamera-4k-tag-nacht-ip67.html",
       "https://www.alarm-technik.eu/IP-Panorama-Dome-8-MPx-1800-WL-ABUS-IPCS28581A"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs29512",
@@ -3616,7 +4357,27 @@
       "https://www.expert-security.de/abus-ipcs29512-ip-kamera-12mpx-t-n-ir-ip67-ik10.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-12-MPx2",
       "https://alarm-technik.eu/en/products/12-mpx-ip-fisheye-kamera-abus-ipcs29512"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 3072,
+          "height": 2304,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs34611a",
@@ -3716,7 +4477,27 @@
       "https://www.rapidonline.com/abus-ipcs34611a-cctv-camera-4mp-day-night-ip67-mobile-access-poe-01-0215",
       "https://www.alarm-technik.eu/IP-Mini-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS34611A",
       "https://www.ispyconnect.com/camera/abus"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54511a",
@@ -3793,7 +4574,27 @@
       "https://geizhals.de/abus-ip-dome-kamera-4-mpx-2-8mm-ipcs54511a-a3394077.html",
       "https://www.testbericht.de/produkte/abus-ipcs54511a",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Spherical-Dome-4-MPx-2.8-mm-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54511b",
@@ -3878,7 +4679,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs54511b-ip-dome-4mp-t-n-weisslicht-poe-ip67.html",
       "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/26/20211208-IPCS54511AB_INST_DE_GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs54611a",
@@ -3974,7 +4795,27 @@
       "https://www.expert-security.de/abus-ipcs54611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
       "https://www.alarm-technik.eu/IP-Kugeldome-4-MPx-2.8-mm-WL-ABUS-IPCS54611A",
       "https://de.rs-online.com/web/p/uberwachungskamera/2728628"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs58571a",
@@ -4071,7 +4912,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs58571a-ip-kamera-4k-t-n-ir-poe-ip67.html",
       "https://www.abus.com/fr/Securite-des-batiments/Videosurveillance/IP/Cameras/Camera-exterieure-dome/Dome-spherique-IP-8-MPx-2-8-mm-avec-audio-2WAY-alarme"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64511b",
@@ -4166,7 +5027,27 @@
       "https://www.expert-security.de/abus-ipcs64511b-ip-bullet-4mpx-t-n-weisslicht-poe.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-tube-4-MPx-4-mm-WL",
       "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-4-mm-WL"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64531",
@@ -4251,7 +5132,27 @@
       "https://www.expert-security.de/abus-ipcs64531-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://alarm-technik.eu/en/products/ip-tube-4-mpx-2-8-12-mm-kennzeichen-anpr-abus-ipcs64531",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-12-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64541",
@@ -4354,7 +5255,27 @@
     "sources": [
       "https://www.expert-security.de/abus-ipcs64541-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPX-Tele-Motorzoom-4.7-118-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2688,
+          "height": 1520,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs64611a",
@@ -4426,7 +5347,27 @@
       "https://www.expert-security.de/abus-ipcs64611a-ip-kamera-4mpx-t-n-weisslicht-poe.html",
       "https://www.alarm-technik.eu/IP-Tube-4-MPx-2.8-mm-WL-schwarz-ABUS-IPCS64611A",
       "https://uk.rs-online.com/web/p/cctv-cameras/2728634"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs74511a",
@@ -4502,7 +5443,27 @@
       "https://firstmall.de/abus-ip-dome-4mpx-2-8mm-hdmi-poe-ueberwachungskamera",
       "https://www.manualslib.com/manual/4025987/Abus-Ipcs74511a.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Dome-4MPx-2.8mm-with-HDMI-port"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84511",
@@ -4598,7 +5559,27 @@
       "https://www.expert-security.de/abus-ipcs84511-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://www.abus.com/uk/Commercial-Security/Video-Surveillance/IP/Cameras/PTZ/IP-Mini-PTZ-4-MPx-4x",
       "https://www.zajadacz.de/ABUS-IP-Mini-PTZ-4-MPx-4x-IPCS84511.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84532",
@@ -4681,7 +5662,27 @@
       "https://www.expert-security.de/abus-ipcs84532-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84532",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/30/20240508-IPCS84532_BDA_INT.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ipcs84551",
@@ -4794,7 +5795,27 @@
       "https://www.expert-security.de/abus-ipcs84551-ip-dome-4mpx-t-n-ir-ptz-poe-ip66.html",
       "https://alarm-technik.eu/en/products/ip-ptz-dome-4-mpx-32x-abus-ipcs84551",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-PTZ-Dome-4-MPx-32x"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-ppic31020",
@@ -5737,7 +6758,27 @@
     ],
     "sources": [
       "https://www.expert-security.de/abus-tvip42510-ip-kamera-1080p-tn-ir-poe-ip67.html"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip42520",
@@ -6011,7 +7052,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip44510-ip-kamera-1440p-tn-ir-poe-ip67-ik10.html",
       "https://www.abus.com/int/abusproductsheet.pdf/191285/eng-ZZ"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip44511",
@@ -6102,7 +7163,27 @@
       "https://www.expert-security.de/abus-tvip44511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://www.sotel.co.uk/en/Computer-Drucker/Smart-Home/Haussteuerung/Alarmanlagen/ABUS-TVIP44511-security-camera-Dome-IP-security-camera-Indoor-outdoor-2688-x-1520-pixels-Ceiling.html",
       "https://www.abus.com/de/Gewerbe/Videoueberwachung/Netzwerktechnik/IP-mini-dome-4-MPx-4-mm"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip48511",
@@ -6206,7 +7287,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip48511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.abus.com/int/abusproductsheet.pdf/264068/eng-ZZ"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip62510",
@@ -6296,7 +7397,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip62510-ip-kamera-1080p-t-n-ir-poe-ip67.html",
       "https://www.abus.com/at/Sicherheit-Zuhause/Videoueberwachung/Ueberwachungskameras/Aussenkameras/2MPx-IP-PoE-Mini-Tube-kamera"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip62562",
@@ -6462,7 +7583,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip64511-ip-kamera-4mpx-t-n-ir-poe-ip67-ik10.html",
       "https://c1.abus.com/asc-pim-assets-01/medias/docus/27/20230119-TVIP6x511_INST_DE-GB.pdf"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip68511",
@@ -6545,7 +7686,27 @@
     "sources": [
       "https://www.expert-security.de/abus-tvip68511-ip-kamera-4k-t-n-ir-poe-ip67-ik10.html",
       "https://www.alarm-technik.eu/en/products/ip-8mpx-poe-mini-tube-kamera-abus-tvip68511"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "abus-tvip82561",
@@ -6626,7 +7787,27 @@
       "https://www.expert-security.de/abus-tvip82561-ip-kamera-1080p-t-n-ir-ptz-poe-ip66.html",
       "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
       "https://www.abus.com/int/Consumer/Video-surveillance/Systems-from-the-expert/Cameras/ABUS-IP-video-surveillance-2MPx-Wi-Fi-PTZ-dome-camera"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS TVIP Performance Line is Hikvision OEM (TVIP82561 shares an ABUS manual with the IPCS84511) — Hikvision-style RTSP paths (101 main / 102 sub / 103 third); /ch1/main also accepted. Enable ONVIF/RTSP + create an ONVIF user in the web UI first. Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (create a dedicated ONVIF user) in the web UI."
+      }
+    }
   },
   {
     "id": "acti-a416",
@@ -21948,7 +23129,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-flexidome-5100i-mena",
@@ -22235,7 +23436,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7504-z12gr",
@@ -22314,7 +23535,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7504-z12wr",
@@ -22420,7 +23661,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30b",
@@ -22526,7 +23787,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30br",
@@ -22635,7 +23916,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30g",
@@ -22736,7 +24037,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30gr",
@@ -22821,7 +24142,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30w",
@@ -22924,7 +24265,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-7522-z30wr",
@@ -23018,7 +24379,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bqs",
@@ -23111,7 +24492,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvf",
@@ -23216,7 +24617,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvf9",
@@ -23319,7 +24740,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvs",
@@ -23411,7 +24852,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30bvs9",
@@ -23521,7 +24982,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gqs",
@@ -23622,7 +25103,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gvf",
@@ -23734,7 +25235,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30gvf9",
@@ -23833,7 +25354,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wqs",
@@ -23923,7 +25464,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvf",
@@ -24015,7 +25576,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvf9",
@@ -24098,7 +25679,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvs",
@@ -24208,7 +25809,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9502-z30wvs9",
@@ -24315,7 +25936,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b06v",
@@ -24410,7 +26051,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b14v",
@@ -24502,7 +26163,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b18q",
@@ -24593,7 +26274,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 320,
+          "height": 240,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30b42v",
@@ -24686,7 +26387,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g06v",
@@ -24775,7 +26496,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g14v",
@@ -24859,7 +26600,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g18q",
@@ -24940,7 +26701,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30g42v",
@@ -25038,7 +26819,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w06v",
@@ -25118,7 +26919,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w14v",
@@ -25205,7 +27026,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w18q",
@@ -25299,7 +27140,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-mic-9803s-z30w42v",
@@ -25393,7 +27254,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-3702-al",
@@ -25477,7 +27358,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-3703-al",
@@ -25556,7 +27457,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-5702-al",
@@ -25820,7 +27741,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7702-alx",
@@ -25921,7 +27862,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7702-alxt",
@@ -26190,7 +28151,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7703-alxt",
@@ -26270,7 +28251,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-al",
@@ -26354,7 +28355,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-alt",
@@ -26451,7 +28472,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbe-7704-alx",
@@ -26551,7 +28592,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7802-ax",
@@ -26646,7 +28707,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7802-axt",
@@ -26731,7 +28812,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803-ax",
@@ -26821,7 +28922,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803-axt",
@@ -26909,7 +29030,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803s-ax",
@@ -27004,7 +29145,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbi-7803s-axt",
@@ -27089,7 +29250,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-63023-b",
@@ -27182,7 +29363,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-73023-ba",
@@ -27275,7 +29476,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbn-9122-p",
@@ -27449,7 +29670,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f05qf",
@@ -27545,7 +29786,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f09qf",
@@ -27642,7 +29903,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8700-f18qf",
@@ -27741,7 +30022,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f06vf",
@@ -27827,7 +30128,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f14vf",
@@ -27927,7 +30248,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f25vf",
@@ -28028,7 +30369,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nbt-8701-f42vf",
@@ -28114,7 +30475,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nce-7703-fk",
@@ -28198,7 +30579,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndc-8502-r-ooh",
@@ -28372,7 +30773,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndd-7803-al",
@@ -28466,7 +30887,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3503-f02",
@@ -28561,7 +31002,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3702-al",
@@ -28636,7 +31097,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3703-al",
@@ -28716,7 +31197,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-3703-al-io",
@@ -28808,7 +31309,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5503-al",
@@ -28976,7 +31497,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5702-al",
@@ -29152,7 +31693,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5703-al",
@@ -29316,7 +31877,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-5704-al",
@@ -29400,7 +31981,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-7703-al",
@@ -29733,7 +32334,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8702-rxl",
@@ -29813,7 +32434,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8702-rxt",
@@ -29904,7 +32545,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-r",
@@ -30005,7 +32666,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rl",
@@ -30091,7 +32772,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rt",
@@ -30192,7 +32893,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rx",
@@ -30286,7 +33007,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rxl",
@@ -30388,7 +33129,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8703-rxt",
@@ -30488,7 +33249,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-r",
@@ -30570,7 +33351,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rl",
@@ -30682,7 +33483,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 3840,
+          "height": 2160,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rt",
@@ -30768,7 +33589,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rx",
@@ -30847,7 +33688,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nde-8704-rxl",
@@ -30945,7 +33806,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-a",
@@ -31023,7 +33904,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-a-io",
@@ -31121,7 +34022,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3702-al",
@@ -31212,7 +34133,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3703-a",
@@ -31291,7 +34232,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndi-3703-al",
@@ -31367,7 +34328,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7702-a",
@@ -31453,7 +34434,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7702-al",
@@ -31560,7 +34561,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7703-a",
@@ -31667,7 +34688,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2560,
+          "height": 1440,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndm-7703-al",
@@ -31850,7 +34891,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30c",
@@ -31952,7 +35013,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30csurfacemount",
@@ -32047,7 +35128,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5522-z30l",
@@ -32158,7 +35259,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-5533-z30l",
@@ -32262,7 +35383,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7802-z40",
@@ -32356,7 +35497,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7802-z40l",
@@ -32455,7 +35616,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndp-7804-z12l",
@@ -32555,7 +35736,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5703-f360",
@@ -32655,7 +35856,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 2112,
+          "height": 2112,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5703-f360le",
@@ -32812,7 +36033,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nds-5704-f360le",
@@ -32921,7 +36162,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5702-a",
@@ -33016,7 +36277,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5702-al",
@@ -33185,7 +36466,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5703-al",
@@ -33355,7 +36656,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-5704-al",
@@ -33447,7 +36768,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8502-r",
@@ -33542,7 +36883,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8502-rx",
@@ -33616,7 +36977,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8503-r",
@@ -33710,7 +37091,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8503-rx",
@@ -33801,7 +37202,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-ndv-8504-r",
@@ -33899,7 +37320,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f07qs",
@@ -33988,7 +37429,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f19qf",
@@ -34084,7 +37545,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8000-f19qs",
@@ -34164,7 +37645,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f09vf",
@@ -34255,7 +37756,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f09vs",
@@ -34345,7 +37866,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f17vf",
@@ -34439,7 +37980,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f35vf",
@@ -34526,7 +38087,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f65vf",
@@ -34607,7 +38188,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nht-8001-f65vs",
@@ -34698,7 +38299,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nmm-7703-a",
@@ -34737,7 +38358,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nmm-7703-al",
@@ -35028,7 +38669,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3702-f04",
@@ -35117,7 +38778,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3702-f06",
@@ -35206,7 +38887,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-al",
@@ -35375,7 +39076,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-f04",
@@ -35455,7 +39176,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nue-3703-f06",
@@ -35542,7 +39283,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f02",
@@ -35631,7 +39392,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f04",
@@ -35719,7 +39500,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f04h",
@@ -35812,7 +39613,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3702-f06",
@@ -35898,7 +39719,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f02",
@@ -35973,7 +39814,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f02h",
@@ -36060,7 +39921,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f04",
@@ -36143,7 +40024,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-nuv-3703-f06",
@@ -36235,7 +40136,27 @@
     "markets": [
       "EU",
       "global"
-    ]
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/?inst=1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/?inst=2",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Bosch official RTSP scheme: /?inst=1 main, /?inst=2 sub (per Bosch 'RTSP usage with Bosch Video IP Devices'). Default admin user is 'service' (no factory default password — set one first). ONVIF Profile S/G (T/M on INTEOX). Not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
+      }
+    }
   },
   {
     "id": "bosch-smart-home-outdoor-cam-2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION


## What does this PR do?

Cameras that supported RTSP/ONVIF but had no integration config now have one, using verified per-OEM RTSP patterns (all verified:false with sourced notes):
- 137 Bosch: official /?inst=1 (main) / ?inst=2 (sub) scheme.
- 58 ABUS Performance Line (IPCA/IPCB/IPCS + 8 PoE TVIP): Hikvision-OEM /Streaming/Channels/101 (main) / 102 (sub).
- Excluded ABUS TVIP62562 (WiFi, unconfirmed path) + 6 Cathexis.
- "No config" RTSP/ONVIF cameras: 203 -> 7.
- ABUS IPCA54512A: added vertical FOV (57) + firstmall.de source.

No camera count change (1,577 / 68 brands); cameras with configs: 1,303.
---

## Checklist

### For new cameras
- [x] JSON file is under `cameras/<brand-slug>/<model-slug>.json`
- [x] `id` is a unique lowercase slug matching the file path
- [x] `brand`, `model`, `type`, `resolution` are all present
- [x] At least one URL in `sources` (manufacturer datasheet or reputable retailer)
- [x] `npm run build` passes locally with no errors

### For corrections
- [x] Include a source URL confirming the correct value
- [x] `npm run build` passes locally with no errors

### For schema / tooling changes
- [x] Existing cameras still validate (`npm run build`)
- [x] Updated `docs/glossary.md` if new fields were added

---

## Source(s)

  - **Bosch:** boschsecurity.com / boschbuildingtechnologies.com (Keenfinity) datasheets; model list via netcamcenter.de                                                             
  - **Dahua:** dahuasecurity.com (official product pages + datasheet PDFs)                                                                                                           
  - **Config RTSP patterns:** Bosch's official "RTSP usage with Bosch Video IP Devices" doc; Hikvision-OEM `/Streaming/Channels/` scheme for the ABUS Performance Line (corroborated 
  via iSpyConnect + official ABUS manuals).

---

## Notes
                                                                                                                                                                                     
 - No runtime/API changes — dataset + schema + build only.                                                                                                                          
 - The dataset remains **CC0**.
