### PR TITLE
Backfill last_verified on all 47 Tapo cameras

### DIFF
--- a/cameras/tapo/c100.json
+++ b/cameras/tapo/c100.json
@@ -86,5 +86,6 @@
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "operating_temp_c": "0 to 40",
-  "dimensions_mm": "67.6 x 54.6 x 98.9"
+  "dimensions_mm": "67.6 x 54.6 x 98.9",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c110.json
+++ b/cameras/tapo/c110.json
@@ -94,5 +94,6 @@
   "dimensions_mm": "67.6 x 54.6 x 98.9",
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c120.json
+++ b/cameras/tapo/c120.json
@@ -95,5 +95,6 @@
   "environment": [
     "indoor",
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c121.json
+++ b/cameras/tapo/c121.json
@@ -88,5 +88,6 @@
   "ip_rating": "IP66",
   "operating_temp_c": "-25 to 45",
   "dimensions_mm": "67.4 x 57.4 x 44.1",
-  "weight_g": 100
+  "weight_g": 100,
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c125.json
+++ b/cameras/tapo/c125.json
@@ -97,5 +97,6 @@
   "dimensions_mm": "76.4 x 66.4 x 44.6",
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c200.json
+++ b/cameras/tapo/c200.json
@@ -98,5 +98,6 @@
   "dimensions_mm": "86.6 x 85 x 117.7",
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c207.json
+++ b/cameras/tapo/c207.json
@@ -3,7 +3,9 @@
   "brand": "Tapo",
   "model": "C207",
   "type": "ptz",
-  "connectivity": ["wifi"],
+  "connectivity": [
+    "wifi"
+  ],
   "resolution": {
     "megapixels": 2,
     "max_width": 1920,
@@ -25,14 +27,19 @@
   "power": {
     "method": "5V DC power adapter (100-240V AC input, 5.0V/1.0A Type-C output); 2.3W typical / 5W max consumption"
   },
-  "power_source": ["dc"],
+  "power_source": [
+    "dc"
+  ],
   "storage": {
     "onboard": false,
     "max_microsd_gb": 512,
     "nvr_compatible": false,
     "cloud": true
   },
-  "protocols": ["rtsp", "onvif"],
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
   "ip_rating": "IP65",
   "audio": {
     "microphone": true,
@@ -40,10 +47,15 @@
     "two_way": true
   },
   "video": {
-    "codecs": ["H.264"],
+    "codecs": [
+      "H.264"
+    ],
     "max_fps": 30
   },
-  "environment": ["indoor", "outdoor"],
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
   "dimensions_mm": "105.3 x 77.8 x 69.8",
   "weight_g": 220,
   "operating_temp_c": "-20 to 50",
@@ -59,7 +71,11 @@
   ],
   "configs": {
     "frigate": {
-      "detect": { "width": 640, "height": 480, "fps": 5 },
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
@@ -73,5 +89,6 @@
       "profile": "Generic/ONVIF",
       "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c210.json
+++ b/cameras/tapo/c210.json
@@ -98,5 +98,6 @@
   "weight_g": 190,
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c216.json
+++ b/cameras/tapo/c216.json
@@ -104,5 +104,6 @@
   "environment": [
     "indoor",
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c220.json
+++ b/cameras/tapo/c220.json
@@ -87,5 +87,6 @@
   "dimensions_mm": "85.4 x 86.8 x 117.7",
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c222-indoor.json
+++ b/cameras/tapo/c222-indoor.json
@@ -86,5 +86,6 @@
       "profile": "Generic/ONVIF",
       "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c225.json
+++ b/cameras/tapo/c225.json
@@ -92,5 +92,6 @@
   "weight_g": 312,
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c230.json
+++ b/cameras/tapo/c230.json
@@ -97,5 +97,6 @@
   "dimensions_mm": "85.4 x 86.8 x 117.7",
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c246d.json
+++ b/cameras/tapo/c246d.json
@@ -108,5 +108,6 @@
   "environment": [
     "indoor",
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c260.json
+++ b/cameras/tapo/c260.json
@@ -94,5 +94,6 @@
   "weight_g": 210.6,
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c310.json
+++ b/cameras/tapo/c310.json
@@ -98,5 +98,6 @@
   "weight_g": 220,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c320ws.json
+++ b/cameras/tapo/c320ws.json
@@ -90,5 +90,6 @@
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",
-  "dimensions_mm": "142.3 x 103.4 x 64.3"
+  "dimensions_mm": "142.3 x 103.4 x 64.3",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c325wb-ca.json
+++ b/cameras/tapo/c325wb-ca.json
@@ -100,5 +100,6 @@
     "max_fps": 20
   },
   "operating_temp_c": "-20 to 45",
-  "dimensions_mm": "148.7 x 104 x 70.6"
+  "dimensions_mm": "148.7 x 104 x 70.6",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c325wb-india.json
+++ b/cameras/tapo/c325wb-india.json
@@ -100,5 +100,6 @@
   "dimensions_mm": "148.7 x 104 x 70.6",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c325wb.json
+++ b/cameras/tapo/c325wb.json
@@ -98,5 +98,6 @@
   "weight_g": 230,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c400-kit.json
+++ b/cameras/tapo/c400-kit.json
@@ -3,7 +3,9 @@
   "brand": "Tapo",
   "model": "C400 Kit",
   "type": "bullet",
-  "connectivity": ["wifi"],
+  "connectivity": [
+    "wifi"
+  ],
   "resolution": {
     "megapixels": 2,
     "max_width": 1920,
@@ -25,7 +27,10 @@
   "power": {
     "method": "Built-in rechargeable lithium-ion battery; included solar panel (monocrystalline silicon, angle-adjustable bracket); optional USB Type-C AC adapter (not included); up to 180-day battery life"
   },
-  "power_source": ["battery", "solar"],
+  "power_source": [
+    "battery",
+    "solar"
+  ],
   "storage": {
     "onboard": false,
     "max_microsd_gb": 512,
@@ -40,10 +45,14 @@
     "two_way": true
   },
   "video": {
-    "codecs": ["H.264"],
+    "codecs": [
+      "H.264"
+    ],
     "max_fps": 15
   },
-  "environment": ["outdoor"],
+  "environment": [
+    "outdoor"
+  ],
   "dimensions_mm": "81 x 48 x 58.32",
   "operating_temp_c": "-20 to 45",
   "status": "available",
@@ -62,5 +71,6 @@
       "integration": "tapo",
       "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed on the official spec page. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c402.json
+++ b/cameras/tapo/c402.json
@@ -72,5 +72,6 @@
   "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "D60 x 89 (diameter x height)",
-  "weight_g": 230
+  "weight_g": 230,
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c420.json
+++ b/cameras/tapo/c420.json
@@ -79,5 +79,6 @@
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",
-  "dimensions_mm": "110.6 x 64.2 x 64.2"
+  "dimensions_mm": "110.6 x 64.2 x 64.2",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c425.json
+++ b/cameras/tapo/c425.json
@@ -85,5 +85,6 @@
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "116.2 x 64.8 x 64.8",
-  "weight_g": 335
+  "weight_g": 335,
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c460.json
+++ b/cameras/tapo/c460.json
@@ -83,5 +83,6 @@
   },
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "D64.8 x 114.6 mm",
-  "weight_g": 327
+  "weight_g": 327,
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c465.json
+++ b/cameras/tapo/c465.json
@@ -3,7 +3,9 @@
   "brand": "Tapo",
   "model": "C465",
   "type": "bullet",
-  "connectivity": ["wifi"],
+  "connectivity": [
+    "wifi"
+  ],
   "resolution": {
     "megapixels": 8,
     "max_width": 3840,
@@ -24,7 +26,10 @@
   "power": {
     "method": "Built-in rechargeable lithium-ion battery with integrated solar panel (built-in, not sold separately); optional 5.0V/2.0A AC adapter (not included) for wired charging"
   },
-  "power_source": ["battery", "solar"],
+  "power_source": [
+    "battery",
+    "solar"
+  ],
   "storage": {
     "onboard": false,
     "max_microsd_gb": 512,
@@ -39,10 +44,15 @@
     "two_way": true
   },
   "video": {
-    "codecs": ["H.265", "H.264"],
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
     "max_fps": 15
   },
-  "environment": ["outdoor"],
+  "environment": [
+    "outdoor"
+  ],
   "dimensions_mm": "109 x 84 x 120",
   "operating_temp_c": "-20 to 45",
   "status": "available",
@@ -61,5 +71,6 @@
       "integration": "tapo",
       "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed explicitly on the official spec page (RTSP: No, ONVIF: No). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c500.json
+++ b/cameras/tapo/c500.json
@@ -99,5 +99,6 @@
   "weight_g": 364,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c510w.json
+++ b/cameras/tapo/c510w.json
@@ -100,5 +100,6 @@
   "weight_g": 364,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c520ws.json
+++ b/cameras/tapo/c520ws.json
@@ -94,5 +94,6 @@
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-30 to 60",
-  "dimensions_mm": "123.8 x 123 x 90"
+  "dimensions_mm": "123.8 x 123 x 90",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c530ws.json
+++ b/cameras/tapo/c530ws.json
@@ -93,5 +93,6 @@
   "weight_g": 347,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c560ws.json
+++ b/cameras/tapo/c560ws.json
@@ -96,5 +96,6 @@
   "dimensions_mm": "147.4 x 74.7 x 165.4 (with bracket); 147.4 x 74.7 x 157.4 (without bracket)",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c566wb.json
+++ b/cameras/tapo/c566wb.json
@@ -71,5 +71,6 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c615f-kit.json
+++ b/cameras/tapo/c615f-kit.json
@@ -88,5 +88,6 @@
   "environment": [
     "outdoor"
   ],
-  "operating_temp_c": "-20 to 45"
+  "operating_temp_c": "-20 to 45",
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c645d-kit.json
+++ b/cameras/tapo/c645d-kit.json
@@ -3,7 +3,9 @@
   "brand": "Tapo",
   "model": "C645D Kit",
   "type": "dual-lens",
-  "connectivity": ["wifi"],
+  "connectivity": [
+    "wifi"
+  ],
   "resolution": {
     "megapixels": 3,
     "max_width": 2304,
@@ -25,7 +27,10 @@
   "power": {
     "method": "Built-in rechargeable lithium-ion battery; Tapo A201 solar panel (included, up to 2.5W output)"
   },
-  "power_source": ["battery", "solar"],
+  "power_source": [
+    "battery",
+    "solar"
+  ],
   "storage": {
     "onboard": false,
     "max_microsd_gb": 512,
@@ -42,11 +47,21 @@
   "video": {
     "max_fps": 15,
     "streams": [
-      { "name": "wide-angle lens", "resolution": "2304x1296", "fps": 15 },
-      { "name": "telephoto lens", "resolution": "2304x1296", "fps": 15 }
+      {
+        "name": "wide-angle lens",
+        "resolution": "2304x1296",
+        "fps": 15
+      },
+      {
+        "name": "telephoto lens",
+        "resolution": "2304x1296",
+        "fps": 15
+      }
     ]
   },
-  "environment": ["outdoor"],
+  "environment": [
+    "outdoor"
+  ],
   "dimensions_mm": "132 x 82 x 160",
   "operating_temp_c": "-20 to 45",
   "status": "available",
@@ -67,5 +82,6 @@
       "integration": "tapo",
       "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ, which explicitly names the C645D). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c660-kit.json
+++ b/cameras/tapo/c660-kit.json
@@ -85,5 +85,6 @@
   "weight_g": 607,
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c675d-kit.json
+++ b/cameras/tapo/c675d-kit.json
@@ -93,5 +93,6 @@
   "environment": [
     "outdoor"
   ],
-  "status": "available"
+  "status": "available",
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/c720.json
+++ b/cameras/tapo/c720.json
@@ -93,5 +93,6 @@
   "dimensions_mm": "151 x 151 x 145.6",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/c840.json
+++ b/cameras/tapo/c840.json
@@ -110,5 +110,6 @@
   "weight_g": 249,
   "environment": [
     "indoor"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/d130.json
+++ b/cameras/tapo/d130.json
@@ -65,5 +65,6 @@
     "https://www.tp-link.com/us/smart-home/smart-doorbell/tapo-d130/",
     "https://www.tp-link.com/us/support/faq/4329/",
     "https://www.tapo.com/en/product/smart-camera/tapo-d130/"
-  ]
+  ],
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/d225.json
+++ b/cameras/tapo/d225.json
@@ -102,5 +102,6 @@
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "operating_temp_c": "-20 to 45",
-  "dimensions_mm": "150 x 50 x 38.4"
+  "dimensions_mm": "150 x 50 x 38.4",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/d230s1.json
+++ b/cameras/tapo/d230s1.json
@@ -75,5 +75,6 @@
   },
   "sensor": "1/2.7\"",
   "operating_temp_c": "-20 to 45",
-  "dimensions_mm": "146 x 54.5 x 35.5"
+  "dimensions_mm": "146 x 54.5 x 35.5",
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/d235-doorbell.json
+++ b/cameras/tapo/d235-doorbell.json
@@ -94,5 +94,6 @@
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "150 x 50 x 38.4 (doorbell unit only, excludes chime)",
-  "weight_g": 297
+  "weight_g": 297,
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/tc40.json
+++ b/cameras/tapo/tc40.json
@@ -81,5 +81,6 @@
       "profile": "Generic/ONVIF",
       "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/cameras/tapo/tc55.json
+++ b/cameras/tapo/tc55.json
@@ -81,5 +81,6 @@
       "profile": "Generic/ONVIF",
       "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/tc82-floodlight.json
+++ b/cameras/tapo/tc82-floodlight.json
@@ -77,5 +77,6 @@
       "integration": "tapo",
       "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
     }
-  }
+  },
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/tc85.json
+++ b/cameras/tapo/tc85.json
@@ -76,5 +76,6 @@
       "integration": "tapo",
       "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
     }
-  }
+  },
+  "last_verified": "2026-06-30"
 }

--- a/cameras/tapo/tcw90-kit.json
+++ b/cameras/tapo/tcw90-kit.json
@@ -3,7 +3,9 @@
   "brand": "Tapo",
   "model": "TCW90 Kit",
   "type": "ptz",
-  "connectivity": ["wifi"],
+  "connectivity": [
+    "wifi"
+  ],
   "resolution": {
     "megapixels": 3,
     "max_width": 2304,
@@ -25,7 +27,10 @@
   "power": {
     "method": "Built-in rechargeable lithium-ion battery; Tapo A201 solar panel (included, up to 5.2V/2.5W max charging); up to 200 days battery life without sunlight"
   },
-  "power_source": ["battery", "solar"],
+  "power_source": [
+    "battery",
+    "solar"
+  ],
   "storage": {
     "onboard": false,
     "max_microsd_gb": 512,
@@ -42,7 +47,9 @@
   "video": {
     "max_fps": 15
   },
-  "environment": ["outdoor"],
+  "environment": [
+    "outdoor"
+  ],
   "dimensions_mm": "130.8 x 116.1 x 84.1",
   "operating_temp_c": "-20 to 45",
   "status": "available",
@@ -63,5 +70,6 @@
       "integration": "tapo",
       "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ) -- not mentioned on the official spec page for this model either. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
     }
-  }
+  },
+  "last_verified": "2026-07-01"
 }

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -118952,7 +118952,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
-    "dimensions_mm": "67.6 x 54.6 x 98.9"
+    "dimensions_mm": "67.6 x 54.6 x 98.9",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c110",
@@ -119050,7 +119051,8 @@
     "dimensions_mm": "67.6 x 54.6 x 98.9",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c120",
@@ -119149,7 +119151,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c121",
@@ -119241,7 +119244,8 @@
     "ip_rating": "IP66",
     "operating_temp_c": "-25 to 45",
     "dimensions_mm": "67.4 x 57.4 x 44.1",
-    "weight_g": 100
+    "weight_g": 100,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c125",
@@ -119342,7 +119346,8 @@
     "dimensions_mm": "76.4 x 66.4 x 44.6",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c200",
@@ -119444,7 +119449,8 @@
     "dimensions_mm": "86.6 x 85 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c207",
@@ -119537,7 +119543,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c210",
@@ -119639,7 +119646,8 @@
     "weight_g": 190,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c216",
@@ -119747,7 +119755,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c220",
@@ -119838,7 +119847,8 @@
     "dimensions_mm": "85.4 x 86.8 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c222",
@@ -119928,7 +119938,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c225",
@@ -120024,7 +120035,8 @@
     "weight_g": 312,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c230",
@@ -120125,7 +120137,8 @@
     "dimensions_mm": "85.4 x 86.8 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c246d",
@@ -120237,7 +120250,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c260",
@@ -120335,7 +120349,8 @@
     "weight_g": 210.6,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c310",
@@ -120437,7 +120452,8 @@
     "weight_g": 220,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c320ws",
@@ -120531,7 +120547,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "142.3 x 103.4 x 64.3"
+    "dimensions_mm": "142.3 x 103.4 x 64.3",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb",
@@ -120633,7 +120650,8 @@
     "weight_g": 230,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb-ca",
@@ -120737,7 +120755,8 @@
       "max_fps": 20
     },
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "148.7 x 104 x 70.6"
+    "dimensions_mm": "148.7 x 104 x 70.6",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb-india",
@@ -120841,7 +120860,8 @@
     "dimensions_mm": "148.7 x 104 x 70.6",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c400-kit",
@@ -120916,7 +120936,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed on the official spec page. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c402",
@@ -120992,7 +121013,8 @@
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D60 x 89 (diameter x height)",
-    "weight_g": 230
+    "weight_g": 230,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c420",
@@ -121075,7 +121097,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "110.6 x 64.2 x 64.2"
+    "dimensions_mm": "110.6 x 64.2 x 64.2",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c425",
@@ -121164,7 +121187,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "116.2 x 64.8 x 64.8",
-    "weight_g": 335
+    "weight_g": 335,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c460",
@@ -121251,7 +121275,8 @@
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
-    "weight_g": 327
+    "weight_g": 327,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c465",
@@ -121326,7 +121351,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed explicitly on the official spec page (RTSP: No, ONVIF: No). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c500",
@@ -121429,7 +121455,8 @@
     "weight_g": 364,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c510w",
@@ -121533,7 +121560,8 @@
     "weight_g": 364,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c520ws",
@@ -121631,7 +121659,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "123.8 x 123 x 90"
+    "dimensions_mm": "123.8 x 123 x 90",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c530ws",
@@ -121728,7 +121757,8 @@
     "weight_g": 347,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c560ws",
@@ -121828,7 +121858,8 @@
     "dimensions_mm": "147.4 x 74.7 x 165.4 (with bracket); 147.4 x 74.7 x 157.4 (without bracket)",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c566wb",
@@ -121903,7 +121934,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c615f-kit",
@@ -121995,7 +122027,8 @@
     "environment": [
       "outdoor"
     ],
-    "operating_temp_c": "-20 to 45"
+    "operating_temp_c": "-20 to 45",
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c645d-kit",
@@ -122081,7 +122114,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ, which explicitly names the C645D). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c660-kit",
@@ -122170,7 +122204,8 @@
     "weight_g": 607,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c675d-kit",
@@ -122267,7 +122302,8 @@
     "environment": [
       "outdoor"
     ],
-    "status": "available"
+    "status": "available",
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c720",
@@ -122364,7 +122400,8 @@
     "dimensions_mm": "151 x 151 x 145.6",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c840",
@@ -122478,7 +122515,8 @@
     "weight_g": 249,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d130",
@@ -122547,7 +122585,8 @@
       "https://www.tp-link.com/us/smart-home/smart-doorbell/tapo-d130/",
       "https://www.tp-link.com/us/support/faq/4329/",
       "https://www.tapo.com/en/product/smart-camera/tapo-d130/"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d225",
@@ -122653,7 +122692,8 @@
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "150 x 50 x 38.4"
+    "dimensions_mm": "150 x 50 x 38.4",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d230s1",
@@ -122732,7 +122772,8 @@
     },
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "146 x 54.5 x 35.5"
+    "dimensions_mm": "146 x 54.5 x 35.5",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d235",
@@ -122830,7 +122871,8 @@
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4 (doorbell unit only, excludes chime)",
-    "weight_g": 297
+    "weight_g": 297,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc40",
@@ -122915,7 +122957,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-tc55",
@@ -123000,7 +123043,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc82-global",
@@ -123081,7 +123125,8 @@
         "integration": "tapo",
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc85",
@@ -123161,7 +123206,8 @@
         "integration": "tapo",
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tcw90-kit",
@@ -123235,7 +123281,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ) -- not mentioned on the official spec page for this model either. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tiandy-tc-c32fn",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -118952,7 +118952,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
-    "dimensions_mm": "67.6 x 54.6 x 98.9"
+    "dimensions_mm": "67.6 x 54.6 x 98.9",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c110",
@@ -119050,7 +119051,8 @@
     "dimensions_mm": "67.6 x 54.6 x 98.9",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c120",
@@ -119149,7 +119151,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c121",
@@ -119241,7 +119244,8 @@
     "ip_rating": "IP66",
     "operating_temp_c": "-25 to 45",
     "dimensions_mm": "67.4 x 57.4 x 44.1",
-    "weight_g": 100
+    "weight_g": 100,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c125",
@@ -119342,7 +119346,8 @@
     "dimensions_mm": "76.4 x 66.4 x 44.6",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c200",
@@ -119444,7 +119449,8 @@
     "dimensions_mm": "86.6 x 85 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c207",
@@ -119537,7 +119543,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c210",
@@ -119639,7 +119646,8 @@
     "weight_g": 190,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c216",
@@ -119747,7 +119755,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c220",
@@ -119838,7 +119847,8 @@
     "dimensions_mm": "85.4 x 86.8 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c222",
@@ -119928,7 +119938,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c225",
@@ -120024,7 +120035,8 @@
     "weight_g": 312,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c230",
@@ -120125,7 +120137,8 @@
     "dimensions_mm": "85.4 x 86.8 x 117.7",
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c246d",
@@ -120237,7 +120250,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c260",
@@ -120335,7 +120349,8 @@
     "weight_g": 210.6,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c310",
@@ -120437,7 +120452,8 @@
     "weight_g": 220,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c320ws",
@@ -120531,7 +120547,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "142.3 x 103.4 x 64.3"
+    "dimensions_mm": "142.3 x 103.4 x 64.3",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb",
@@ -120633,7 +120650,8 @@
     "weight_g": 230,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb-ca",
@@ -120737,7 +120755,8 @@
       "max_fps": 20
     },
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "148.7 x 104 x 70.6"
+    "dimensions_mm": "148.7 x 104 x 70.6",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c325wb-india",
@@ -120841,7 +120860,8 @@
     "dimensions_mm": "148.7 x 104 x 70.6",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c400-kit",
@@ -120916,7 +120936,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed on the official spec page. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c402",
@@ -120992,7 +121013,8 @@
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D60 x 89 (diameter x height)",
-    "weight_g": 230
+    "weight_g": 230,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c420",
@@ -121075,7 +121097,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "110.6 x 64.2 x 64.2"
+    "dimensions_mm": "110.6 x 64.2 x 64.2",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c425",
@@ -121164,7 +121187,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "116.2 x 64.8 x 64.8",
-    "weight_g": 335
+    "weight_g": 335,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c460",
@@ -121251,7 +121275,8 @@
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
-    "weight_g": 327
+    "weight_g": 327,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c465",
@@ -121326,7 +121351,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed explicitly on the official spec page (RTSP: No, ONVIF: No). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c500",
@@ -121429,7 +121455,8 @@
     "weight_g": 364,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c510w",
@@ -121533,7 +121560,8 @@
     "weight_g": 364,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c520ws",
@@ -121631,7 +121659,8 @@
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "123.8 x 123 x 90"
+    "dimensions_mm": "123.8 x 123 x 90",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c530ws",
@@ -121728,7 +121757,8 @@
     "weight_g": 347,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c560ws",
@@ -121828,7 +121858,8 @@
     "dimensions_mm": "147.4 x 74.7 x 165.4 (with bracket); 147.4 x 74.7 x 157.4 (without bracket)",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c566wb",
@@ -121903,7 +121934,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c615f-kit",
@@ -121995,7 +122027,8 @@
     "environment": [
       "outdoor"
     ],
-    "operating_temp_c": "-20 to 45"
+    "operating_temp_c": "-20 to 45",
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c645d-kit",
@@ -122081,7 +122114,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ, which explicitly names the C645D). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c660-kit",
@@ -122170,7 +122204,8 @@
     "weight_g": 607,
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c675d-kit",
@@ -122267,7 +122302,8 @@
     "environment": [
       "outdoor"
     ],
-    "status": "available"
+    "status": "available",
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-c720",
@@ -122364,7 +122400,8 @@
     "dimensions_mm": "151 x 151 x 145.6",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-c840",
@@ -122478,7 +122515,8 @@
     "weight_g": 249,
     "environment": [
       "indoor"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d130",
@@ -122547,7 +122585,8 @@
       "https://www.tp-link.com/us/smart-home/smart-doorbell/tapo-d130/",
       "https://www.tp-link.com/us/support/faq/4329/",
       "https://www.tapo.com/en/product/smart-camera/tapo-d130/"
-    ]
+    ],
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d225",
@@ -122653,7 +122692,8 @@
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "150 x 50 x 38.4"
+    "dimensions_mm": "150 x 50 x 38.4",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d230s1",
@@ -122732,7 +122772,8 @@
     },
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
-    "dimensions_mm": "146 x 54.5 x 35.5"
+    "dimensions_mm": "146 x 54.5 x 35.5",
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-d235",
@@ -122830,7 +122871,8 @@
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4 (doorbell unit only, excludes chime)",
-    "weight_g": 297
+    "weight_g": 297,
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc40",
@@ -122915,7 +122957,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tapo-tc55",
@@ -123000,7 +123043,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc82-global",
@@ -123081,7 +123125,8 @@
         "integration": "tapo",
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tc85",
@@ -123161,7 +123206,8 @@
         "integration": "tapo",
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
-    }
+    },
+    "last_verified": "2026-06-30"
   },
   {
     "id": "tapo-tcw90-kit",
@@ -123235,7 +123281,8 @@
         "integration": "tapo",
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ) -- not mentioned on the official spec page for this model either. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
-    }
+    },
+    "last_verified": "2026-07-01"
   },
   {
     "id": "tiandy-tc-c32fn",


### PR DESCRIPTION
## Summary
- Backfills the new `last_verified` field (added in #41) on all 47 Tapo cameras.
- Dates come from each file's actual last-commit history, not a single guessed date: `2026-06-30` for cameras untouched since the full brand recheck (v1.13.0), `2026-07-01` for the 11 cameras added/fixed in the more recent individual-link verification round (v1.14.0).
- This commit was originally pushed to `audit/ezviz` but landed after #41 was merged, so it never made it into `main` — cherry-picked here instead.

## Test plan
- [x] `npm run build` passes
- [x] `data/cameras.json`, `data/cameras.csv`, `docs/cameras.json` regenerated in sync

