### PR TITLE
Inject git-derived `added` date into generated cameras.json (v1.34.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: build.js derives each camera's `added` date from
+          # `git log --diff-filter=A`; a shallow clone would compute different
+          # dates and falsely trip the stale-files check below.
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.34.0] — 2026-07-14
+
+Generated-artifact feature: each camera in the **generated** `cameras.json` (data/, docs/, and downstream mirrors) now carries an **`added`** date (YYYY-MM-DD) — derived at build time from git history (`git log --diff-filter=A`, with `--follow` fallback for renamed files). Per-camera **source files are unchanged** and the schema is untouched; `added` is provenance metadata injected after validation. Powers downstream "recently added" listings and RSS feeds. CI now checks out with full history (`fetch-depth: 0`) so the stale-artifact check reproduces identical dates.
+
 ## [1.33.0] — 2026-07-11
 
 **ACTi catalogue completion** — added **129 currently-orderable ACTi cameras** that were missing from the dataset. Discovered by diffing ACTi's official product-roadmap (only `AvailableToOrder=Available` models) against our set, then extracted from ACTi's server-side spec-API (`newPopupSpecifications.ashx` + `_value.ashx`). Net: **2,101 -> 2,230 cameras** (71 brands unchanged). ACTi coverage 119 -> 248.

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -68,7 +68,8 @@
       "https://www.expert-security.de/abus-hdcc35512-analog-hd-mini-tube-5mpx-tn-ir-ip67.html",
       "https://alarm-technik.eu/en/products/abus-analog-hd-mini-tube-5-mpx-2-8-mm-hdcc35512"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-hdcc52512",
@@ -144,7 +145,8 @@
       "https://www.expert-security.de/abus-hdcc52512-analog-hd-mini-dome-ir-1080p-ip67.html",
       "https://www.digitec.ch/en/s1/product/abus-hdcc52512-analog-hd-mini-dome-ir-1080p-ip67-1920-x-1080-pixels-network-camera-61175216"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-hdcc75550",
@@ -211,7 +213,8 @@
       "https://www.expert-security.de/abus-hdcc75550-analog-hd-tube-5mpx-t-n-ir-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Analogue-HD/Analog-HD-Tube-5-MPx-2.7-13.5-mm"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34512a",
@@ -317,7 +320,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34512b",
@@ -430,7 +434,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34612a",
@@ -540,7 +545,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54512a",
@@ -664,7 +670,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54512b",
@@ -782,7 +789,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54572a",
@@ -891,7 +899,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54581b",
@@ -994,7 +1003,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54612a",
@@ -1106,7 +1116,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64512a",
@@ -1218,7 +1229,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64512b",
@@ -1339,7 +1351,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64581d",
@@ -1451,7 +1464,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64612a",
@@ -1584,7 +1598,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34511a",
@@ -1695,7 +1710,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34511b",
@@ -1820,7 +1836,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34611a",
@@ -1941,7 +1958,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb38511a",
@@ -2066,7 +2084,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb38511b",
@@ -2169,7 +2188,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44510a",
@@ -2263,7 +2283,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44510c",
@@ -2368,7 +2389,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44511a",
@@ -2485,7 +2507,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44511b",
@@ -2600,7 +2623,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44561a",
@@ -2703,7 +2727,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44611a",
@@ -2806,7 +2831,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44611b",
@@ -2931,7 +2957,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54511a",
@@ -3047,7 +3074,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54511b",
@@ -3158,7 +3186,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54611b",
@@ -3262,7 +3291,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58511a",
@@ -3388,7 +3418,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58511b",
@@ -3505,7 +3536,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58611a",
@@ -3618,7 +3650,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb64510a",
@@ -3712,7 +3745,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64510b",
@@ -3805,7 +3839,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64510c",
@@ -3899,7 +3934,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64521",
@@ -4025,7 +4061,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb64620",
@@ -4120,7 +4157,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64621",
@@ -4226,7 +4264,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb68515a",
@@ -4322,7 +4361,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb68521",
@@ -4451,7 +4491,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb68621",
@@ -4558,7 +4599,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb74521",
@@ -4687,7 +4729,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb78521",
@@ -4795,7 +4838,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs24500",
@@ -4890,7 +4934,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs28581a",
@@ -5006,7 +5051,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs29512",
@@ -5137,7 +5183,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs34511a",
@@ -5231,7 +5278,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs34511b",
@@ -5325,7 +5373,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs34611a",
@@ -5450,7 +5499,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54511a",
@@ -5552,7 +5602,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54511b",
@@ -5662,7 +5713,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54611a",
@@ -5783,7 +5835,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs58571a",
@@ -5905,7 +5958,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64511b",
@@ -6025,7 +6079,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64531",
@@ -6135,7 +6190,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64541",
@@ -6263,7 +6319,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64611a",
@@ -6360,7 +6417,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs74511a",
@@ -6461,7 +6519,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84511",
@@ -6582,7 +6641,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84532",
@@ -6690,7 +6750,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84551",
@@ -6828,7 +6889,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic31020",
@@ -6910,7 +6972,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/ABUS-WLAN-Privacy-Innen-Kamera.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic42520",
@@ -7001,7 +7064,8 @@
     "weight_g": 650,
     "operating_temp_c": "-10 to 50",
     "last_verified": "2026-07-05",
-    "release_notes": "Absorbed the former 'PPIC42520 (Austria)' regional-duplicate entry."
+    "release_notes": "Absorbed the former 'PPIC42520 (Austria)' regional-duplicate entry.",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic44520",
@@ -7072,7 +7136,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic46520",
@@ -7153,7 +7218,8 @@
     "dimensions_mm": "75 x 155 x 180",
     "weight_g": 985,
     "operating_temp_c": "-20 to 50",
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic52520",
@@ -7238,7 +7304,8 @@
       "https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html",
       "https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic54520",
@@ -7321,7 +7388,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/SmartLook-abus.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic90520",
@@ -7394,7 +7462,8 @@
       "solar"
     ],
     "operating_temp_c": "-20 to 50",
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic91000",
@@ -7468,7 +7537,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/ABUS-Akku-Kamera-Pro-mit-Basisstation.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic91520",
@@ -7548,7 +7618,8 @@
         "notes": "App-only ABUS battery camera (App2Cam Plus) — no ONVIF/RTSP; local NVR/Frigate not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-tvcc35512",
@@ -7605,7 +7676,8 @@
       "https://uk.rs-online.com/web/p/cctv-cameras/0633204",
       "https://www.expert-security.de/abus-kameras.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvcc55512",
@@ -7679,7 +7751,8 @@
       "https://www.expert-security.de/abus-tvcc55512-analog-hd-mini-dome-kamera-5mpx-t-n.html",
       "https://www.abus.com/uk/Commercial-Security/Video-surveillance/Analogue-HD/Analog-HD-Mini-Dome-5-MPx-2.8-mm"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip42510",
@@ -7796,7 +7869,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip42520",
@@ -7891,7 +7965,8 @@
         "notes": "Select 'Hikvision' profile. Most ABUS IP cameras use Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-tvip42562",
@@ -7980,7 +8055,8 @@
       "https://www.expert-security.de/abus-tvip42562-ip-kamera-1080p-t-n-ir-wlan-ip66.html",
       "https://toolbrothers.de/products/abus-tvip42562-2mpx-wlan-mini-dome-kamera-mit-12-v-anschluss-full-hd-1080p"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip44510",
@@ -8097,7 +8173,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip44511",
@@ -8213,7 +8290,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip48511",
@@ -8342,7 +8420,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip62510",
@@ -8457,7 +8536,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip62562",
@@ -8564,7 +8644,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip64511",
@@ -8671,7 +8752,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip68511",
@@ -8779,7 +8861,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip82561",
@@ -8885,7 +8968,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip83900",
@@ -8982,7 +9066,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-05"
   },
   {
     "id": "acti-a213",
@@ -9064,7 +9149,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a214",
@@ -9151,7 +9237,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a29",
@@ -9233,7 +9320,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a313",
@@ -9321,7 +9409,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a314",
@@ -9408,7 +9497,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a315",
@@ -9490,7 +9580,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a317",
@@ -9579,7 +9670,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371",
@@ -9669,7 +9761,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371-p1",
@@ -9759,7 +9852,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371-p2",
@@ -9829,7 +9923,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a372",
@@ -9892,7 +9987,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a372-p1",
@@ -9953,7 +10049,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a374",
@@ -10024,7 +10121,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a374-p1",
@@ -10095,7 +10193,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a377",
@@ -10181,7 +10280,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a410",
@@ -10248,7 +10348,8 @@
     },
     "ip_rating": "IP66, IK10",
     "weight_g": 1600,
-    "operating_temp_c": "-30 to 50"
+    "operating_temp_c": "-30 to 50",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a412",
@@ -10339,7 +10440,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a415",
@@ -10425,7 +10527,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a416",
@@ -10514,7 +10617,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-a421",
@@ -10603,7 +10707,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a422",
@@ -10691,7 +10796,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a423",
@@ -10778,7 +10884,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a424",
@@ -10869,7 +10976,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a425",
@@ -10955,7 +11063,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a426",
@@ -11043,7 +11152,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a427",
@@ -11128,7 +11238,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a428",
@@ -11194,7 +11305,8 @@
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "140 x 378.4",
     "weight_g": 2170,
-    "operating_temp_c": "-40 to 65"
+    "operating_temp_c": "-40 to 65",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a429",
@@ -11281,7 +11393,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a432",
@@ -11343,7 +11456,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a432-p1",
@@ -11398,7 +11512,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570",
@@ -11488,7 +11603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570-p1",
@@ -11557,7 +11673,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570-p2",
@@ -11626,7 +11743,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573",
@@ -11716,7 +11834,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573-p1",
@@ -11806,7 +11925,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573-p2",
@@ -11896,7 +12016,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a711",
@@ -11985,7 +12106,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a713",
@@ -12071,7 +12193,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a76",
@@ -12157,7 +12280,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a77",
@@ -12244,7 +12368,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a78",
@@ -12331,7 +12456,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a810",
@@ -12400,7 +12526,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a811",
@@ -12486,7 +12613,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a817",
@@ -12575,7 +12703,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a820",
@@ -12665,7 +12794,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a821",
@@ -12753,7 +12883,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a822",
@@ -12842,7 +12973,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a826",
@@ -12930,7 +13062,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a828",
@@ -13020,7 +13153,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a85",
@@ -13105,7 +13239,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a86",
@@ -13190,7 +13325,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a88",
@@ -13272,7 +13408,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-a912",
@@ -13337,7 +13474,8 @@
     },
     "dimensions_mm": "119.9 x 41.2",
     "weight_g": 320,
-    "operating_temp_c": "-10 to 50"
+    "operating_temp_c": "-10 to 50",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a952",
@@ -13427,7 +13565,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a955",
@@ -13512,7 +13651,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a956",
@@ -13598,7 +13738,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a957",
@@ -13687,7 +13828,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a959",
@@ -13774,7 +13916,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a962",
@@ -13864,7 +14007,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a966",
@@ -13956,7 +14100,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a967",
@@ -14043,7 +14188,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a972",
@@ -14132,7 +14278,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a973",
@@ -14200,7 +14347,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a981",
@@ -14289,7 +14437,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a982",
@@ -14375,7 +14524,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b26",
@@ -14457,7 +14607,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b412-k1",
@@ -14546,7 +14697,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b416",
@@ -14634,7 +14786,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-b419",
@@ -14720,7 +14873,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b419-p2",
@@ -14805,7 +14959,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b511a",
@@ -14890,7 +15045,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b57",
@@ -14974,7 +15130,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b64",
@@ -15057,7 +15214,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b76a",
@@ -15144,7 +15302,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b911",
@@ -15226,7 +15385,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b912",
@@ -15309,7 +15469,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b915",
@@ -15396,7 +15557,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b916",
@@ -15477,7 +15639,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b923",
@@ -15558,7 +15721,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b928",
@@ -15644,7 +15808,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b934",
@@ -15725,7 +15890,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-c11w",
@@ -15803,7 +15969,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e11",
@@ -15881,7 +16048,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e11a",
@@ -15959,7 +16127,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e13a",
@@ -16037,7 +16206,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e14",
@@ -16117,7 +16287,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e16",
@@ -16197,7 +16368,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e19",
@@ -16275,7 +16447,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e217",
@@ -16357,7 +16530,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e33a",
@@ -16441,7 +16615,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e43b",
@@ -16525,7 +16700,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e54",
@@ -16607,7 +16783,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e618",
@@ -16690,7 +16867,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e815",
@@ -16777,7 +16955,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e816",
@@ -16864,7 +17043,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e915",
@@ -16948,7 +17128,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e918",
@@ -17028,7 +17209,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e918m",
@@ -17108,7 +17290,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e925m",
@@ -17192,7 +17375,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e93",
@@ -17271,7 +17455,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e933",
@@ -17356,7 +17541,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e933m",
@@ -17441,7 +17627,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e936",
@@ -17522,7 +17709,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e936m",
@@ -17603,7 +17791,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e96",
@@ -17682,7 +17871,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i42",
@@ -17768,7 +17958,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i47",
@@ -17853,7 +18044,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i915",
@@ -17939,7 +18131,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i96",
@@ -18022,7 +18215,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-i98",
@@ -18112,7 +18306,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-j41",
@@ -18200,7 +18395,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-j71",
@@ -18287,7 +18483,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j72",
@@ -18374,7 +18571,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j73",
@@ -18462,7 +18660,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j81",
@@ -18548,7 +18747,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-k31",
@@ -18637,7 +18837,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k31-p1",
@@ -18726,7 +18927,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k32",
@@ -18815,7 +19017,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k33",
@@ -18904,7 +19107,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k372",
@@ -18991,7 +19195,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-k41",
@@ -19079,7 +19284,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k42",
@@ -19167,7 +19373,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k43",
@@ -19257,7 +19464,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k71",
@@ -19345,7 +19553,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k72",
@@ -19433,7 +19642,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k73",
@@ -19522,7 +19732,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k81",
@@ -19610,7 +19821,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k82",
@@ -19698,7 +19910,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k83",
@@ -19788,7 +20001,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k9001",
@@ -19874,7 +20088,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k953",
@@ -19967,7 +20182,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k954",
@@ -20060,7 +20276,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k958",
@@ -20153,7 +20370,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-kcm-5611",
@@ -20241,7 +20459,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-kcm-7311",
@@ -20321,7 +20540,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l31",
@@ -20409,7 +20629,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l31-p1",
@@ -20497,7 +20718,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l33",
@@ -20585,7 +20807,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l33-p1",
@@ -20673,7 +20896,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l41",
@@ -20761,7 +20985,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l43",
@@ -20849,7 +21074,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l71",
@@ -20937,7 +21163,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l73",
@@ -21025,7 +21252,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l73-p1",
@@ -21113,7 +21341,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l81",
@@ -21201,7 +21430,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l83",
@@ -21289,7 +21519,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-pcam-1600",
@@ -21372,7 +21603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q113",
@@ -21451,7 +21683,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q115",
@@ -21530,7 +21763,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q12",
@@ -21609,7 +21843,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q120",
@@ -21668,7 +21903,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q121",
@@ -21728,7 +21964,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q150",
@@ -21811,7 +22048,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q150-12mm",
@@ -21892,7 +22130,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q170",
@@ -21951,7 +22190,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q22",
@@ -22032,7 +22272,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q22-k1",
@@ -22112,7 +22353,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q450",
@@ -22192,7 +22434,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q550",
@@ -22280,7 +22523,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q711",
@@ -22347,7 +22591,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q75",
@@ -22414,7 +22659,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q83",
@@ -22501,7 +22747,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q84",
@@ -22591,7 +22838,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q950",
@@ -22677,7 +22925,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q970",
@@ -22738,7 +22987,8 @@
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "82 x 212 x 47.2",
     "weight_g": 728,
-    "operating_temp_c": "-40 to 55"
+    "operating_temp_c": "-40 to 55",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q981",
@@ -22826,7 +23076,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982",
@@ -22914,7 +23165,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982-p1",
@@ -23002,7 +23254,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982-p2",
@@ -23090,7 +23343,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q992",
@@ -23179,7 +23433,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-359",
@@ -23267,7 +23522,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-359-p1",
@@ -23356,7 +23612,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-370",
@@ -23422,7 +23679,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-371",
@@ -23507,7 +23765,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-601",
@@ -23573,7 +23832,8 @@
     },
     "dimensions_mm": "140.5 x 122.6",
     "weight_g": 954,
-    "operating_temp_c": "-30 to 60"
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-vmgb-602",
@@ -23639,7 +23899,8 @@
     },
     "dimensions_mm": "140.5 x 122.6",
     "weight_g": 948,
-    "operating_temp_c": "-30 to 60"
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-y31",
@@ -23701,7 +23962,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y32",
@@ -23763,7 +24025,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y35",
@@ -23825,7 +24088,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y55",
@@ -23890,7 +24154,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y71",
@@ -23955,7 +24220,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y72",
@@ -24017,7 +24283,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z310",
@@ -24105,7 +24372,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z315",
@@ -24193,7 +24461,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z316",
@@ -24281,7 +24550,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z316-p1",
@@ -24369,7 +24639,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z317",
@@ -24457,7 +24728,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z317-p1",
@@ -24544,7 +24816,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z318",
@@ -24633,7 +24906,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z319",
@@ -24721,7 +24995,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z322",
@@ -24808,7 +25083,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z324",
@@ -24892,7 +25168,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z325",
@@ -24982,7 +25259,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z330",
@@ -25069,7 +25347,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z330-p1",
@@ -25156,7 +25435,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z331",
@@ -25243,7 +25523,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z331-p1",
@@ -25330,7 +25611,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z332",
@@ -25419,7 +25701,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z41",
@@ -25506,7 +25789,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z411",
@@ -25598,7 +25882,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z412",
@@ -25684,7 +25969,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z413-p1",
@@ -25754,7 +26040,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z415",
@@ -25842,7 +26129,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z416",
@@ -25933,7 +26221,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z419",
@@ -26020,7 +26309,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z429",
@@ -26111,7 +26401,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z47",
@@ -26202,7 +26493,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z49",
@@ -26290,7 +26582,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z510",
@@ -26379,7 +26672,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z511",
@@ -26465,7 +26759,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z512",
@@ -26554,7 +26849,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z53",
@@ -26642,7 +26938,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z54",
@@ -26726,7 +27023,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z56",
@@ -26814,7 +27112,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z64",
@@ -26884,7 +27183,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z714",
@@ -26971,7 +27271,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z72",
@@ -27058,7 +27359,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z721",
@@ -27145,7 +27447,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z722",
@@ -27235,7 +27538,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z724",
@@ -27324,7 +27628,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z78",
@@ -27411,7 +27716,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z79",
@@ -27497,7 +27803,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z79-p1",
@@ -27584,7 +27891,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z81",
@@ -27671,7 +27979,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z810",
@@ -27761,7 +28070,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z812",
@@ -27849,7 +28159,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z813",
@@ -27936,7 +28247,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z814",
@@ -28022,7 +28334,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z818",
@@ -28113,7 +28426,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z819",
@@ -28201,7 +28515,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z82",
@@ -28288,7 +28603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z84",
@@ -28370,7 +28686,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z86",
@@ -28458,7 +28775,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z87",
@@ -28544,7 +28862,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z91",
@@ -28612,7 +28931,8 @@
     "ip_rating": "IP67, IK10",
     "dimensions_mm": "108.5 x 81",
     "weight_g": 450,
-    "operating_temp_c": "-35 to 60"
+    "operating_temp_c": "-35 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z910",
@@ -28699,7 +29019,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z911",
@@ -28786,7 +29107,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z912",
@@ -28874,7 +29196,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z913",
@@ -28963,7 +29286,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z914",
@@ -29028,7 +29352,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z952",
@@ -29116,7 +29441,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z953",
@@ -29207,7 +29533,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z954",
@@ -29300,7 +29627,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z956",
@@ -29385,7 +29713,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z957",
@@ -29474,7 +29803,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z958",
@@ -29561,7 +29891,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z959",
@@ -29651,7 +29982,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z972",
@@ -29737,7 +30069,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "adt-command-indoor-cam",
@@ -29802,7 +30135,8 @@
     "markets": [
       "US"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "adt-command-outdoor-cam",
@@ -29864,7 +30198,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "adt-doorbell-cam-v2",
@@ -29919,7 +30254,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ajax-bulletcam-hl-5mp-28mm",
@@ -30009,7 +30345,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-5mp-4mm",
@@ -30099,7 +30436,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-8mp-28mm",
@@ -30189,7 +30527,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-8mp-4mm",
@@ -30279,7 +30618,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-hlvf-5mp",
@@ -30370,7 +30710,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-hlvf-8mp",
@@ -30461,7 +30802,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-5mp-28mm",
@@ -30549,7 +30891,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 2.8mm wide lens. Wired PoE/DC. Also supports 4/3/2/0.6MP modes."
+    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 2.8mm wide lens. Wired PoE/DC. Also supports 4/3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-5mp-4mm",
@@ -30637,7 +30980,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 4mm lens (narrower FoV than the 2.8mm). Available in black and white."
+    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 4mm lens (narrower FoV than the 2.8mm). Available in black and white.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-8mp-28mm",
@@ -30725,7 +31069,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 2.8mm wide lens; 4K mode capped at ~20fps."
+    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 2.8mm wide lens; 4K mode capped at ~20fps.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-8mp-4mm",
@@ -30813,7 +31158,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 4mm lens; 4K mode capped at ~20fps."
+    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 4mm lens; 4K mode capped at ~20fps.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-5mp-28mm",
@@ -30903,7 +31249,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-8mp-28mm",
@@ -30993,7 +31340,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-8mp-4mm",
@@ -31083,7 +31431,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-doorbell",
@@ -31176,7 +31525,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF supported; RTSP not independently confirmed for the doorbell."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-bulletcam-hlvf-4mp",
@@ -31269,7 +31619,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior BulletCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Also supports 3/2/0.6MP modes."
+    "release_notes": "Ajax Superior BulletCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Also supports 3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-bulletcam-hlvf-8mp",
@@ -31362,7 +31713,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior BulletCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. 24-month warranty."
+    "release_notes": "Ajax Superior BulletCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. 24-month warranty.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-domecam-hlvf-4mp",
@@ -31455,7 +31807,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior DomeCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m. Also supports 3/2/0.6MP modes."
+    "release_notes": "Ajax Superior DomeCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m. Also supports 3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-domecam-hlvf-8mp",
@@ -31548,7 +31901,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior DomeCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m."
+    "release_notes": "Ajax Superior DomeCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-5mp-28mm",
@@ -31636,7 +31990,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-5mp-4mm",
@@ -31724,7 +32079,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-8mp-28mm",
@@ -31812,7 +32168,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-8mp-4mm",
@@ -31900,7 +32257,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ad410-doorbell",
@@ -31992,7 +32350,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Portrait 3:4 aspect ratio. Doorbell press triggers alert."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ash42-w",
@@ -32070,7 +32429,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip2m-841b",
@@ -32146,7 +32506,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip4m-1041w",
@@ -32224,7 +32585,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip4m-1051ew",
@@ -32300,7 +32662,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip5m-b1186ew",
@@ -32377,7 +32740,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip5m-t1179e",
@@ -32463,7 +32827,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip5m-t1273ew-ai",
@@ -32541,7 +32906,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ip5m-t1277ew",
@@ -32627,7 +32993,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2493ew",
@@ -32712,7 +33079,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2496e",
@@ -32802,7 +33170,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2693ew",
@@ -32880,7 +33249,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip8m-2779e",
@@ -32967,7 +33337,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2899ew-ai",
@@ -33056,7 +33427,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible (PTZ supported)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ip8m-t2599ew",
@@ -33132,7 +33504,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip8m-vt2879ew-ai",
@@ -33218,7 +33591,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "annke-ac400",
@@ -33310,7 +33684,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-ac500",
@@ -33401,7 +33776,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-ac800",
@@ -33495,7 +33871,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c1200",
@@ -33598,7 +33975,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-c500",
@@ -33691,7 +34069,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800-bullet",
@@ -33792,7 +34171,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800-turret",
@@ -33893,7 +34273,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800x",
@@ -33991,7 +34372,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-i61dq",
@@ -34080,7 +34462,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-nc400",
@@ -34172,7 +34555,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-nc800",
@@ -34265,7 +34649,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-video-doorbell",
@@ -34319,7 +34704,8 @@
     "power_source": [
       "battery",
       "ac-mains"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "annke-wz500",
@@ -34409,7 +34795,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera. This is a WiFi (Tuya-based) PTZ, not a Hikvision-protocol camera."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "aqara-camera-hub-g3",
@@ -34480,7 +34867,8 @@
         "notes": "No RTSP or ONVIF. HomeKit Secure Video only. Use HomeKit integration in HA. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "aqara-camera-hub-g5-pro",
@@ -34557,7 +34945,8 @@
         "notes": "No RTSP or ONVIF. HomeKit/Matter only. Use HomeKit integration in HA. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-1st-gen",
@@ -34615,7 +35004,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/arlo/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-baby-monitor",
@@ -34680,7 +35070,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-1st-gen",
@@ -34746,7 +35137,8 @@
     "sources": [
       "https://kb.arlo.com/000062416/Arlo-Essential-Wire-Free-Camera-Series-FAQ"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-essential-indoor-1st-gen",
@@ -34810,7 +35202,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-indoor-2nd-gen",
@@ -34873,7 +35266,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-outdoor-2nd-gen",
@@ -34940,7 +35334,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-spotlight-1st-gen",
@@ -35005,7 +35400,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-video-doorbell-wired",
@@ -35068,7 +35464,8 @@
     "sources": [
       "https://www.arlo.com/en-us/doorbell/video/arlo-wired-video-doorbell.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-essential-xl-v2",
@@ -35134,7 +35531,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-xlr",
@@ -35197,7 +35595,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-go",
@@ -35264,7 +35663,8 @@
     "sources": [
       "https://www.arlo.com/en-us/products/arlo-go/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-go-2",
@@ -35334,7 +35734,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-indoor-plug-in",
@@ -35401,7 +35802,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-pro",
@@ -35467,7 +35869,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/pro/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-pro-2",
@@ -35532,7 +35935,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/pro-2/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-pro-3",
@@ -35597,7 +36001,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-pro-3-floodlight",
@@ -35662,7 +36067,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-pro-4",
@@ -35728,7 +36134,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-pro-5s",
@@ -35795,7 +36202,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-q",
@@ -35863,7 +36271,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/q/arlo-q.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-q-plus",
@@ -35934,7 +36343,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/q/VMC3040S-100NAS.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-ultra",
@@ -36000,7 +36410,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-ultra-2-spotlight",
@@ -36068,7 +36479,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-video-doorbell-hd",
@@ -36134,7 +36546,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-wired-floodlight-2025",
@@ -36201,7 +36614,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h4ptze-dp30",
@@ -36287,7 +36701,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo1-ir-2mp",
@@ -36370,7 +36785,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo1-ir-4mp",
@@ -36454,7 +36870,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo2-ir-5mp",
@@ -36538,7 +36955,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-d1-2mp",
@@ -36622,7 +37040,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-dh2-ir-10mp",
@@ -36705,7 +37124,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-do",
@@ -36790,7 +37210,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-do1-ir-2mp",
@@ -36874,7 +37295,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-mh-15mp",
@@ -36957,7 +37379,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-mh-24mp",
@@ -37040,7 +37463,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5sl-do1-ir-3mp",
@@ -37125,7 +37549,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-bo1-ir-5mp",
@@ -37209,7 +37634,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-dc1-ir-2mp",
@@ -37293,7 +37719,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-do1-ir-5mp",
@@ -37378,7 +37805,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6m-d1-ir-2mp",
@@ -37463,7 +37891,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6ptze-dp30",
@@ -37547,7 +37976,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6sl-bo1-ir-5mp",
@@ -37631,7 +38061,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6sl-do1-ir-2mp",
@@ -37716,7 +38147,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-f4105-re",
@@ -37793,7 +38225,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-fa54",
@@ -37867,7 +38300,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m2025-le",
@@ -37947,7 +38381,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m2035-le",
@@ -38029,7 +38464,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3048-p",
@@ -38107,7 +38543,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3064-v",
@@ -38188,7 +38625,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3077-plve",
@@ -38275,7 +38713,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m3085-v",
@@ -38360,7 +38799,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m3086-v",
@@ -38446,7 +38886,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3088-v",
@@ -38532,7 +38973,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3106-l-mk-ii",
@@ -38619,7 +39061,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3106-lve-mk-ii",
@@ -38704,7 +39147,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3115-lve",
@@ -38786,7 +39230,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3116-lve",
@@ -38868,7 +39313,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4216-lv",
@@ -38957,7 +39403,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4216-v",
@@ -39045,7 +39492,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4317-plve",
@@ -39131,7 +39579,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m4318-plve",
@@ -39218,7 +39667,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m5526-e",
@@ -39300,7 +39750,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1275",
@@ -39382,7 +39833,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1368-e",
@@ -39460,7 +39912,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1448-le",
@@ -39544,7 +39997,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1465-le",
@@ -39630,7 +40084,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p1465-le-3",
@@ -39717,7 +40172,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3245-lv",
@@ -39792,7 +40248,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-lve",
@@ -39879,7 +40336,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-lve-3",
@@ -39967,7 +40425,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-v",
@@ -40050,7 +40509,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-v-mena",
@@ -40141,7 +40601,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-ve",
@@ -40219,7 +40680,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lv",
@@ -40310,7 +40772,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lve",
@@ -40400,7 +40863,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lve-3",
@@ -40490,7 +40954,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-v",
@@ -40577,7 +41042,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3267-lv",
@@ -40663,7 +41129,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3267-lve",
@@ -40749,7 +41216,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3268-lve",
@@ -40825,7 +41293,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3344",
@@ -40900,7 +41369,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3727-ple",
@@ -40987,7 +41457,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3737-ple",
@@ -41072,7 +41543,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3818-pve",
@@ -41154,7 +41626,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p5655-e",
@@ -41235,7 +41708,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p5676-le",
@@ -41323,7 +41797,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1656",
@@ -41402,7 +41877,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1656-be",
@@ -41485,7 +41961,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1785-le",
@@ -41570,7 +42047,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1942-e",
@@ -41652,7 +42130,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1952-e",
@@ -41738,7 +42217,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-q2101-e",
@@ -41821,7 +42301,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3527-lve",
@@ -41904,7 +42385,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3536-lve",
@@ -41988,7 +42470,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3538-lve",
@@ -42078,7 +42561,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3538-slve",
@@ -42166,7 +42650,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3819-pve",
@@ -42252,7 +42737,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6100-e",
@@ -42334,7 +42820,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6114-e",
@@ -42412,7 +42899,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6135-le",
@@ -42505,7 +42993,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6135-le-mena",
@@ -42597,7 +43086,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6315-le",
@@ -42685,7 +43175,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6318-le",
@@ -42774,7 +43265,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-q9307-lv",
@@ -42854,7 +43346,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "blink-indoor",
@@ -42916,7 +43409,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-mini",
@@ -42977,7 +43471,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-mini-2",
@@ -43042,7 +43537,8 @@
     "markets": [
       "AU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-mini-2k-plus",
@@ -43104,7 +43600,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-mini-pan-tilt-mount",
@@ -43166,7 +43663,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-outdoor-2k-plus",
@@ -43231,7 +43729,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-outdoor-3rd-gen",
@@ -43294,7 +43793,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-outdoor-4",
@@ -43363,7 +43863,8 @@
     "markets": [
       "EU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-outdoor-4-floodlight",
@@ -43428,7 +43929,8 @@
       "solar",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-video-doorbell",
@@ -43491,7 +43993,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-wired-floodlight",
@@ -43553,7 +44056,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-xt2",
@@ -43616,7 +44120,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "bosch-fcs-8000-vfd-i",
@@ -43744,7 +44249,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-flexidome-5100i-mena",
@@ -43836,7 +44342,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-mic-550ir55-p",
@@ -43896,7 +44403,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-mic-7504-z12br",
@@ -44037,7 +44545,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7504-z12gr",
@@ -44141,7 +44650,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7504-z12wr",
@@ -44272,7 +44782,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30b",
@@ -44403,7 +44914,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30br",
@@ -44537,7 +45049,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30g",
@@ -44660,7 +45173,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30gr",
@@ -44770,7 +45284,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30w",
@@ -44898,7 +45413,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30wr",
@@ -45017,7 +45533,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bqs",
@@ -45135,7 +45652,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvf",
@@ -45263,7 +45781,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvf9",
@@ -45391,7 +45910,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvs",
@@ -45508,7 +46028,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvs9",
@@ -45643,7 +46164,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gqs",
@@ -45769,7 +46291,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gvf",
@@ -45906,7 +46429,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gvf9",
@@ -46030,7 +46554,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wqs",
@@ -46145,7 +46670,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvf",
@@ -46262,7 +46788,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvf9",
@@ -46370,7 +46897,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvs",
@@ -46505,7 +47033,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvs9",
@@ -46637,7 +47166,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b06v",
@@ -46757,7 +47287,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b14v",
@@ -46874,7 +47405,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b18q",
@@ -46990,7 +47522,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b42v",
@@ -47108,7 +47641,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g06v",
@@ -47222,7 +47756,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g14v",
@@ -47331,7 +47866,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g18q",
@@ -47437,7 +47973,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g42v",
@@ -47560,7 +48097,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w06v",
@@ -47661,7 +48199,8 @@
         "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w14v",
@@ -47773,7 +48312,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w18q",
@@ -47892,7 +48432,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w42v",
@@ -48011,7 +48552,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-3702-al",
@@ -48120,7 +48662,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-3703-al",
@@ -48224,7 +48767,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-5702-al",
@@ -48307,7 +48851,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-5703-al",
@@ -48391,7 +48936,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-5704-al",
@@ -48515,7 +49061,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7702-alx",
@@ -48641,7 +49188,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7702-alxt",
@@ -48724,7 +49272,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-7703-alx",
@@ -48851,7 +49400,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7703-alxt",
@@ -48956,7 +49506,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-al",
@@ -49065,7 +49616,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-alt",
@@ -49187,7 +49739,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-alx",
@@ -49312,7 +49865,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7802-ax",
@@ -49432,7 +49986,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7802-axt",
@@ -49542,7 +50097,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803-ax",
@@ -49657,7 +50213,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803-axt",
@@ -49767,7 +50324,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803s-ax",
@@ -49887,7 +50445,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803s-axt",
@@ -49997,7 +50556,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-63023-b",
@@ -50115,7 +50675,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-73023-ba",
@@ -50233,7 +50794,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-9122-p",
@@ -50313,7 +50875,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbt-8700-f03qf",
@@ -50433,7 +50996,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f05qf",
@@ -50554,7 +51118,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f09qf",
@@ -50673,7 +51238,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f18qf",
@@ -50794,7 +51360,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f06vf",
@@ -50905,7 +51472,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f14vf",
@@ -51030,7 +51598,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f25vf",
@@ -51156,7 +51725,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f42vf",
@@ -51267,7 +51837,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nce-7703-fk",
@@ -51376,7 +51947,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndc-8502-r-ooh",
@@ -51464,7 +52036,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndd-7802-al",
@@ -51576,7 +52149,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndd-7803-al",
@@ -51695,7 +52269,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3503-f02",
@@ -51815,7 +52390,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3702-al",
@@ -51915,7 +52491,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3703-al",
@@ -52020,7 +52597,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3703-al-io",
@@ -52137,7 +52715,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5503-al",
@@ -52219,7 +52798,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5702-a",
@@ -52331,7 +52911,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5702-al",
@@ -52413,7 +52994,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5703-a",
@@ -52533,7 +53115,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5703-al",
@@ -52616,7 +53199,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5704-a",
@@ -52723,7 +53307,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5704-al",
@@ -52832,7 +53417,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8512-r",
@@ -52918,7 +53504,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-8512-rx",
@@ -53002,7 +53589,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-8702-rx",
@@ -53111,7 +53699,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8702-rxl",
@@ -53216,7 +53805,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8702-rxt",
@@ -53332,7 +53922,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-r",
@@ -53458,7 +54049,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rl",
@@ -53569,7 +54161,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rt",
@@ -53695,7 +54288,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rx",
@@ -53812,7 +54406,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rxl",
@@ -53936,7 +54531,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rxt",
@@ -54058,7 +54654,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-r",
@@ -54165,7 +54762,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rl",
@@ -54302,7 +54900,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rt",
@@ -54413,7 +55012,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rx",
@@ -54517,7 +55117,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rxl",
@@ -54640,7 +55241,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-a",
@@ -54743,7 +55345,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-a-io",
@@ -54866,7 +55469,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-al",
@@ -54979,7 +55583,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3703-a",
@@ -55083,7 +55688,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3703-al",
@@ -55184,7 +55790,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7702-a",
@@ -55295,7 +55902,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7702-al",
@@ -55427,7 +56035,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7703-a",
@@ -55559,7 +56168,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7703-al",
@@ -55638,7 +56248,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndp-5522-z30",
@@ -55766,7 +56377,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5522-z30c",
@@ -55890,7 +56502,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5522-z30l",
@@ -56026,7 +56639,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5533-z30l",
@@ -56155,7 +56769,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7802-z40",
@@ -56274,7 +56889,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7802-z40l",
@@ -56398,7 +57014,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7804-z12l",
@@ -56521,7 +57138,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5703-f360",
@@ -56646,7 +57264,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5703-f360le",
@@ -56724,7 +57343,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nds-5704-f360",
@@ -56829,7 +57449,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5704-f360le",
@@ -56963,7 +57584,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5702-a",
@@ -57083,7 +57705,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5702-al",
@@ -57166,7 +57789,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndv-5703-a",
@@ -57278,7 +57902,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5703-al",
@@ -57361,7 +57986,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndv-5704-a",
@@ -57474,7 +58100,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5704-al",
@@ -57591,7 +58218,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8502-r",
@@ -57711,7 +58339,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8502-rx",
@@ -57810,7 +58439,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8503-r",
@@ -57929,7 +58559,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8503-rx",
@@ -58045,7 +58676,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8504-r",
@@ -58168,7 +58800,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f07qs",
@@ -58282,7 +58915,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f19qf",
@@ -58403,7 +59037,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f19qs",
@@ -58508,7 +59143,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f09vf",
@@ -58624,7 +59260,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f09vs",
@@ -58739,7 +59376,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f17vf",
@@ -58858,7 +59496,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f35vf",
@@ -58970,7 +59609,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f65vf",
@@ -59076,7 +59716,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f65vs",
@@ -59192,7 +59833,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nti-50022-a3",
@@ -59276,7 +59918,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nti-50022-a3s",
@@ -59357,7 +60000,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nue-3702-f02",
@@ -59470,7 +60114,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3702-f04",
@@ -59584,7 +60229,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3702-f06",
@@ -59698,7 +60344,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f02",
@@ -59812,7 +60459,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f04",
@@ -59917,7 +60565,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f06",
@@ -60027,7 +60676,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f02",
@@ -60139,7 +60789,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f04",
@@ -60247,7 +60898,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f04h",
@@ -60362,7 +61014,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f06",
@@ -60473,7 +61126,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f02",
@@ -60573,7 +61227,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f02h",
@@ -60685,7 +61340,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f04",
@@ -60793,7 +61449,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f06",
@@ -60910,7 +61567,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-smart-home-outdoor-cam-2",
@@ -60980,7 +61638,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "camius-boltx-4k",
@@ -61051,7 +61710,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-boltx-5mp",
@@ -61122,7 +61782,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-iris-4k",
@@ -61193,7 +61854,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-iris-5mp",
@@ -61274,7 +61936,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "canon-vb-h47",
@@ -61373,7 +62036,8 @@
         "profile": "Canon",
         "notes": "Select the 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "canon-vb-m46",
@@ -61472,7 +62136,8 @@
         "profile": "Canon",
         "notes": "Select the 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "canon-vb-r13ve",
@@ -61562,7 +62227,8 @@
         "profile": "Canon",
         "notes": "Select 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "canon-vb-s805d-mk2",
@@ -61651,7 +62317,8 @@
         "profile": "Canon",
         "notes": "Select 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "costar-av02cid-200",
@@ -61751,7 +62418,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av02cid-201",
@@ -61851,7 +62519,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cid-200",
@@ -61949,7 +62618,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cid-201",
@@ -62047,7 +62717,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cld-200",
@@ -62149,7 +62820,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av10956dn-28",
@@ -62237,7 +62909,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av12cfe-250",
@@ -62332,7 +63005,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av12cpd-236",
@@ -62434,7 +63108,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av16956dn-28",
@@ -62523,7 +63198,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av4956dn-28",
@@ -62611,7 +63287,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-e35q",
@@ -62692,7 +63369,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-e45q-india",
@@ -62773,7 +63451,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-be51e-vmd-q",
@@ -62855,7 +63534,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da21l3b-lq",
@@ -62945,7 +63625,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da21l3c-q",
@@ -63036,7 +63717,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da21pl3",
@@ -63128,7 +63810,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-lq",
@@ -63219,7 +63902,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-lq2",
@@ -63310,7 +63994,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-q2",
@@ -63401,7 +64086,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-lq",
@@ -63493,7 +64179,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ee61l2c-vmd-q",
@@ -63588,7 +64275,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ta21l3b-lq",
@@ -63678,7 +64366,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta21l3c-q",
@@ -63769,7 +64458,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ta21l6c-q",
@@ -63860,7 +64550,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta21pl3",
@@ -63950,7 +64641,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-d-lq",
@@ -64038,7 +64730,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-d-q2",
@@ -64129,7 +64822,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-lq",
@@ -64219,7 +64913,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-tc21l5c-vmd-lq",
@@ -64313,7 +65008,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc61l5c-vmd-lq",
@@ -64407,7 +65103,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc81l5c-vmd-lq",
@@ -64501,7 +65198,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc81zl6c-vmd-lq",
@@ -64595,7 +65293,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-te81zl6c-vmds-q",
@@ -64690,7 +65389,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-vc61l5c-vmd-lq",
@@ -64784,7 +65484,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-vc81zl5c-vmd-q",
@@ -64878,7 +65579,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-z43q",
@@ -64963,7 +65665,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-dh-sd49425xb-hnr",
@@ -65054,7 +65757,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-dh-sd6al245xa-hnr",
@@ -65145,7 +65849,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-dh-sdt7425-4p-ad3e-pv-i",
@@ -65273,7 +65978,8 @@
         }
       ]
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-12"
   },
   {
     "id": "dahua-hac-hdw1200trq-il-t",
@@ -65340,7 +66046,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1249sm-a-pro",
@@ -65406,7 +66113,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1500trq-il-t",
@@ -65473,7 +66181,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1509t-a-led",
@@ -65526,7 +66235,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-hac-hdw1549sm-a-pro",
@@ -65593,7 +66303,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1549sm-il-a-pro",
@@ -65660,7 +66371,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1801trq-il-t",
@@ -65727,7 +66439,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw1509t-a-led",
@@ -65780,7 +66493,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-hac-hfw1549sm-a-pro",
@@ -65847,7 +66561,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw1549sm-il-a-pro",
@@ -65914,7 +66629,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw2249e-a-led",
@@ -65981,7 +66697,8 @@
     "sources": [
       "https://www.dahuasecurity.com/asset/upload/uploads/soft/20190506/DH-HAC-HFW2249E-A-LED_Datasheet.pdf"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-hac-hfw2802e-a",
@@ -66053,7 +66770,8 @@
     "sources": [
       "https://www.dahuasecurity.com/products/All-Products/HDCVI-Cameras/Pro-Series/4K/Starlight/HAC-HFW2802E-A"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdbw2441e-s",
@@ -66138,7 +66856,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw2441r-zas",
@@ -66227,7 +66946,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdbw2831e-s-s2",
@@ -66311,7 +67031,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw2849e-s-il",
@@ -66399,7 +67120,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3241e-s",
@@ -66475,7 +67197,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3441dr1-ast-4g-la",
@@ -66562,7 +67285,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3441e-s",
@@ -66639,7 +67363,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3449r1-zas-pv-pro",
@@ -66728,7 +67453,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3649r1-zas-pv-pro",
@@ -66817,7 +67543,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3849e-s-il",
@@ -66893,7 +67620,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3849f-as-il",
@@ -66980,7 +67708,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3849r1-zas-pv",
@@ -67067,7 +67796,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3849r1-zas-pv-pro",
@@ -67156,7 +67886,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3866ep-as",
@@ -67244,7 +67975,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3866rp-zas",
@@ -67331,7 +68063,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3867e-as-il",
@@ -67417,7 +68150,8 @@
     },
     "last_verified": "2026-07-06",
     "field_of_view_deg": "110",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3867r-zas-il",
@@ -67504,7 +68238,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "114-32",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw5259r-ase-il",
@@ -67593,7 +68328,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw5442r-ze",
@@ -67677,7 +68413,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw5842ep-ze-s3",
@@ -67765,7 +68502,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw1230dt-stw",
@@ -67850,7 +68588,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1239t1-led-s6",
@@ -67925,7 +68664,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1339da-saw-il",
@@ -68011,7 +68751,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1339da-sw-pv",
@@ -68098,7 +68839,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1430dt-stw",
@@ -68183,7 +68925,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1439t-a-led-s4",
@@ -68262,7 +69005,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1439t1-led",
@@ -68338,7 +69082,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1439v-il-k",
@@ -68422,7 +69167,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1539da-saw-il",
@@ -68508,7 +69254,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1539da-sw-pv",
@@ -68595,7 +69342,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1830t-h",
@@ -68672,7 +69420,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2241t-s",
@@ -68769,7 +69518,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2249t-s-il",
@@ -68856,7 +69606,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw2249t-zs-il",
@@ -68942,7 +69693,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2439t-as-led-s2",
@@ -69018,7 +69770,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2441t-s",
@@ -69115,7 +69868,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2449t-s-il",
@@ -69215,7 +69969,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2449t-zs-il",
@@ -69302,7 +70057,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2449tm-s-il",
@@ -69388,7 +70144,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2549emp-s-pro",
@@ -69471,7 +70228,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw2649t-zs-il",
@@ -69558,7 +70316,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2649tm-s-il",
@@ -69644,7 +70403,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2831t-as-s2",
@@ -69732,7 +70492,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2841t-zs",
@@ -69820,7 +70581,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-il",
@@ -69921,7 +70683,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-il-india",
@@ -70021,7 +70784,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-pro",
@@ -70123,7 +70887,8 @@
       "blue_iris": {
         "profile": "Dahua"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2849t-zs-il",
@@ -70210,7 +70975,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2849tm-s-il",
@@ -70308,7 +71074,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw3449h-as-pv-pro",
@@ -70398,7 +71165,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3549h-as-pv",
@@ -70482,7 +71250,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3649h-as-pv",
@@ -70572,7 +71341,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3841tp-zas",
@@ -70657,7 +71427,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-as-pv",
@@ -70748,7 +71519,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-as-pv-pro",
@@ -70836,7 +71608,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-zas-pv",
@@ -70922,7 +71695,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849t-zs-il",
@@ -71010,7 +71784,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw3866emp-s",
@@ -71097,7 +71872,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "110",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3866tp-zs",
@@ -71185,7 +71961,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3867em-s-il",
@@ -71271,7 +72048,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3867t-zs-il",
@@ -71356,7 +72134,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw5259t-ze-il",
@@ -71444,7 +72223,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw5259tm-ase-il",
@@ -71532,7 +72312,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw5442t-ze",
@@ -71613,7 +72394,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5442tm-ase",
@@ -71699,7 +72481,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5449h-ase-d2",
@@ -71789,7 +72572,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw5842t-ze",
@@ -71875,7 +72659,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5842tm-ase",
@@ -71961,7 +72746,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hf71242f-z-x",
@@ -72049,7 +72835,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1230ds-saw",
@@ -72135,7 +72922,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1239s1-led-s6",
@@ -72209,7 +72997,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1339dtk1-sw-pv",
@@ -72296,7 +73085,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1430dt-stw",
@@ -72381,7 +73171,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1439s-led-s4",
@@ -72456,7 +73247,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1-led",
@@ -72531,7 +73323,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1-led-s4",
@@ -72605,7 +73398,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1p-led-s4",
@@ -72692,7 +73486,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw1539dtk1-sw-pv",
@@ -72779,7 +73574,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1830s-s6",
@@ -72855,7 +73651,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2241s-s",
@@ -72930,7 +73727,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2249s-s-il-nl",
@@ -73017,7 +73815,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw2431t-as-s2",
@@ -73105,7 +73904,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2439s-sa-led-b",
@@ -73179,7 +73979,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2441s-s",
@@ -73254,7 +74055,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2449s-s-il",
@@ -73338,7 +74140,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2449t-as-il",
@@ -73424,7 +74227,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2449t-zas-il",
@@ -73511,7 +74315,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2649t-as-il",
@@ -73597,7 +74402,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2649t-zas-il",
@@ -73684,7 +74490,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2831sp-s-s2",
@@ -73771,7 +74578,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw2831t-as-s2-latam",
@@ -73863,7 +74671,8 @@
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2831t-zas-s2",
@@ -73947,7 +74756,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2831tp-zs",
@@ -74030,7 +74840,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw2841t-zas-s2",
@@ -74105,7 +74916,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849s-s-il",
@@ -74189,7 +75001,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849s-s-il-s2",
@@ -74265,7 +75078,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849t-as-il",
@@ -74351,7 +75165,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2849t-zas-il",
@@ -74438,7 +75253,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2849tl-s-pro",
@@ -74546,7 +75362,8 @@
       "blue_iris": {
         "profile": "Dahua"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3241e-s",
@@ -74621,7 +75438,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3441e-s",
@@ -74696,7 +75514,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3449t1-as-pv",
@@ -74804,7 +75623,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3549e-as-led",
@@ -74887,7 +75707,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3549t1-as-pv",
@@ -74993,7 +75814,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3649t1-as-pv-s2",
@@ -75081,7 +75903,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw3667t-zas-il",
@@ -75168,7 +75991,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "114-32",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3841t-zas-s2",
@@ -75244,7 +76068,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3841tp-zas",
@@ -75333,7 +76158,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "113-31",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3849e-as-il",
@@ -75416,7 +76242,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849e-s-il",
@@ -75501,7 +76328,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-as-pv",
@@ -75590,7 +76418,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-as-pv-pro",
@@ -75680,7 +76509,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-zas-pv",
@@ -75765,7 +76595,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-zas-pv-pro",
@@ -75853,7 +76684,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw3866ep-as",
@@ -75938,7 +76770,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3866tp-zas",
@@ -76024,7 +76857,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3867t-zas-il",
@@ -76109,7 +76943,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw5442e-ze",
@@ -76194,7 +77029,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5442e-ze-s3",
@@ -76272,7 +77108,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5842e-ze",
@@ -76358,7 +77195,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5842h-z4he",
@@ -76446,7 +77284,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5849t1-ase-led",
@@ -76554,7 +77393,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw71242h-z",
@@ -76644,7 +77484,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw7442h-z4-x",
@@ -76721,7 +77562,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw7842h-z-x",
@@ -76799,7 +77641,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw7842h-z4-x",
@@ -76887,7 +77730,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pdbw5831-b360",
@@ -76972,7 +77816,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pf83230-a180",
@@ -77057,7 +77902,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pfw5849-a180-e2-aste",
@@ -77148,7 +77994,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-pfw8802-a180",
@@ -77233,7 +78080,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-itc237-pw1b-irz-lr",
@@ -77319,7 +78167,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd49225xa-hnr-mena",
@@ -77413,7 +78262,8 @@
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd49425db-hny",
@@ -77501,7 +78351,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd49825gb-hnr",
@@ -77586,7 +78437,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd4d225mb-hnr",
@@ -77674,7 +78526,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd4d425mb-hnr",
@@ -77762,7 +78615,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd4d825mb-hnr",
@@ -77851,7 +78705,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd5a432gb-hnr",
@@ -77939,7 +78794,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd6c3432gb-hnr-a-pv1",
@@ -78053,7 +78909,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-sdt3e410-8p-mb-a-pv1",
@@ -78137,7 +78994,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "Panoramic 1/1.8\" + PTZ 1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-sdt4e425-8p-gb-apv1",
@@ -78222,7 +79080,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "STARVIS CMOS",
-    "field_of_view_deg": "180"
+    "field_of_view_deg": "180",
+    "added": "2026-07-06"
   },
   {
     "id": "eufy-4g-lte-cam-s330",
@@ -78290,7 +79149,8 @@
     "operating_temp_c": "-20 to 50",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-2",
@@ -78366,7 +79226,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase-served RTSP URL on port 554; eufy is not ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-2-pro",
@@ -78452,7 +79313,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app; stream comes from HomeBase IP."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-2c",
@@ -78537,7 +79399,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app; stream comes from HomeBase IP."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-2c-pro",
@@ -78614,7 +79477,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase-served RTSP URL on port 554; eufy is not ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-3",
@@ -78689,7 +79553,8 @@
       "global"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-eufycam-3c",
@@ -78765,7 +79630,8 @@
       "global"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-e",
@@ -78824,7 +79690,8 @@
       "https://service.eufy.com/article-description/Differences-Between-All-Add-on-eufyCams"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-e330-pro",
@@ -78890,7 +79757,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-e40",
@@ -78961,7 +79829,8 @@
       "outdoor"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-s3-pro",
@@ -79066,7 +79935,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-s4",
@@ -79148,7 +80018,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-1080p",
@@ -79220,7 +80091,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-2-pro",
@@ -79306,7 +80178,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in the Eufy Security app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-floodlight-cam-2k",
@@ -79378,7 +80251,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-e220",
@@ -79447,7 +80321,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-floodlight-cam-e30",
@@ -79516,7 +80391,8 @@
     "status": "available",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-e340",
@@ -79585,7 +80461,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-garage-cam-s330",
@@ -79677,7 +80554,8 @@
         "profile": "Generic/RTSP",
         "notes": "Eufy is not a Hikvision/ONVIF brand — use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF)."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-indoor-cam-2k-pan-tilt",
@@ -79771,7 +80649,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-c120",
@@ -79862,7 +80741,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-c210",
@@ -79935,7 +80815,8 @@
       "https://service.eufy.com/article-description/eufy-Security-Indoor-Cam-C210-User-Guide-T8419"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-c220",
@@ -80003,7 +80884,8 @@
       "https://service.eufy.com/article-description/Indoor-Cam-C220-User-Guide-T8W11"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-e220",
@@ -80093,7 +80975,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-e30",
@@ -80156,7 +81039,8 @@
     "status": "available",
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-mini",
@@ -80224,7 +81108,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "release_notes": "Corrected from 1080p fixed to 2K 360 pan/tilt per eufy's official 'Introducing eufy Indoor Cam Mini 2K' article (360 horizontal / 100 vertical). RTSP not confirmed by an official eufy source; app/cloud (http) only."
+    "release_notes": "Corrected from 1080p fixed to 2K 360 pan/tilt per eufy's official 'Introducing eufy Indoor Cam Mini 2K' article (360 horizontal / 100 vertical). RTSP not confirmed by an official eufy source; app/cloud (http) only.",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-indoor-cam-s350",
@@ -80296,7 +81181,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "release_notes": "RTSP removed: not confirmed by any official eufy source (eufy 'About NAS/RTSP' article lists only eufyCam 3C/3/E330 Pro; S350 FAQ and product page do not mention RTSP). Community (iSpyConnect) reports /live0 but this is unverified."
+    "release_notes": "RTSP removed: not confirmed by any official eufy source (eufy 'About NAS/RTSP' article lists only eufyCam 3C/3/E330 Pro; S350 FAQ and product page do not mention RTSP). Community (iSpyConnect) reports /live0 but this is unverified.",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-outdoor-cam-e210",
@@ -80389,7 +81275,8 @@
         "profile": "Generic/RTSP",
         "notes": "Add as a Network IP camera with a manual RTSP path (/live0); no ONVIF."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-outdoor-cam-e220",
@@ -80491,7 +81378,8 @@
         "profile": "Generic/RTSP",
         "notes": "Add as a Network IP camera with a manual RTSP path (/live0); no ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-s220-solocam",
@@ -80559,7 +81447,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-c210",
@@ -80629,7 +81518,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-e30",
@@ -80690,7 +81580,8 @@
     "status": "available",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-solocam-e40",
@@ -80757,7 +81648,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-e42",
@@ -80831,7 +81723,8 @@
       "https://service.eufy.com/article-description/Basic-Information-of-SoloCam-E42"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-solocam-l20",
@@ -80899,7 +81792,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-l40",
@@ -80967,7 +81861,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-s230",
@@ -81038,7 +81933,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-s340",
@@ -81107,7 +82003,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-s40",
@@ -81176,7 +82073,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-c30",
@@ -81242,7 +82140,8 @@
       "https://service.eufy.com/article-description/Video-Doorbell-C30-User-Guide-T8224"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-video-doorbell-c31",
@@ -81312,7 +82211,8 @@
       "https://service.eufy.com/product-description/a08J1000000YA4KIAW"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-video-doorbell-dual",
@@ -81387,7 +82287,8 @@
         "integration": "eufy_security",
         "notes": "Use the eufy_security HACS integration (P2P live stream). Doorbell press exposed as event. No native RTSP/ONVIF — eufy confirms the Video Doorbell Dual does not support RTSP."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-e340",
@@ -81481,7 +82382,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF). Portrait aspect ratio."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-s220",
@@ -81549,7 +82451,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-video-doorbell-s330",
@@ -81640,7 +82543,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF). Portrait aspect ratio."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-wall-light-cam-s100",
@@ -81708,7 +82612,8 @@
       "https://www.eufy.com/eu-en/products/t84a1311",
       "https://service.eufy.com/article-description/Introducing-S100-Wall-Light-Cam"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "ezviz-bc1c-4k",
@@ -81778,7 +82683,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-bc1c-elife",
@@ -81847,7 +82753,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-bc1c-elife-2k",
@@ -81914,7 +82821,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-bc2",
@@ -81978,7 +82886,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c1c-b",
@@ -82040,7 +82949,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c1c-pir",
@@ -82108,7 +83018,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c2c-h265",
@@ -82171,7 +83082,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3tn",
@@ -82237,7 +83149,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3tn-2k",
@@ -82305,7 +83218,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3w-pro",
@@ -82370,7 +83284,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c3x",
@@ -82433,7 +83348,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c60p-dual-mix-2k",
@@ -82496,7 +83412,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6c-2k",
@@ -82560,7 +83477,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6n",
@@ -82668,7 +83586,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c6n-g1-4k",
@@ -82733,7 +83652,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6n-pro-2k",
@@ -82798,7 +83718,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c7-dual",
@@ -82862,7 +83783,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c8c",
@@ -82938,7 +83860,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c8c-4k",
@@ -83005,7 +83928,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c8pf",
@@ -83074,7 +83998,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c8w-pro-2k",
@@ -83152,7 +84077,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c90-dual-2k-plus",
@@ -83219,7 +84145,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c9c-dual-3k",
@@ -83286,7 +84213,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb1",
@@ -83351,7 +84279,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb2",
@@ -83415,7 +84344,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb2-4g",
@@ -83477,7 +84407,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb3-4g",
@@ -83541,7 +84472,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb3-aov",
@@ -83610,7 +84542,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb5-4k",
@@ -83677,7 +84610,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8",
@@ -83743,7 +84677,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-lite-4g",
@@ -83811,7 +84746,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-lite-4k",
@@ -83878,7 +84814,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-pro",
@@ -83945,7 +84882,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb90-dual-kit",
@@ -84012,7 +84950,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb90x-dual-4g-kit",
@@ -84080,7 +85019,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cp1-pro",
@@ -84144,7 +85084,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-db2-doorbell",
@@ -84223,7 +85164,8 @@
         "notes": "No RTSP or ONVIF. Cloud-dependent, app-only. EZVIZ integration in HA provides basic status but no local stream. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-db2c-doorbell",
@@ -84297,7 +85239,8 @@
         "notes": "No RTSP or ONVIF. Cloud-dependent, app-only. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-e4p",
@@ -84360,7 +85303,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-e6",
@@ -84426,7 +85370,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb3-4g",
@@ -84490,7 +85435,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb3-aov",
@@ -84560,7 +85506,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb5-4k",
@@ -84628,7 +85575,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-4g",
@@ -84694,7 +85642,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-pro-4g",
@@ -84763,7 +85712,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-pro-ranger-kit",
@@ -84831,7 +85781,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-el3",
@@ -84895,7 +85846,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h1c",
@@ -84958,7 +85910,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3-2k",
@@ -85024,7 +85977,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3c-2k",
@@ -85089,7 +86043,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h3c-color",
@@ -85154,7 +86109,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3k-poe-4k",
@@ -85223,7 +86179,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h4",
@@ -85291,7 +86248,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h4-poe-2k",
@@ -85358,7 +86316,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h5-4g",
@@ -85425,7 +86384,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h5-poe-2k",
@@ -85489,7 +86449,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6",
@@ -85555,7 +86516,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c",
@@ -85621,7 +86583,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c-g1-4k",
@@ -85686,7 +86649,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c-pro",
@@ -85751,7 +86715,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h7c-dual-2k-plus",
@@ -85816,7 +86781,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8-pro-3k",
@@ -85921,7 +86887,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h80f-multi-2k-plus",
@@ -85986,7 +86953,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h80x-dual",
@@ -86051,7 +87019,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c",
@@ -86156,7 +87125,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-4g",
@@ -86222,7 +87192,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-poe-2k",
@@ -86287,7 +87258,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-2k",
@@ -86351,7 +87323,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-2k-plus",
@@ -86425,7 +87398,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-pro-4g",
@@ -86493,7 +87467,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-4k",
@@ -86568,7 +87543,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-pro-4k-r210",
@@ -86633,7 +87609,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8x-2k-plus",
@@ -86698,7 +87675,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h90-dual-2k-plus",
@@ -86763,7 +87741,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h9c-dual-3k",
@@ -86828,7 +87807,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h9c-dual-4g",
@@ -86896,7 +87876,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8",
@@ -86964,7 +87945,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-lite-4g",
@@ -87031,7 +88013,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-lite-4k",
@@ -87098,7 +88081,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-pro",
@@ -87164,7 +88148,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb90-dual-kit",
@@ -87232,7 +88217,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb90x-dual-4g-kit",
@@ -87300,7 +88286,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-lc3",
@@ -87364,7 +88351,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-s10",
@@ -87430,7 +88418,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty1-g1-2k",
@@ -87495,7 +88484,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty1-pro",
@@ -87559,7 +88549,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty7-dual-2k-plus",
@@ -87625,7 +88616,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "flir-elara-fb-324t",
@@ -87702,7 +88694,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fb-632t",
@@ -87779,7 +88772,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-324t",
@@ -87856,7 +88850,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-632t",
@@ -87934,7 +88929,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-648t",
@@ -88012,7 +89008,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6302-11-i",
@@ -88090,7 +89087,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6308-31-i",
@@ -88168,7 +89166,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6404-31-i",
@@ -88246,7 +89245,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-saros-dh-390",
@@ -88325,7 +89325,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-saros-dm-390",
@@ -88403,7 +89404,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "foscam-c5m",
@@ -88482,7 +89484,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-c8m",
@@ -88561,7 +89564,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d2ep",
@@ -88640,7 +89644,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d4z",
@@ -88715,7 +89720,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d8et",
@@ -88792,7 +89798,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d8t",
@@ -88875,7 +89882,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-g4c",
@@ -88941,7 +89949,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-pd5",
@@ -89025,7 +90034,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-pd8",
@@ -89119,7 +90129,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-r8m",
@@ -89202,7 +90213,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd4",
@@ -89274,7 +90286,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd4h",
@@ -89358,7 +90371,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd8ep",
@@ -89455,7 +90469,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd8p",
@@ -89548,7 +90563,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-t5ep",
@@ -89629,7 +90645,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-t8ep",
@@ -89713,7 +90730,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed working with Blue Iris per retailer product Q&A, using generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v4ec",
@@ -89785,7 +90803,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v5ep",
@@ -89878,7 +90897,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed working with Blue Iris per official product page Q&A."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v8ep",
@@ -89973,7 +90993,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v8p",
@@ -90048,7 +91069,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-w5ep",
@@ -90127,7 +91149,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-x5",
@@ -90201,7 +91224,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "geovision-gv-abl2702",
@@ -90280,7 +91304,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-abl4712",
@@ -90359,7 +91384,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-abl8712",
@@ -90438,7 +91464,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-adr2702",
@@ -90517,7 +91544,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-adr4702",
@@ -90596,7 +91624,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-bl2702",
@@ -90674,7 +91703,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-efer3700",
@@ -90753,7 +91783,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-sd2322-ir",
@@ -90831,7 +91862,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-sd4825-ir",
@@ -90910,7 +91942,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr2704",
@@ -90988,7 +92021,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr4704",
@@ -91066,7 +92100,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr8805",
@@ -91144,7 +92179,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "godrej-eve-cube",
@@ -91212,7 +92248,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-mini",
@@ -91280,7 +92317,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-nx-pt",
@@ -91351,7 +92389,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-pro-outdoor",
@@ -91415,7 +92454,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-battery-2",
@@ -91468,7 +92508,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-indoor-1st-gen",
@@ -91530,7 +92571,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-indoor-3rd-gen",
@@ -91595,7 +92637,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-iq-indoor",
@@ -91657,7 +92700,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-iq-outdoor",
@@ -91720,7 +92764,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-outdoor-2nd-gen",
@@ -91788,7 +92833,8 @@
     "markets": [
       "EU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-outdoor-wire",
@@ -91838,7 +92884,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-wired-2021",
@@ -91902,7 +92949,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-with-floodlight",
@@ -91964,7 +93012,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-3rd-gen",
@@ -92030,7 +93079,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-battery",
@@ -92081,7 +93131,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-wired-2nd-gen",
@@ -92147,7 +93198,8 @@
     "markets": [
       "UK"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-ane-l6012r",
@@ -92260,7 +93312,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-ano-l7082r",
@@ -92368,7 +93421,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-anv-l7082r",
@@ -92476,7 +93530,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnb-a9001",
@@ -92584,7 +93639,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnd-9080r",
@@ -92707,7 +93763,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnd-a9081rv",
@@ -92826,7 +93883,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-pnm-9000vq",
@@ -92933,7 +93991,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnm-9031rv",
@@ -93053,7 +94112,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-9322vqp",
@@ -93162,7 +94222,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnm-c16083rvq",
@@ -93283,7 +94344,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-c34404rqpz",
@@ -93408,7 +94470,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-c9022rv",
@@ -93529,7 +94592,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pno-a9081r",
@@ -93650,7 +94714,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnv-a9081r",
@@ -93770,7 +94835,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qnd-6082r",
@@ -93876,7 +94942,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-6082r1",
@@ -93976,7 +95043,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-8020r",
@@ -94074,7 +95142,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-8080r-kr",
@@ -94182,7 +95251,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qne-8021r",
@@ -94290,7 +95360,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-qne-c8013rl",
@@ -94403,7 +95474,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qne-c9013rl",
@@ -94517,7 +95589,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qno-6082r1",
@@ -94624,7 +95697,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8030r",
@@ -94731,7 +95805,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8080r",
@@ -94838,7 +95913,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8080r-mena",
@@ -94948,7 +96024,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-c9083r",
@@ -95057,7 +96134,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-6082r1",
@@ -95161,7 +96239,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8030r",
@@ -95263,7 +96342,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080r",
@@ -95371,7 +96451,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080r-mena",
@@ -95482,7 +96563,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080rb",
@@ -95587,7 +96669,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-c9083r",
@@ -95697,7 +96780,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-tnv-8011c",
@@ -95809,7 +96893,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-tnv-c7013rc",
@@ -95930,7 +97015,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xnd-a9085rv",
@@ -96049,7 +97135,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xno-a9084r",
@@ -96165,7 +97252,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xno-c7083r",
@@ -96276,7 +97364,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xno-c9083r",
@@ -96387,7 +97476,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnp-9300rw",
@@ -96508,7 +97598,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-8080r",
@@ -96632,7 +97723,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-8093r",
@@ -96755,7 +97847,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-9083rz",
@@ -96873,7 +97966,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-a9084r",
@@ -96998,7 +98092,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-a9084rs",
@@ -97117,7 +98212,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xnv-c7083r",
@@ -97239,7 +98335,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hifocus-hc-ipc-b4262",
@@ -97327,7 +98424,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105.6",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4212du-vf-x",
@@ -97415,7 +98513,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
     "field_of_view_deg": "112.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4212w-vf",
@@ -97502,7 +98601,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4214dz-vf",
@@ -97589,7 +98689,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "106.25-30.42",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215da-0280",
@@ -97677,7 +98778,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "107.4-29.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215dv-0280",
@@ -97765,7 +98867,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "102",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215dzs-vf",
@@ -97855,7 +98958,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.5\" progressive-scan CMOS",
     "field_of_view_deg": "80-38",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4312dz-vf",
@@ -97943,7 +99047,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94-28",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-di3212dvzk-n5-o",
@@ -98030,7 +99135,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
     "field_of_view_deg": "98.3-32.2",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-di3215dvzk-n5-o",
@@ -98119,7 +99225,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "102.9-31.4",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-dqa4318l-twl-0280",
@@ -98207,7 +99314,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" progressive-scan CMOS",
     "field_of_view_deg": "110.4-89.4",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-dt4215-0280",
@@ -98293,7 +99401,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "115",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-rg31t",
@@ -98357,7 +99466,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "1/3\" color CMOS",
-    "field_of_view_deg": "105"
+    "field_of_view_deg": "105",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-rg31tl",
@@ -98442,7 +99552,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd0440t-al",
@@ -98530,7 +99641,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" BSI CMOS (NIR+)",
     "field_of_view_deg": "97-31",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd3380e",
@@ -98618,7 +99730,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd3820sr",
@@ -98707,7 +99820,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd4420-x33-ex",
@@ -98793,7 +99907,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP68"
+    "ip_rating": "IP68",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdbg31t",
@@ -98878,7 +99993,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdbg41t",
@@ -98939,7 +100055,8 @@
       "ac-mains"
     ],
     "last_verified": "2026-07-06",
-    "field_of_view_deg": "108"
+    "field_of_view_deg": "108",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdq53320s",
@@ -99028,7 +100145,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdqa20540-s",
@@ -99116,7 +100234,8 @@
         "notes": "Hi-Focus PTZ uses the Dahua protocol — select the 'Dahua' profile (or Generic/ONVIF)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4212er5-0600",
@@ -99202,7 +100321,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
     "field_of_view_deg": "106.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4212u-0600",
@@ -99287,7 +100407,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4213d-vf",
@@ -99373,7 +100494,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94-28",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214a-0600",
@@ -99460,7 +100582,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214dz-vf",
@@ -99543,7 +100666,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/3\" progressive-scan CMOS",
     "field_of_view_deg": "105-35",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214sr5-0600",
@@ -99630,7 +100754,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "93.38-28.56",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4215t12-0400",
@@ -99717,7 +100842,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "82",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-ti4312dvzk-n8-o",
@@ -99804,7 +100930,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
     "field_of_view_deg": "102.9-31.4",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-ti4315dvzk-n8-o",
@@ -99893,7 +101020,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "98.3-32.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tqa4415l-twl-0600",
@@ -99980,7 +101108,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "88.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tsa3300n3-pe-dl",
@@ -100065,7 +101194,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
     "field_of_view_deg": "69",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tv31e-4g",
@@ -100151,7 +101281,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-lpc-tqa4312l-twl-0400",
@@ -100236,7 +101367,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "77.5",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-lpc-tqa4318l-twl-0400",
@@ -100324,7 +101456,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" progressive-scan CMOS",
     "field_of_view_deg": "99.0-77.5",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg30n3-4g",
@@ -100409,7 +101542,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg31t-4g",
@@ -100474,7 +101608,8 @@
     ],
     "last_verified": "2026-07-06",
     "field_of_view_deg": "98.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg42t",
@@ -100559,7 +101694,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3022-dl-i2",
@@ -100643,7 +101779,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3022e-i2",
@@ -100729,7 +101866,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3024-dl-i2",
@@ -100815,7 +101953,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3024e-i2",
@@ -100899,7 +102038,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3112-dls-i2",
@@ -100987,7 +102127,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3115-dls-i2",
@@ -101075,7 +102216,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3304-dls-r1",
@@ -101162,7 +102304,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3312-dls-i2",
@@ -101248,7 +102391,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3315-dls-i2",
@@ -101334,7 +102478,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3512-kvdl-i2",
@@ -101418,7 +102563,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4022-dl-i2",
@@ -101504,7 +102650,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4022e-i2",
@@ -101587,7 +102734,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4024-dl-i2",
@@ -101671,7 +102819,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4024e-i2",
@@ -101755,7 +102904,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4404-dl-r1",
@@ -101837,7 +102987,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4504-adl-r1",
@@ -101921,7 +103072,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4504-dls-r1",
@@ -102008,7 +103160,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4512-adls-i2",
@@ -102091,7 +103244,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4515-adls-i2",
@@ -102176,7 +103330,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4804-dls-r1",
@@ -102263,7 +103418,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4815-kdls-i2",
@@ -102348,7 +103504,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215itg",
@@ -102408,7 +103565,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215tg",
@@ -102466,7 +103624,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215tg-3",
@@ -102524,7 +103683,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225itg",
@@ -102584,7 +103744,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225tg",
@@ -102642,7 +103803,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225tg-3",
@@ -102700,7 +103862,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4425itg",
@@ -102760,7 +103923,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5225itg",
@@ -102819,7 +103983,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5225tg",
@@ -102877,7 +104042,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5232itg",
@@ -102936,7 +104102,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5232tg",
@@ -102994,7 +104161,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5425itg",
@@ -103053,7 +104221,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae7232itg",
@@ -103113,7 +104282,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cc12d9t-a",
@@ -103168,7 +104338,8 @@
     "lens": {
       "count": 1,
       "varifocal": false
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cc12d9t-ait3ze",
@@ -103227,7 +104398,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "32.1-98",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd1023g0e-i",
@@ -103343,7 +104515,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2cd1023g2-iuf",
@@ -103441,7 +104614,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
-    "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD."
+    "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1023g2-liu",
@@ -103525,7 +104699,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1023g2-liuf",
@@ -103621,7 +104796,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m."
+    "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1027g2h-liu",
@@ -103744,7 +104920,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2cd1027g2h-liuf",
@@ -103841,7 +105018,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic."
+    "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1043g2-iuf",
@@ -103939,7 +105117,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD."
+    "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1043g2-liu",
@@ -104023,7 +105202,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1043g2-liuf",
@@ -104121,7 +105301,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic."
+    "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1047g0-luf",
@@ -104219,7 +105400,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense."
+    "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1047g2h-liuf",
@@ -104318,7 +105500,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense."
+    "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1067g2h-liuf",
@@ -104417,7 +105600,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res."
+    "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1123g2-i",
@@ -104514,7 +105698,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot."
+    "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1123g2-liu",
@@ -104598,7 +105783,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1123g2-liuf",
@@ -104697,7 +105883,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08."
+    "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1127g0-luf-d",
@@ -104796,7 +105983,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR."
+    "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1127g2h-liuf",
@@ -104895,7 +106083,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08."
+    "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-i",
@@ -104994,7 +106183,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD."
+    "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-iuf",
@@ -105095,7 +106285,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I."
+    "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liu",
@@ -105179,7 +106370,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf",
@@ -105278,7 +106470,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08."
+    "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf-india",
@@ -105369,7 +106562,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf-n",
@@ -105440,7 +106634,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1147g0-luf-d",
@@ -105539,7 +106734,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic."
+    "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1147g2h-liuf",
@@ -105638,7 +106834,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08."
+    "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1153g2-liuf",
@@ -105709,7 +106906,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1167g2h-liuf",
@@ -105808,7 +107006,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps."
+    "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1183g2-liuf",
@@ -105879,7 +107078,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1323g2-iuf",
@@ -105977,7 +107177,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR."
+    "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1323g2-liuf",
@@ -106075,7 +107276,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
+    "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1327g2h-liuf",
@@ -106173,7 +107375,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic."
+    "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1343g2-iuf",
@@ -106272,7 +107475,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP."
+    "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1343g2-liuf",
@@ -106370,7 +107574,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
+    "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1347g2h-liuf",
@@ -106468,7 +107673,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic."
+    "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1367g2h-liuf",
@@ -106567,7 +107773,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps."
+    "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1623g2-izs",
@@ -106667,7 +107874,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD."
+    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1643g2-izs",
@@ -106767,7 +107975,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1723g2-izs",
@@ -106866,7 +108075,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10."
+    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1743g2-izs",
@@ -106966,7 +108176,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1h43g2-izs",
@@ -107065,7 +108276,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1t27g0-luf-c",
@@ -107164,7 +108376,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic."
+    "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2021g1-i",
@@ -107262,7 +108475,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal",
-    "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense."
+    "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2023g0-i",
@@ -107336,7 +108550,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2023g2-iu",
@@ -107409,7 +108624,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2025fwd-i",
@@ -107482,7 +108698,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2026g2-iu",
@@ -107580,7 +108797,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U)."
+    "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2027g2-lu",
@@ -107665,7 +108883,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2027g2h-liu",
@@ -107752,7 +108971,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-i",
@@ -107835,7 +109055,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-iu",
@@ -107933,7 +109154,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
-    "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U)."
+    "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2043g2-l",
@@ -108032,7 +109254,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102 (2.8mm) horizontal",
-    "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR)."
+    "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2043g2-li",
@@ -108116,7 +109339,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-li2u",
@@ -108214,7 +109438,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
-    "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone."
+    "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2-iu",
@@ -108313,7 +109538,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U)."
+    "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2-iu-sl",
@@ -108438,7 +109664,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2h-i2u-slrb",
@@ -108536,7 +109763,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
-    "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio."
+    "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2h-iu",
@@ -108634,7 +109862,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U)."
+    "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g2-l",
@@ -108719,7 +109948,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2047g2-lu",
@@ -108803,7 +110033,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2-lu-sl-mena",
@@ -108896,7 +110127,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-li",
@@ -108981,7 +110213,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-liu",
@@ -109079,7 +110312,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence)."
+    "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-liu-sl",
@@ -109178,7 +110412,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g3-li2uy-slrb",
@@ -109278,7 +110513,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2063g2-li",
@@ -109362,7 +110598,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2066g2-iu-sl",
@@ -109488,7 +110725,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2067g2h-liu",
@@ -109576,7 +110814,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2067g2h-liu-sl",
@@ -109676,7 +110915,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio."
+    "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2083g2-i",
@@ -109759,7 +110999,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2083g2-iu",
@@ -109856,7 +111097,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
-    "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."
+    "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2083g2-li",
@@ -109940,7 +111182,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2085g1-i",
@@ -110023,7 +111266,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2086g2-iu",
@@ -110121,7 +111365,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm)/51 (6mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2-iu-sl",
@@ -110220,7 +111465,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "110 (2.8mm)/88 (4mm)/60 (6mm) horizontal",
-    "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR."
+    "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2h-i2u-slrb",
@@ -110319,7 +111565,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio."
+    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2h-iu",
@@ -110417,7 +111664,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2087g2-l",
@@ -110503,7 +111751,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2087g2-lu",
@@ -110589,7 +111838,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2-su",
@@ -110673,7 +111923,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-li",
@@ -110759,7 +112010,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-liu",
@@ -110857,7 +112109,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U)."
+    "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-liu-sl",
@@ -110944,7 +112197,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2087g3-li2uy-sl",
@@ -111032,7 +112286,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g3-li2uy-slrb",
@@ -111132,7 +112387,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2123g0-is",
@@ -111207,7 +112463,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2123g2-i",
@@ -111290,7 +112547,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2123g2-is",
@@ -111388,7 +112646,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic)."
+    "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2123g2-iu",
@@ -111462,7 +112721,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2125g0-ims",
@@ -111562,7 +112822,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm)/52 (6mm) horizontal",
-    "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only."
+    "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2126g2-i",
@@ -111661,7 +112922,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10."
+    "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2126g2-isu",
@@ -111761,7 +113023,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O."
+    "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2143g2-i",
@@ -111850,7 +113113,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-is",
@@ -111924,7 +113188,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-iu",
@@ -112007,7 +113272,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-li",
@@ -112091,7 +113357,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2146g2-isu",
@@ -112174,7 +113441,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2146g2h-isu",
@@ -112274,7 +113542,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2-su",
@@ -112373,7 +113642,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
-    "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-li-su",
@@ -112462,7 +113732,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-lisu",
@@ -112562,7 +113833,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-liu-eu",
@@ -112660,7 +113932,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2147g3-lis2uy",
@@ -112762,7 +114035,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2163g2-i",
@@ -112844,7 +114118,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2163g2-is",
@@ -112918,7 +114193,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2166g2-isu",
@@ -113043,7 +114319,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2167g2h-lisu",
@@ -113143,7 +114420,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2167g2h-liu",
@@ -113232,7 +114510,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2183g2-is",
@@ -113331,7 +114610,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O."
+    "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2183g2-iu",
@@ -113418,7 +114698,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2183g2-li",
@@ -113503,7 +114784,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2185fwd-is",
@@ -113576,7 +114858,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2186g2-isu",
@@ -113676,7 +114959,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2186g2h-isu",
@@ -113777,7 +115061,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2-lsu",
@@ -113878,7 +115163,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "109 (2.8mm)/93 (4mm) horizontal",
-    "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-li",
@@ -113965,7 +115251,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "105.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-lisu",
@@ -114066,7 +115353,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-liu",
@@ -114156,7 +115444,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2187g3-lis2uy",
@@ -114244,7 +115533,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd23166g3-i2uy",
@@ -114379,7 +115669,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2323g2-iu",
@@ -114477,7 +115768,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR."
+    "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2326g2-iu",
@@ -114576,7 +115868,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR."
+    "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2327g2-lu",
@@ -114675,7 +115968,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic."
+    "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2343g2-iu",
@@ -114773,7 +116067,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR."
+    "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2343g2-li",
@@ -114856,7 +116151,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2345g0p-i",
@@ -114954,7 +116250,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
-    "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor)."
+    "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2-isu-sl",
@@ -115055,7 +116352,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio."
+    "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2-iu",
@@ -115139,7 +116437,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2346g2h-is2u-slrb",
@@ -115239,7 +116538,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio."
+    "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2h-iu",
@@ -115338,7 +116638,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U)."
+    "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2p-isu-sl",
@@ -115422,7 +116723,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-l",
@@ -115507,7 +116809,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-lsu-sl",
@@ -115593,7 +116896,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-lu",
@@ -115678,7 +116982,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2h-lisu-sl",
@@ -115765,7 +117070,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2h-liu",
@@ -115852,7 +117158,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2p-lsu-sl",
@@ -115952,7 +117259,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "180 horizontal / 81 vertical (dual-lens panoramic)",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2347g3-lis2uy-slrb",
@@ -116054,7 +117362,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2367g2-l",
@@ -116139,7 +117448,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2367g2h-lisu-sl",
@@ -116224,7 +117534,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "112.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2367g2h-liu",
@@ -116322,7 +117633,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U)."
+    "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2367g2p-lsu-sl",
@@ -116408,7 +117720,8 @@
     "last_verified": "2026-07-06",
     "sensor": "Dual 1/2.7\" CMOS",
     "field_of_view_deg": "180",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2367g3-lis2uy-sl",
@@ -116495,7 +117808,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2383g2-i",
@@ -116579,7 +117893,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2383g2-iu",
@@ -116677,7 +117992,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."
+    "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2383g2-li",
@@ -116761,7 +118077,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2385g1-i",
@@ -116846,7 +118163,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-i",
@@ -116928,7 +118246,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-isu-sl2",
@@ -117013,7 +118332,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-iu",
@@ -117096,7 +118416,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2h-is2u-slrb",
@@ -117196,7 +118517,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence."
+    "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2386g2h-iu",
@@ -117294,7 +118616,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U)."
+    "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2387g2-lu",
@@ -117380,7 +118703,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2387g2h-lisu-sl",
@@ -117480,7 +118804,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio."
+    "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2387g2h-liu",
@@ -117568,7 +118893,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2387g2p-lsu-sl",
@@ -117654,7 +118980,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2 x 1/1.8\" CMOS",
     "field_of_view_deg": "180",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2387g3-lis2uy-sl",
@@ -117739,7 +119066,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2387g3-lis2uy-slrb",
@@ -117840,7 +119168,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2421g0-idw",
@@ -117939,7 +119268,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm) horizontal",
-    "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE)."
+    "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2423g2-i",
@@ -118038,7 +119368,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/87.6 (4mm) horizontal",
-    "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection."
+    "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2423g2-iw",
@@ -118138,7 +119469,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "92 (2.8mm)/75 (4mm) horizontal",
-    "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio."
+    "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2443g2-i",
@@ -118237,7 +119569,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104.3 (2.8mm)/83.7 (4mm) horizontal",
-    "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I)."
+    "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2443g2-iw",
@@ -118312,7 +119645,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2446g2-i",
@@ -118412,7 +119746,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
-    "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio."
+    "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2447g2-lu",
@@ -118497,7 +119832,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2483g2-i",
@@ -118596,7 +119932,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107.8 (2.8mm)/82.8 (4mm) horizontal",
-    "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio."
+    "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2523g2-is",
@@ -118696,7 +120033,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S)."
+    "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2526g2-is",
@@ -118778,7 +120116,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2542fwd-is",
@@ -118853,7 +120192,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2543g2-is",
@@ -118924,7 +120264,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2543g2-iws",
@@ -119011,7 +120352,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2546g2-iws",
@@ -119113,7 +120455,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08."
+    "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2547g2-ls",
@@ -119215,7 +120558,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O."
+    "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2566g2-is",
@@ -119341,7 +120685,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2583g2-is",
@@ -119441,7 +120786,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "106.4 (2.8mm)/87.6 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O."
+    "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2583g2-izs",
@@ -119524,7 +120870,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2586g2-is",
@@ -119624,7 +120971,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic."
+    "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2623g2-izs",
@@ -119723,7 +121071,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "107°-32° (H)",
-    "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10."
+    "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2626g2-izs",
@@ -119806,7 +121155,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2643g2-izs",
@@ -119905,7 +121255,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR."
+    "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2-izs",
@@ -120005,7 +121356,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "108°-30° horizontal",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2h-izs",
@@ -120103,7 +121455,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H)."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2ht-izs",
@@ -120202,7 +121555,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2t-izs",
@@ -120301,7 +121655,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2647g2-lzs",
@@ -120386,7 +121741,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2647g2ht-lizs",
@@ -120485,7 +121841,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m."
+    "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2647g3-lizs2uy-slrb",
@@ -120585,7 +121942,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2667g2ht-lizs",
@@ -120684,7 +122042,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m."
+    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2683g2-izs",
@@ -120767,7 +122126,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2686g2-izs",
@@ -120893,7 +122253,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2h-izs",
@@ -120993,7 +122354,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "112.3°-41.2° (H)",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2ht-izs",
@@ -121092,7 +122454,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2t-izs",
@@ -121192,7 +122555,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "108°-46° horizontal",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2687g2ht-lizs",
@@ -121280,7 +122644,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2687g2t-lzs",
@@ -121377,7 +122742,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K."
+    "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2687g3-lizs2uy-slrb",
@@ -121477,7 +122843,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2723g2-izs",
@@ -121575,7 +122942,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2726g2-izs",
@@ -121658,7 +123026,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2726g2t-izs",
@@ -121757,7 +123126,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2743g2-izs",
@@ -121840,7 +123210,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2746g2-izs",
@@ -121939,7 +123310,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2746g2h-iptrzs2u-slrb",
@@ -122039,7 +123411,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2746g2ht-izs",
@@ -122140,7 +123513,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "105.4°-34.3° (H)",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2h-liptrzs2u-slrb",
@@ -122240,7 +123614,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2ht-lizs",
@@ -122341,7 +123716,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "114.6°-41.8° horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m."
+    "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2t-lzs",
@@ -122439,7 +123815,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light."
+    "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2763g2-izs",
@@ -122525,7 +123902,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2767g2ht-lizs",
@@ -122624,7 +124002,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m."
+    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2783g2-izs",
@@ -122722,7 +124101,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR."
+    "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2-izs",
@@ -122821,7 +124201,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2h-iptrzs2u-slrb",
@@ -122922,7 +124303,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2ht-izs",
@@ -123021,7 +124403,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2h-liptrzs2u-slrb",
@@ -123123,7 +124506,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "112.3°-41.2° (H)",
-    "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2ht-lizs",
@@ -123222,7 +124606,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2t-lzs",
@@ -123323,7 +124708,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103.3°-40° horizontal",
-    "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K."
+    "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g3-izs",
@@ -123410,7 +124796,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2955fwd-is",
@@ -123499,7 +124886,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2955g0-isu",
@@ -123595,7 +124983,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic."
+    "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2d25g1-d-nf",
@@ -123689,7 +125078,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only."
+    "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2e23g2-u",
@@ -123785,7 +125175,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
+    "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2e43g2-u",
@@ -123881,7 +125272,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
+    "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h23g2-izs",
@@ -123979,7 +125371,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR."
+    "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h43g2-izs",
@@ -124078,7 +125471,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR."
+    "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h43g2-izs-uk",
@@ -124169,7 +125563,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h46g2-izs",
@@ -124253,7 +125648,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h83g2-izs",
@@ -124337,7 +125733,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h86g2-izs",
@@ -124438,7 +125835,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "108°-46° (H)",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h86g2t-izs",
@@ -124537,7 +125935,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h87g3-lizs2uy-slrb",
@@ -124639,7 +126038,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "112.3°-41.2° horizontal",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h87g3-lizsy",
@@ -124727,7 +126127,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-2i",
@@ -124811,7 +126212,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-2i-4i",
@@ -124907,7 +126309,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens."
+    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-4i",
@@ -124989,7 +126392,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-4is",
@@ -125061,7 +126465,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t26g2-2i-4i",
@@ -125158,7 +126563,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t26g2-isu-sl",
@@ -125241,7 +126647,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t27g2-l",
@@ -125339,7 +126746,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu fixed bullet, 60m white light."
+    "release_notes": "2MP ColorVu fixed bullet, 60m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t43g2-2i-4i",
@@ -125435,7 +126843,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t43g2-4i",
@@ -125518,7 +126927,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t45g0p-i",
@@ -125614,7 +127024,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR."
+    "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-2i-4i",
@@ -125711,7 +127122,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-4i",
@@ -125793,7 +127205,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-isu-sl",
@@ -125892,7 +127305,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103°/83°/53° (H)",
-    "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR."
+    "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2h-2i-4i",
@@ -125989,7 +127403,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2h-is2u-slrb",
@@ -126088,7 +127503,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "100° (2.8mm)/81° (4mm) horizontal",
-    "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio."
+    "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2p-isu-sl",
@@ -126187,7 +127603,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-l",
@@ -126272,7 +127689,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-l-sl",
@@ -126359,7 +127777,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-lse",
@@ -126447,7 +127866,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-lsu-sl",
@@ -126532,7 +127952,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-li",
@@ -126619,7 +128040,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-lisu-sl",
@@ -126717,7 +128139,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-liu",
@@ -126801,7 +128224,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2p-lsu-sl",
@@ -126901,7 +128325,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio."
+    "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-lis2uy-sl",
@@ -126990,7 +128415,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-lis2uy-slrb",
@@ -127090,7 +128516,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-liy",
@@ -127179,7 +128606,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t63g2-4i",
@@ -127261,7 +128689,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t67g2-l",
@@ -127345,7 +128774,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t67g2h-li",
@@ -127441,7 +128871,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP."
+    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t67g2h-lisu-sl",
@@ -127540,7 +128971,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio."
+    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t83g2-2i-4i",
@@ -127638,7 +129070,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "107°/87°/54° (H)",
-    "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t83g2-4i",
@@ -127721,7 +129154,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t85g1-i8",
@@ -127805,7 +129239,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-2i-4i",
@@ -127902,7 +129337,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-4i",
@@ -127985,7 +129421,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-isu-sl",
@@ -128085,7 +129522,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "110°/88°/59° horizontal",
-    "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K."
+    "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2h-2i-4i",
@@ -128181,7 +129619,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2h-is2u-slrb",
@@ -128279,7 +129718,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio."
+    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-4i",
@@ -128364,7 +129804,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-l",
@@ -128451,7 +129892,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-lsu-sl",
@@ -128537,7 +129979,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g2h-li",
@@ -128634,7 +130077,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2h-lisu-sl",
@@ -128733,7 +130177,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2p-lsu-sl",
@@ -128833,7 +130278,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio."
+    "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-li",
@@ -128922,7 +130368,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-lis2uy-sl",
@@ -129006,7 +130453,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-lis2uy-slrb",
@@ -129105,7 +130553,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3043g2-iu",
@@ -129203,7 +130652,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103°/84°/52° (H)",
-    "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR."
+    "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3056g2-is",
@@ -129335,7 +130785,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3086g2-is",
@@ -129468,7 +130919,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3143g2-iu",
@@ -129543,7 +130995,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3156g2-is-u",
@@ -129676,7 +131129,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3343g2-isu",
@@ -129773,7 +131227,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR."
+    "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3347g2-lu",
@@ -129846,7 +131301,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3386g2-is-u",
@@ -129975,7 +131431,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3387g2-lu",
@@ -130048,7 +131505,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3523g2-is",
@@ -130123,7 +131581,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3686g2t-izsy-h",
@@ -130225,7 +131684,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "108°-46° horizontal",
-    "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K."
+    "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3746g2-izs",
@@ -130360,7 +131820,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3766g2t-izs-y",
@@ -130495,7 +131956,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3t47g2-lzs",
@@ -130568,7 +132030,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3t87g2-lzs",
@@ -130641,7 +132104,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6365g0e-ivs",
@@ -130716,7 +132180,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6365g1-ivs",
@@ -130817,7 +132282,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR."
+    "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd6365g1-s-rc",
@@ -130915,7 +132381,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics."
+    "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd63c5g1-ivs",
@@ -131002,7 +132469,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd63c5g1-s-rc",
@@ -131101,7 +132569,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating."
+    "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd6944g0-ihs",
@@ -131175,7 +132644,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6w65g1-ivs",
@@ -131275,7 +132745,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR."
+    "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd7a87g0-xzs",
@@ -131348,7 +132819,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-exif",
@@ -131415,7 +132887,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-it3e",
@@ -131484,7 +132957,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-itfs",
@@ -131553,7 +133027,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lfs",
@@ -131609,7 +133084,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lpfs",
@@ -131665,7 +133141,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lxts",
@@ -131734,7 +133211,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-vfir3e",
@@ -131803,7 +133281,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d8t-it3f",
@@ -131852,7 +133331,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16d9t-airazh",
@@ -131911,7 +133391,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "6-59",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16h0t-itec",
@@ -131969,7 +133450,8 @@
     "last_verified": "2026-07-06",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "93 / 77",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16h8t-it3f",
@@ -132017,7 +133499,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-itf",
@@ -132065,7 +133548,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-lfs",
@@ -132121,7 +133605,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-lpfs",
@@ -132177,7 +133662,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16u0t-itf",
@@ -132235,7 +133721,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16u0t-itpf",
@@ -132294,7 +133781,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce17d0t-lfs",
@@ -132350,7 +133838,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78 / 49.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce17k0t-lfs",
@@ -132406,7 +133895,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 (2.8mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce18k0t-lfs",
@@ -132463,7 +133953,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3 / 51.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19h0t-it3zec",
@@ -132521,7 +134012,8 @@
     "last_verified": "2026-07-06",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "95-26",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19u1t-it3zf",
@@ -132580,7 +134072,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP progressive-scan CMOS",
     "field_of_view_deg": "108.1-45.6",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19u8t-ait3z",
@@ -132639,7 +134132,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "45.6-108.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce57u0t-vpitf",
@@ -132697,7 +134191,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76d0t-lmfs",
@@ -132753,7 +134248,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76d0t-lpfs",
@@ -132808,7 +134304,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
-    "field_of_view_deg": "101 / 78"
+    "field_of_view_deg": "101 / 78",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-itmfs",
@@ -132857,7 +134354,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-lmfs",
@@ -132913,7 +134411,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-lpfs",
@@ -132968,7 +134467,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
-    "field_of_view_deg": "104.9 / 81.3"
+    "field_of_view_deg": "104.9 / 81.3",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76u0t-itmf",
@@ -133027,7 +134527,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76u0t-itpf",
@@ -133085,7 +134586,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
-    "field_of_view_deg": "102.9 / 79 / 44.7"
+    "field_of_view_deg": "102.9 / 79 / 44.7",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78d0t-lfs",
@@ -133141,7 +134643,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "100 / 80",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78k0t-lfs",
@@ -133197,7 +134700,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78u0t-it3f",
@@ -133255,7 +134759,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cv2041g2-idw",
@@ -133352,7 +134857,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR."
+    "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cv2141g2-idw-e",
@@ -133449,7 +134955,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR."
+    "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cv2q21g1-idw",
@@ -133548,7 +135055,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "75° (H)",
-    "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor)."
+    "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2a204iw-de3-w",
@@ -133632,7 +135140,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de2a404iw-de3-ws6",
@@ -133737,7 +135246,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "96.7°-31.6° horizontal",
-    "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°."
+    "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2a404iw-de3s6",
@@ -133840,7 +135350,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic."
+    "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2c400iwg",
@@ -133938,7 +135449,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V."
+    "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3404w-det5",
@@ -134038,7 +135550,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR)."
+    "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bw-de",
@@ -134124,7 +135637,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de3a400bw-de-wt5",
@@ -134223,7 +135737,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light."
+    "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bw-det5",
@@ -134322,7 +135837,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light."
+    "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bwg-e",
@@ -134408,7 +135924,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de3a404iwg-e",
@@ -134510,7 +136027,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR."
+    "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a404iwg-e-w",
@@ -134613,7 +136131,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR)."
+    "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4215iw-det5",
@@ -134717,7 +136236,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "57.6°-4° (H)",
-    "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°."
+    "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4225iw-det5",
@@ -134818,7 +136338,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE."
+    "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4425iw-de",
@@ -134908,7 +136429,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4425iw-de-t5-india",
@@ -134999,7 +136521,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4425iw-det5",
@@ -135102,7 +136625,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "55°-2.4° horizontal",
-    "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°."
+    "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4825wg-e3",
@@ -135188,7 +136712,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP54"
+    "ip_rating": "IP54",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iw-de",
@@ -135274,7 +136799,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iw-des6",
@@ -135374,7 +136900,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR."
+    "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4a225iwg-e",
@@ -135461,7 +136988,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iwg1-e",
@@ -135548,7 +137076,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a404iwg-e",
@@ -135635,7 +137164,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4a425iw-de",
@@ -135721,7 +137251,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a425iwg-e",
@@ -135806,7 +137337,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4a425iwg1-e",
@@ -135893,7 +137425,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de5225w-ae3t5",
@@ -135994,7 +137527,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE."
+    "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de5425iw-aet5",
@@ -136095,7 +137629,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE."
+    "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de5a425iwg-e",
@@ -136180,7 +137715,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de5a425iwg-eb",
@@ -136262,7 +137798,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de7a225iw-aebt5",
@@ -136363,7 +137900,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a225iwg-eb-sl",
@@ -136450,7 +137988,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a225iwg1-e",
@@ -136537,7 +138076,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a232iw-aebt5",
@@ -136640,7 +138180,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a232iwg-eb-sl",
@@ -136727,7 +138268,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a232iwg1-e",
@@ -136816,7 +138358,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a425iwg-eb-sl",
@@ -136904,7 +138447,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a432iw-aeb",
@@ -136990,7 +138534,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2de7a432iw-aebt5",
@@ -137093,7 +138638,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a632iwg1-e",
@@ -137181,7 +138727,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a825iwg1-e",
@@ -137269,7 +138816,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2pt3q27iwx-de",
@@ -137351,7 +138899,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se4c215mwg-e",
@@ -137436,7 +138985,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c225mwg-e",
@@ -137522,7 +139072,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c425mwg-4g",
@@ -137610,7 +139161,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c425mwg-e",
@@ -137690,7 +139242,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se4c430mwg-e",
@@ -137769,7 +139322,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se7c432mwg-eb",
@@ -137855,7 +139409,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2sf7c425mxg2-lm-el",
@@ -137985,7 +139540,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2sf8c442mxg1-elw",
@@ -138072,7 +139628,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2sf8c848mxg1-elw",
@@ -138160,7 +139717,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2xs6a25g0-i",
@@ -138235,7 +139793,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ids-2cd7a46g0-p-izhs-y",
@@ -138373,7 +139932,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hilook-ipc-b129haa-lu",
@@ -138461,7 +140021,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-b140h",
@@ -138549,7 +140110,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b180ha-lu",
@@ -138638,7 +140200,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b429haa-lu",
@@ -138726,7 +140289,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-b480h",
@@ -138813,7 +140377,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b529haa-lu",
@@ -138901,7 +140466,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-c340ha-dw",
@@ -138985,7 +140551,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d121h-m",
@@ -139072,7 +140639,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "112.1 (2.8mm) / 90.2 (4mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-d140h",
@@ -139160,7 +140728,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d140ha-lu",
@@ -139247,7 +140816,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d150h-m",
@@ -139333,7 +140903,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-d180h",
@@ -139420,7 +140991,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t140h",
@@ -139508,7 +141080,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t229haa-lu",
@@ -139596,7 +141169,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-t240h",
@@ -139682,7 +141256,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t240ha",
@@ -139769,7 +141344,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t241h-c",
@@ -139855,7 +141431,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "104 (2.8mm) / 82 (4mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-t280h",
@@ -139943,7 +141520,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t280ha-lu",
@@ -140033,7 +141611,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ptz-n2c200m-de",
@@ -140119,7 +141698,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "111.4 (2.8mm) / 91.5 (4mm)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2c400m-de",
@@ -140206,7 +141786,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
     "field_of_view_deg": "97 (2.8mm) / 79 (4mm)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2d200m-de",
@@ -140291,7 +141872,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2d400m-de",
@@ -140378,7 +141960,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94 (panoramic) / 44 (PT)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hive-view-indoor",
@@ -140444,7 +142027,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hive-view-outdoor",
@@ -140511,7 +142095,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "honeywell-hcc-ip-3mp-dome",
@@ -140600,7 +142185,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "honeywell-hcc-ip-4mp-bullet",
@@ -140689,7 +142275,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-s2236l",
@@ -140783,7 +142370,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -140877,7 +142465,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-x2251l",
@@ -140968,7 +142557,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "idis-dc-d4516wrx",
@@ -141058,7 +142648,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-a1-pro-4k",
@@ -141143,7 +142734,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-dual",
@@ -141209,7 +142801,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-4k",
@@ -141286,7 +142879,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-5mp",
@@ -141369,7 +142963,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-lite",
@@ -141447,7 +143042,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-pro",
@@ -141529,7 +143125,8 @@
         "notes": "Battery AOV camera — the official datasheet states no browser/local access, so no RTSP or ONVIF stream is exposed. Use the Imou Life app + cloud (or on-device microSD).",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2-4mp",
@@ -141616,7 +143213,8 @@
     },
     "release_notes": "Bullet 2 4MP. Wi-Fi variant is IPC-F42FEP(-D); the PoE variant (matching this entry) is IPC-F42EAP. Night vision is smart dual-mode (IR + full-color spotlight).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-bullet-2-pro-4mp",
@@ -141710,7 +143308,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2c-5mp",
@@ -141797,7 +143396,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2c-pro-5mp",
@@ -141884,7 +143484,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2e-5mp",
@@ -141977,7 +143578,8 @@
     },
     "release_notes": "Bullet 2E 5MP (IPC-K3DP-5H0WF). Corrected from a fabricated code (IPC-F57FEP-D, which returns no matching product).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-bullet-2e-pro-5mp",
@@ -142064,7 +143666,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-3-5mp",
@@ -142157,7 +143760,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-3c-5mp",
@@ -142246,7 +143850,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-2",
@@ -142331,7 +143936,8 @@
     },
     "aliases": [
       "IPC-B46LP"
-    ]
+    ],
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3",
@@ -142409,7 +144015,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3c-5mp",
@@ -142491,7 +144098,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3c-all-in-one-5mp",
@@ -142573,7 +144181,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-go",
@@ -142648,7 +144257,8 @@
       }
     },
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cell-go-full-color",
@@ -142723,7 +144333,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt",
@@ -142793,7 +144404,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-2c-5mp",
@@ -142866,7 +144478,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-4g-2nd",
@@ -142943,7 +144556,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-lite",
@@ -143020,7 +144634,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser",
@@ -143112,7 +144727,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-2-5mp",
@@ -143206,7 +144822,8 @@
     },
     "release_notes": "Single-lens Cruiser 2 5MP (IPC-GS7EP-5M0WE). Corrected from a fabricated code (IPC-S7XEP-5M0WED, which is the dual-lens Cruiser Dual 2) and wrong 2.7mm lens. Absorbed the former MENA regional-duplicate entry.",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-2c-5mp",
@@ -143298,7 +144915,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-4g",
@@ -143360,7 +144978,8 @@
     ],
     "release_notes": "Cruiser 4G (IPC-S21FTP): a 1080p/2MP MAINS-POWERED 4G LTE pan/tilt camera. Corrected from a fabricated 4MP battery+solar spec block (that described a different Imou solar model).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-dual",
@@ -143453,7 +145072,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-dual-2",
@@ -143548,7 +145168,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-dual-2c-4g",
@@ -143641,7 +145262,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-pano-z",
@@ -143737,7 +145359,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-sc-4g-5mp",
@@ -143830,7 +145453,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-sc-8mp",
@@ -143922,7 +145546,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-se-plus",
@@ -144006,7 +145631,8 @@
     },
     "release_notes": "Cruiser SE+ 4MP (IPC-S41FEP). Corrected from a wrong 'bullet' form factor (it is a 355/0-90 pan/tilt) and a wrong 'PoE' claim (it is DC 12V + Wi-Fi/LAN).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-triple",
@@ -144101,7 +145727,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-z-5mp",
@@ -144190,7 +145817,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-dk3-3mp",
@@ -144279,7 +145907,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-dk7-5mp",
@@ -144370,7 +145999,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-indoor-2k",
@@ -144444,7 +146074,8 @@
       }
     },
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-knight-8mp",
@@ -144538,7 +146169,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps2m-5mp",
@@ -144624,7 +146256,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps3d-5mp",
@@ -144713,7 +146346,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps3e-8mp",
@@ -144802,7 +146436,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps70f-10mp",
@@ -144893,7 +146528,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps7f-5mp",
@@ -144985,7 +146621,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps8d-5mp",
@@ -145073,7 +146710,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2",
@@ -145165,7 +146803,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. IMOU uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "imou-ranger-2-4mp",
@@ -145254,7 +146893,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2-pro-4k",
@@ -145345,7 +146985,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2c-pro-4k",
@@ -145436,7 +147077,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-rc-r1",
@@ -145514,7 +147156,8 @@
         "notes": "Plugged-in Wi-Fi 6 indoor camera. RTSP is not documented for this new (2026) SKU; the older Ranger RC exposed the Dahua realmonitor path (rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0), which will likely work here too but is unverified.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-s2",
@@ -145609,7 +147252,8 @@
     },
     "release_notes": "Ranger S2 3MP indoor pan/tilt (IPC-DK2-3H1W). Corrected from a fabricated code (IPC-GS7EP-3M0WE, which is actually the Cruiser 2) and a wrong 'color' night-vision claim (it is IR). Absorbed the former MENA regional-duplicate entry.",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-rex-3d-r1-5mp",
@@ -145696,7 +147340,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-titan-pro-6mp",
@@ -145790,7 +147435,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-versa-2mp",
@@ -145880,7 +147526,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8003-full-hd",
@@ -145957,7 +147604,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8015-full-hd",
@@ -146038,7 +147686,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8401-2k-plus",
@@ -146122,7 +147771,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8403-2k-plus",
@@ -146207,7 +147857,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8415-2k-plus",
@@ -146292,7 +147943,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8815-4k",
@@ -146377,7 +148029,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9008-full-hd",
@@ -146469,7 +148122,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9020-full-hd",
@@ -146562,7 +148216,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model, but the confirmed RTSP URL should work with a generic RTSP camera profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9408-2k-plus",
@@ -146660,7 +148315,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF Profile S support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9420-2k-plus",
@@ -146756,7 +148412,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9808-4k",
@@ -146838,7 +148495,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9820-4k",
@@ -146931,7 +148589,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "intelbras-im3-wifi-indoor",
@@ -147027,7 +148686,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-im5-wifi-outdoor",
@@ -147120,7 +148780,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1230-b-g4",
@@ -147214,7 +148875,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1230-d-g5",
@@ -147307,7 +148969,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1430-b-g2",
@@ -147400,7 +149063,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-3230-b-sl",
@@ -147473,7 +149137,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-3830-b-ai",
@@ -147546,7 +149211,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-s4020-g2",
@@ -147621,7 +149287,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "kasa-kc420ws",
@@ -147682,7 +149349,8 @@
       "https://www.kasasmart.com/us/products/security-cameras/kasa-cam-product-kc420ws",
       "https://www.tp-link.com/us/support/faq/1959/"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "kedacom-ipc121-ei7n",
@@ -147761,7 +149429,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc123-ei7n",
@@ -147840,7 +149509,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc123-fi4n",
@@ -147925,7 +149595,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc143-hn",
@@ -148012,7 +149683,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-an",
@@ -148104,7 +149776,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-an-ir1",
@@ -148194,7 +149867,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-dn-ir",
@@ -148298,7 +149972,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-dn-l",
@@ -148390,7 +150065,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2132-an",
@@ -148488,7 +150164,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2150-an",
@@ -148580,7 +150257,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2151-an-bn",
@@ -148673,7 +150351,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2151-an-bn-d",
@@ -148762,7 +150441,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-fn-dir",
@@ -148850,7 +150530,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-hn-dir",
@@ -148950,7 +150631,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-hn-pir",
@@ -149040,7 +150722,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-dn",
@@ -149139,7 +150822,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-dn-ir",
@@ -149231,7 +150915,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-en-l",
@@ -149319,7 +151004,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-fn-s",
@@ -149412,7 +151098,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-fn-sir40",
@@ -149507,7 +151194,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-hn-s",
@@ -149599,7 +151287,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-hn-sir40",
@@ -149690,7 +151379,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2232-an-dl",
@@ -149775,7 +151465,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2233-fn-s",
@@ -149865,7 +151556,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2233-fn-sir40-z2712",
@@ -149972,7 +151664,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-p",
@@ -150062,7 +151755,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-pir30",
@@ -150151,7 +151845,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-s",
@@ -150238,7 +151933,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-sir30",
@@ -150327,7 +152023,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2241-fn-sir",
@@ -150438,7 +152135,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2250-an",
@@ -150530,7 +152228,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2251-hn",
@@ -150637,7 +152336,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2252-fn-dir",
@@ -150719,7 +152419,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2252-hn-pir",
@@ -150806,7 +152507,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2431-hn-s",
@@ -150900,7 +152602,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2433-hn-sir40",
@@ -150993,7 +152696,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2440-hn-s",
@@ -151080,7 +152784,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2440-hn-sir30",
@@ -151187,7 +152892,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2451-fi4n-sir50",
@@ -151286,7 +152992,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2452-hn-hnb-sir50",
@@ -151383,7 +153090,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2452-hn-pir",
@@ -151479,7 +153187,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2511-fn-sir",
@@ -151577,7 +153286,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2533-fn-sir50-z2812",
@@ -151670,7 +153380,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2533-fn-sir50-z6022-l",
@@ -151779,7 +153490,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2552-fn-sir50-z2812",
@@ -151878,7 +153590,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2655-gi4n",
@@ -151969,7 +153682,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2655-gi7n",
@@ -152060,7 +153774,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2833-fi4n-sir50-z6022",
@@ -152160,7 +153875,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2833-fn-sir50-l",
@@ -152252,7 +153968,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2852-fn-sir50-z",
@@ -152352,7 +154069,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2855-gi4n",
@@ -152444,7 +154162,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-f223-n",
@@ -152540,7 +154259,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-f233-n",
@@ -152640,7 +154360,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-g223-n",
@@ -152737,7 +154458,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc442-i405-np",
@@ -152829,7 +154551,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2110-an",
@@ -152932,7 +154655,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2110-bn-d",
@@ -153010,7 +154734,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2150-an-d",
@@ -153095,7 +154820,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "laview-f1",
@@ -153142,7 +154868,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-l2",
@@ -153189,7 +154916,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-n3",
@@ -153246,7 +154974,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r12",
@@ -153294,7 +155023,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r18",
@@ -153340,7 +155070,8 @@
     "power_source": [
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r28",
@@ -153394,7 +155125,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "longse-lbe905xss500",
@@ -153468,7 +155200,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbf30sv800",
@@ -153562,7 +155295,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbh30ss500",
@@ -153645,7 +155379,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbp60ss500",
@@ -153724,7 +155459,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lorex-b862aj",
@@ -153794,7 +155530,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e841cd",
@@ -153860,7 +155597,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-e842cab",
@@ -153926,7 +155664,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e842cdb",
@@ -153992,7 +155731,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e871ab",
@@ -154058,7 +155798,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e872sb",
@@ -154123,7 +155864,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e891ab",
@@ -154186,7 +155928,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-e893ab",
@@ -154255,7 +155998,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-e896ab",
@@ -154320,7 +156064,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-e920sb",
@@ -154360,7 +156105,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e920sd",
@@ -154405,7 +156151,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-f461aqd-e",
@@ -154473,7 +156220,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-f861asd",
@@ -154543,7 +156291,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lnb9242b",
@@ -154607,7 +156356,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lnb9292b",
@@ -154703,7 +156453,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-lnb9393",
@@ -154790,7 +156541,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-lne9242b",
@@ -154855,7 +156607,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lne9292b",
@@ -154951,7 +156704,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-lne9393",
@@ -155039,7 +156793,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-u3-2k-bullet",
@@ -155135,7 +156890,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-2k-turret",
@@ -155232,7 +156988,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-4k-bullet",
@@ -155328,7 +157085,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-4k-turret",
@@ -155425,7 +157183,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u471aa",
@@ -155493,7 +157252,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-v3-bullet",
@@ -155593,7 +157353,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v3-turret",
@@ -155692,7 +157453,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v5-bullet",
@@ -155792,7 +157554,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v5-turret",
@@ -155892,7 +157655,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-w452asd",
@@ -155961,7 +157725,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w461asc",
@@ -156025,7 +157790,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-w462aqc-e-pantilt",
@@ -156118,7 +157884,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-w482cad",
@@ -156197,7 +157964,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w881aad",
@@ -156259,7 +158027,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w891uad",
@@ -156328,7 +158097,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-x-ptz-4k",
@@ -156428,7 +158198,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-dual-lens-turret",
@@ -156528,7 +158299,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-mvf-bullet",
@@ -156626,7 +158398,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-mvf-turret",
@@ -156723,7 +158496,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x5-bullet",
@@ -156823,7 +158597,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x5-turret",
@@ -156923,7 +158698,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lts-ltcmip3c8pw-sdl",
@@ -157013,7 +158789,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-ltcmip9783nw-sz",
@@ -157110,7 +158887,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model, but Hikvision-OEM hardware typically works with Blue Iris's generic Hikvision camera profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-lxip3c82w-28aisp",
@@ -157186,7 +158964,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-lxptzip4c8wi-x25sdl",
@@ -157272,7 +159051,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-ptzip688x36",
@@ -157363,7 +159143,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-vsip3442w-28ma",
@@ -157457,7 +159238,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit, though not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-vsip75122f-se",
@@ -157542,7 +159324,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "luma-lum-210-ptz",
@@ -157614,7 +159397,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-310-drb",
@@ -157686,7 +159470,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-410-fis",
@@ -157757,7 +159542,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-bul",
@@ -157828,7 +159614,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-dom",
@@ -157899,7 +159686,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-tur",
@@ -157970,7 +159758,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-810-bul",
@@ -158042,7 +159831,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-810-dom",
@@ -158114,7 +159904,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lupus-le201-wlan",
@@ -158208,7 +159999,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le202-wlan",
@@ -158302,7 +160094,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le203-poe",
@@ -158396,7 +160189,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le204-wlan",
@@ -158489,7 +160283,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le213-ai",
@@ -158581,7 +160376,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le221-poe",
@@ -158677,7 +160473,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le224-poe",
@@ -158773,7 +160570,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le228-poe",
@@ -158868,7 +160666,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le232-alarm",
@@ -158964,7 +160763,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "march-networks-me4-series",
@@ -159034,7 +160834,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-me8",
@@ -159105,7 +160906,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-se2",
@@ -159175,7 +160977,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-se4",
@@ -159245,7 +161048,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2942-epb",
@@ -159322,7 +161126,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2961-rlpb",
@@ -159401,7 +161206,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2962-fpb",
@@ -159481,7 +161287,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2964-fpd",
@@ -159560,7 +161367,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2972-fpb",
@@ -159640,7 +161448,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2983-pb",
@@ -159720,7 +161529,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c4462-fpb",
@@ -159799,7 +161609,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c5362-fpa",
@@ -159879,7 +161690,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c5383-pb",
@@ -159959,7 +161771,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c8172-fpa",
@@ -160039,7 +161852,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c8262-fpb",
@@ -160119,7 +161933,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c9674-pb",
@@ -160198,7 +162013,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "mobotix-c71",
@@ -160270,7 +162086,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-d71",
@@ -160350,7 +162167,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-m73",
@@ -160435,7 +162253,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-p71",
@@ -160516,7 +162335,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-q71",
@@ -160601,7 +162421,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-s74",
@@ -160681,7 +162502,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-s74-dual",
@@ -160758,7 +162580,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-v71",
@@ -160828,7 +162651,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-indoor-camera",
@@ -160900,7 +162724,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-outdoor-camera",
@@ -160975,7 +162800,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-outdoor-camera-with-siren",
@@ -161047,7 +162873,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-video-doorbell",
@@ -161121,7 +162948,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netcamcenter-ndm-7702-a",
@@ -161212,7 +163040,8 @@
         "notes": "Bosch OEM — use the ONVIF/RTSP (or 'Bosch') profile; add each imager as a separate camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "netcamcenter-ndm-7703-al",
@@ -161308,7 +163137,8 @@
         "notes": "Bosch OEM — use the ONVIF/RTSP (or 'Bosch') profile; add each imager as a separate camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "pelco-optera-4k-imo-panoramic",
@@ -161386,7 +163216,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-optera-imm12027-1ep",
@@ -161463,7 +163294,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-enhanced-4-ibv532-1er",
@@ -161540,7 +163372,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-enhanced-4-ime832-1irs",
@@ -161618,7 +163451,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp231-1ers",
@@ -161696,7 +163530,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp531-1ers",
@@ -161774,7 +163609,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp831-1irs",
@@ -161852,7 +163688,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-enhanced-7-s7230l-ew1",
@@ -161930,7 +163767,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-enhanced-7-s7240l-ew1",
@@ -162008,7 +163846,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-professional-4k-s6230-fwl1",
@@ -162086,7 +163925,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "qubo-bullet-cam-pro",
@@ -162154,7 +163994,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-doorbell-cam",
@@ -162217,7 +164058,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-smart-cam-360-3mp",
@@ -162289,7 +164131,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-smart-cam-360-pro-4mp",
@@ -162360,7 +164203,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-altas",
@@ -162438,7 +164282,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-altas-go-pt",
@@ -162517,7 +164362,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-altas-pt-ultra",
@@ -162605,7 +164451,8 @@
     ],
     "dimensions_mm": "178 x 151 x 102",
     "weight_g": 853,
-    "operating_temp_c": "-20 to 55"
+    "operating_temp_c": "-20 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-2",
@@ -162684,7 +164531,8 @@
     ],
     "dimensions_mm": "96 x 58 x 59",
     "weight_g": 260,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-2e",
@@ -162763,7 +164611,8 @@
     ],
     "dimensions_mm": "105 x 105 x 58",
     "weight_g": 310,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-2k",
@@ -162843,7 +164692,8 @@
     ],
     "dimensions_mm": "121 x 90 x 56",
     "weight_g": 330,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-pro",
@@ -162959,7 +164809,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-pro-au",
@@ -163074,7 +164925,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-ultra",
@@ -163179,7 +165031,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-4-pro",
@@ -163262,7 +165115,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-4-pro-at",
@@ -163384,7 +165238,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-eco",
@@ -163462,7 +165317,8 @@
     "dimensions_mm": "Φ71 x 186",
     "weight_g": 360,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-eco-ultra",
@@ -163542,7 +165398,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-argus-magicam",
@@ -163633,7 +165490,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pro",
@@ -163711,7 +165569,8 @@
     ],
     "dimensions_mm": "96 x 58 x 59",
     "weight_g": 230,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt",
@@ -163790,7 +165649,8 @@
     "dimensions_mm": "Φ98 x 122",
     "weight_g": 477,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt-2k",
@@ -163867,7 +165727,8 @@
     ],
     "dimensions_mm": "Φ98 x 112",
     "weight_g": 470,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt-ultra",
@@ -163953,7 +165814,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-solar",
@@ -164035,7 +165897,8 @@
     "operating_temp_c": "-20 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "reolink-argus-track",
@@ -164128,7 +165991,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b1200",
@@ -164226,7 +166090,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b400",
@@ -164325,7 +166190,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b500",
@@ -164425,7 +166291,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b800",
@@ -164525,7 +166392,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx410",
@@ -164635,7 +166503,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx410w",
@@ -164735,7 +166604,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-cx810",
@@ -164843,7 +166713,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx820",
@@ -164953,7 +166824,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d1200",
@@ -165044,7 +166916,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d400",
@@ -165140,7 +167013,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d500",
@@ -165231,7 +167105,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d800",
@@ -165322,7 +167197,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-battery",
@@ -165405,7 +167281,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-duo-2-lte",
@@ -165484,7 +167361,8 @@
     ],
     "dimensions_mm": "228 x 132 x 120",
     "weight_g": 900,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-poe",
@@ -165591,7 +167469,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-wifi",
@@ -165691,7 +167570,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2v-poe",
@@ -165797,7 +167677,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3-poe",
@@ -165903,7 +167784,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3-wifi",
@@ -166003,7 +167885,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3v-poe",
@@ -166105,7 +167988,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-4g",
@@ -166183,7 +168067,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-floodlight-poe",
@@ -166284,7 +168169,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-floodlight-wifi",
@@ -166381,7 +168267,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-e1-indoor",
@@ -166462,7 +168349,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-cx",
@@ -166566,7 +168454,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-poe",
@@ -166669,7 +168558,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-pro",
@@ -166773,7 +168663,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-e1-outdoor-se-poe",
@@ -166872,7 +168763,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-e1-outdoor-wifi",
@@ -166981,7 +168873,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-pro",
@@ -167085,7 +168978,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-e1-zoom",
@@ -167185,7 +169079,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-floodlight-wifi",
@@ -167290,7 +169185,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-pro-floodlight-poe",
@@ -167396,7 +169292,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-wifi",
@@ -167495,7 +169392,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-fe-p",
@@ -167602,7 +169500,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-fe-w",
@@ -167699,7 +169598,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-go-4g",
@@ -167785,7 +169685,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt",
@@ -167866,7 +169767,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt-plus",
@@ -167952,7 +169854,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt-s-lite",
@@ -168030,7 +169933,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-go-pt-ultra",
@@ -168112,7 +170016,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-ranger-pt",
@@ -168191,7 +170096,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-home-hub",
@@ -168262,7 +170168,8 @@
       "indoor"
     ],
     "release_notes": "This is Reolink's NVR/hub accessory (used with Reolink WiFi/battery/PoE cameras for local storage + AI features without a cloud subscription), not a camera. The camera schema is a poor fit for several fields: resolution/lens/night_vision/field_of_view/ip_rating describe the hub itself (which has no image sensor), not the cameras it manages. 'type': 'box' is used only because the schema has no dedicated hub/NVR enum value. 'connectivity' reflects only the hub's own uplink (wired Ethernet to the router); the hub separately hosts its own private Wi-Fi 6 access point to talk to its cameras, which is a distinct function from network uplink and not the same as the hub itself being a Wi-Fi client. No official IP rating is published by Reolink for this indoor-only device, so ip_rating has been left unset rather than guessed.",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-keen-ranger-pt",
@@ -168344,7 +170251,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-lumus",
@@ -168454,7 +170362,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-lumus-pro",
@@ -168553,7 +170462,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-omvi-3i-poe",
@@ -168672,7 +170582,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-omvi-3i-wifi",
@@ -168787,7 +170698,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-omvi-x16-poe",
@@ -168870,7 +170782,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-p340",
@@ -168980,7 +170893,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-p430",
@@ -169088,7 +171002,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-p830",
@@ -169193,7 +171108,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-reolink-go-plus",
@@ -169282,7 +171198,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1210a",
@@ -169396,7 +171313,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1212a-dome",
@@ -169502,7 +171420,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1220a",
@@ -169611,7 +171530,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1224a",
@@ -169718,7 +171638,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1240a",
@@ -169825,7 +171746,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-410",
@@ -169937,7 +171859,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-410s",
@@ -170046,7 +171969,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-410w",
@@ -170149,7 +172073,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-422",
@@ -170259,7 +172184,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-423",
@@ -170372,7 +172298,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-510a",
@@ -170483,7 +172410,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-510wa",
@@ -170584,7 +172512,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511",
@@ -170696,7 +172625,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511w",
@@ -170808,7 +172738,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511wa",
@@ -170923,7 +172854,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-520",
@@ -171034,7 +172966,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-520a",
@@ -171148,7 +173081,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-522",
@@ -171260,7 +173194,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-523wa",
@@ -171368,7 +173303,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-540a",
@@ -171476,7 +173412,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-542wa",
@@ -171582,7 +173519,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-810a",
@@ -171697,7 +173635,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-810wa",
@@ -171803,7 +173742,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-811a",
@@ -171915,7 +173855,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-811wa",
@@ -172011,7 +173952,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-812a",
@@ -172120,7 +174062,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-81ma",
@@ -172231,7 +174174,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-81pa",
@@ -172341,7 +174285,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-820a",
@@ -172452,7 +174397,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-822a",
@@ -172560,7 +174506,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823a",
@@ -172682,7 +174629,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823a-16x",
@@ -172789,7 +174737,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s1",
@@ -172901,7 +174850,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s1w",
@@ -173013,7 +174963,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s2",
@@ -173120,7 +175071,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-824a",
@@ -173221,7 +175173,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-830a",
@@ -173328,7 +175281,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-833a",
@@ -173439,7 +175393,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-840a",
@@ -173549,7 +175504,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-840wa",
@@ -173651,7 +175607,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-842a",
@@ -173751,7 +175708,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-843a",
@@ -173855,7 +175813,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-843wa",
@@ -173957,7 +175916,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-solar-floodlight-cam",
@@ -174058,7 +176018,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-talon-pro",
@@ -174133,7 +176094,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-trackflex-floodlight-wifi",
@@ -174244,7 +176206,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-lte",
@@ -174328,7 +176291,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-lte-c",
@@ -174406,7 +176370,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-trackmix-lte-plus",
@@ -174490,7 +176455,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-trackmix-poe",
@@ -174604,7 +176570,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-wifi",
@@ -174716,7 +176683,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-2nd-gen",
@@ -174768,7 +176736,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-poe",
@@ -174891,7 +176860,8 @@
     "dimensions_mm": "133 x 48 x 23",
     "weight_g": 96,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-wifi",
@@ -175007,7 +176977,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "ring-battery-doorbell-pro-2025",
@@ -175074,7 +177045,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-doorbell-elite",
@@ -175139,7 +177111,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-floodlight-cam-wired-plus",
@@ -175203,7 +177176,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-floodlight-cam-wired-pro",
@@ -175264,7 +177238,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-indoor-cam-2nd-gen",
@@ -175325,7 +177300,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-outdoor-cam-plus",
@@ -175393,7 +177369,8 @@
       "https://ring.com/support/products/cameras/outdoor-cam-plus"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "ring-pan-tilt-indoor-cam",
@@ -175455,7 +177432,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-peephole-cam",
@@ -175521,7 +177499,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-plus-battery",
@@ -175583,7 +177562,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-spotlight-cam-plus-eu",
@@ -175651,7 +177631,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-spotlight-cam-plus-plug-in",
@@ -175716,7 +177697,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-plus-solar",
@@ -175782,7 +177764,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-pro",
@@ -175849,7 +177832,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-stick-up-cam-battery-2nd-gen",
@@ -175913,7 +177897,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-stick-up-cam-battery-3rd-gen",
@@ -175979,7 +177964,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-stick-up-cam-plug-in",
@@ -176043,7 +178029,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-stick-up-cam-pro",
@@ -176110,7 +178097,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-video-doorbell-2nd-gen",
@@ -176175,7 +178163,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-video-doorbell-3-plus",
@@ -176239,7 +178228,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-video-doorbell-4",
@@ -176314,7 +178304,8 @@
       "UK",
       "US"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-video-doorbell-wired",
@@ -176377,7 +178368,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "simplisafe-indoor-cam-v2",
@@ -176430,7 +178422,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-outdoor-cam",
@@ -176494,7 +178487,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-outdoor-cam-v2",
@@ -176555,7 +178549,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-smart-alarm-indoor-cam",
@@ -176614,7 +178609,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-indoor-camera",
@@ -176686,7 +178682,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-one-plus",
@@ -176748,7 +178745,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-outdoor-camera",
@@ -176821,7 +178819,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "speco-o12b1m",
@@ -176908,7 +178907,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o12mdp4",
@@ -177002,7 +179002,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o2db1",
@@ -177084,7 +179085,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4b9m",
@@ -177172,7 +179174,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4bdd1m",
@@ -177260,7 +179263,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4bxlp1m",
@@ -177353,7 +179357,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4d9",
@@ -177441,7 +179446,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4d9m",
@@ -177529,7 +179535,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4fdms1",
@@ -177616,7 +179623,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4p25x2",
@@ -177716,7 +179724,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4t9",
@@ -177815,7 +179824,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed RTSP protocol support and strong ONVIF conformance make this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4tdd2",
@@ -177906,7 +179916,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4vt2",
@@ -178001,7 +180012,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o84s",
@@ -178088,7 +180100,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8b9",
@@ -178171,7 +180184,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8b9m",
@@ -178258,7 +180272,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8d9",
@@ -178343,7 +180358,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8d9m",
@@ -178430,7 +180446,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fb1",
@@ -178515,7 +180532,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fb1m",
@@ -178601,7 +180619,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fbms1",
@@ -178687,7 +180706,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed with Blue Iris specifically; advanced analytics features require a Speco NRE recorder rather than a third-party NVR."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fd1",
@@ -178774,7 +180794,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fd1m",
@@ -178858,7 +180879,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8ft1",
@@ -178944,7 +180966,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8ft1m",
@@ -179031,7 +181054,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8kt1",
@@ -179113,7 +181137,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8kt1b",
@@ -179195,7 +181220,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8lmst1",
@@ -179279,7 +181305,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vd3",
@@ -179374,7 +181401,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vlt1",
@@ -179457,7 +181485,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vt3",
@@ -179555,7 +181584,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically. Speco's own recorders are the officially supported pairing (Speco Blue Series NVR)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "steinel-l-620-cam-sc",
@@ -179620,7 +181650,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "steinel-l-625-cam",
@@ -179694,7 +181725,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "sv3c-b04poe",
@@ -179775,7 +181807,8 @@
     "sources": [
       "https://www.sv3c.com/Upgraded-SV3C-IP-POE-Camera-Security-Outdoor-4-Megapixels-Super-HD-2560x1440-H-265-Waterproof-Video-Camera-IR-Night-Vision-Motion-Detection-Wired-p1743568.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b05poe",
@@ -179848,7 +181881,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-POE-IP-Camera-5-Megapixels-Security-Camera-Outdoor-with-2-Way-Audio-Humanoid-Detection-IP66-Waterproof-Power-Over-Ethernet-Cameras-Support-Max-128G-SD-Card-Record-Browser-View-No-WiFi-p2437989.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b05w",
@@ -179923,7 +181957,8 @@
     "sources": [
       "https://www.sv3c.com/5MP-8MP-Outdoor-Security-Camera-SV3C-WiFi-Wireless-5-8-Megapixels-HD-Night-Vision-Surveillance-Cameras-2-Way-Audio-IP-Camera-Motion-Detection-CCTV-Weatherproof-Outside-Camera-Support-Max-128GB-SD-Card-p395185.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b06w",
@@ -180017,7 +182052,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-b08poe",
@@ -180113,7 +182149,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-POE-IP-Camera-Outdoor-8MP-POE-Security-Camera-with-Smart-Motion-Detection-IR-Color-Night-Vision-120-Wide-Angle-2-Way-Audio-Metal-Shell-RTSP-SD-Card-Record-Wired-p2471515.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-c12",
@@ -180195,7 +182232,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-PTZ-WiFi-Security-Camera-Outdoor-15X-Optical-Zoom-Auto-Tracking-5MP-8MP-Floodlight-Color-Night-Vision-Wireless-IP-Cam-2-Way-Audio-Metal-Shell-RTSP-FTP-SD-Card-Record-BlueIris-p2032033.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-c22-4k",
@@ -180289,7 +182327,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-c25",
@@ -180391,7 +182430,8 @@
         }
       ]
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-d08poe",
@@ -180468,7 +182508,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-POE-Camera-Outdoor-IP-Dome-Wired-Security-Indoor-Camera-with-Human-Vehicle-Detection-8MP-HD-Color-Night-Vision-Two-Way-Audio-Waterproof-24-7-Recording-RTSP-Up-to-512GB-SD-Card-p2471510.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-hx03",
@@ -180561,7 +182602,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-ptz-1080p-wifi-4x",
@@ -180631,7 +182673,8 @@
     "sources": [
       "https://www.sv3c.com/1080P-Wifi-Surveillance-Camera-SV3C-Wireless-Home-Security-PTZ-Camera-IP-CCTV-4X-Digital-ZOOM-AI-Human-Detect-CamHi-p2058778.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-4k-dual-network",
@@ -180705,7 +182748,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-PTZ-POE-Wired-WiFi-Security-Camera-Outdoor-Dual-Network-Support-Auto-Tracking-Security-Cam-Color-Night-Vision-Human-Vehicle-Detection-2-Way-Audio-Waterproof-24-7-Record-CamHiPro-p2707179.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-5mp-wifi-5x",
@@ -180775,7 +182819,8 @@
     "sources": [
       "https://www.sv3c.com/New-Auto-Track-PTZ-WiFi-Camera-Outdoor-Wireless-5MP-5X-Zoom-Spotlight-Color-Night-Vision-Camera-IP66-Waterproof-Playback-p1737238.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-poe-15x",
@@ -180845,7 +182890,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-8MP-POE-PTZ-Security-Camera-Outdoor-15X-Optical-Zoom-5MP-4k-Auto-Tracking-Floodlight-Color-Night-Vision-IP-Camera-2-Way-Audio-Metal-Shell-RTSP-FTP-SD-Card-Record-BlueIris-Wired-p2302126.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-poe-36x",
@@ -180938,7 +182984,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-ptz-wifi-track",
@@ -181013,7 +183060,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-8MP-WiFi-IP-Camera-Outdoor-Metal-Motion-Track-PTZ-Security-Surveillance-Camera-Spotlight-Full-Color-Night-Vision-IP-Camera-p2010092.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-solar-dual-lens-2k",
@@ -181071,7 +183119,8 @@
         "verified": false
       }
     },
-    "release_notes": "App-only solar/battery camera (CamHiPro + local hub) — no ONVIF/RTSP."
+    "release_notes": "App-only solar/battery camera (CamHiPro + local hub) — no ONVIF/RTSP.",
+    "added": "2026-06-12"
   },
   {
     "id": "swann-4k-bullet",
@@ -181152,7 +183201,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-4k-dome",
@@ -181233,7 +183283,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-buddy-doorbell",
@@ -181289,7 +183340,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-corecam",
@@ -181353,7 +183405,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-doorbell-camera",
@@ -181415,7 +183468,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-pan-and-tilt-indoor",
@@ -181477,7 +183531,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-swpro-1080msfb",
@@ -181544,7 +183599,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swpro-4kmsb",
@@ -181611,7 +183667,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swwhd-intcam",
@@ -181679,7 +183736,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swwhd-outcam",
@@ -181768,7 +183826,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-wifi-spotlight",
@@ -181831,7 +183890,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-xtreem-solar",
@@ -181894,7 +183954,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "synology-bc500",
@@ -181981,7 +184042,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-bc800z",
@@ -182070,7 +184132,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-cc400w",
@@ -182155,7 +184218,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-tc500",
@@ -182242,7 +184306,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c100",
@@ -182333,7 +184398,8 @@
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
     "dimensions_mm": "67.6 x 54.6 x 98.9",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c110",
@@ -182432,7 +184498,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c120",
@@ -182532,7 +184599,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c121",
@@ -182625,7 +184693,8 @@
     "operating_temp_c": "-25 to 45",
     "dimensions_mm": "67.4 x 57.4 x 44.1",
     "weight_g": 100,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-c125",
@@ -182727,7 +184796,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c200",
@@ -182830,7 +184900,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c207",
@@ -182924,7 +184995,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c210",
@@ -183027,7 +185099,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c216",
@@ -183136,7 +185209,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c220",
@@ -183228,7 +185302,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c222",
@@ -183319,7 +185394,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c225",
@@ -183416,7 +185492,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c230",
@@ -183518,7 +185595,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c246d",
@@ -183631,7 +185709,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c260",
@@ -183730,7 +185809,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c310",
@@ -183833,7 +185913,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c320ws",
@@ -183928,7 +186009,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "142.3 x 103.4 x 64.3",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb",
@@ -184031,7 +186113,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb-ca",
@@ -184136,7 +186219,8 @@
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb-india",
@@ -184241,7 +186325,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c400-kit",
@@ -184317,7 +186402,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed on the official spec page. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c402",
@@ -184394,7 +186480,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D60 x 89 (diameter x height)",
     "weight_g": 230,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c420",
@@ -184478,7 +186565,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "110.6 x 64.2 x 64.2",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c425",
@@ -184568,7 +186656,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "116.2 x 64.8 x 64.8",
     "weight_g": 335,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c460",
@@ -184656,7 +186745,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
     "weight_g": 327,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c465",
@@ -184732,7 +186822,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed explicitly on the official spec page (RTSP: No, ONVIF: No). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c500",
@@ -184836,7 +186927,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c510w",
@@ -184941,7 +187033,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c520ws",
@@ -185040,7 +187133,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
     "dimensions_mm": "123.8 x 123 x 90",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c530ws",
@@ -185138,7 +187232,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c560ws",
@@ -185239,7 +187334,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c566wb",
@@ -185315,7 +187411,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c615f-kit",
@@ -185408,7 +187505,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-20 to 45",
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c645d-kit",
@@ -185495,7 +187593,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ, which explicitly names the C645D). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c660-kit",
@@ -185585,7 +187684,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c675d-kit",
@@ -185683,7 +187783,8 @@
       "outdoor"
     ],
     "status": "available",
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c720",
@@ -185781,7 +187882,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c840",
@@ -185896,7 +187998,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d130",
@@ -185966,7 +188069,8 @@
       "https://www.tp-link.com/us/support/faq/4329/",
       "https://www.tapo.com/en/product/smart-camera/tapo-d130/"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-d225",
@@ -186073,7 +188177,8 @@
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d230s1",
@@ -186153,7 +188258,8 @@
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "146 x 54.5 x 35.5",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d235",
@@ -186252,7 +188358,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4 (doorbell unit only, excludes chime)",
     "weight_g": 297,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc40",
@@ -186338,7 +188445,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc55",
@@ -186424,7 +188532,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-tc82-global",
@@ -186506,7 +188615,8 @@
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc85",
@@ -186587,7 +188697,8 @@
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tcw90-kit",
@@ -186662,7 +188773,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ) -- not mentioned on the official spec page for this model either. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tiandy-tc-c32gn",
@@ -186741,7 +188853,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32gp",
@@ -186821,7 +188934,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32ms",
@@ -186900,7 +189014,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32qn",
@@ -186979,7 +189094,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34gs",
@@ -187060,7 +189176,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34hn",
@@ -187140,7 +189257,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34sp",
@@ -187221,7 +189339,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c35ms",
@@ -187302,7 +189421,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c38ls",
@@ -187384,7 +189504,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-h326m",
@@ -187465,7 +189586,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-h388m",
@@ -187545,7 +189667,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8423is-a",
@@ -187625,7 +189748,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8443is-a",
@@ -187705,7 +189829,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8483is-a",
@@ -187786,7 +189911,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9422e3-a",
@@ -187865,7 +189991,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9423e3-a",
@@ -187944,7 +190071,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9443e3-a",
@@ -188023,7 +190151,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9452e3-a",
@@ -188102,7 +190231,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9482e3-a",
@@ -188182,7 +190312,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9483e3-a",
@@ -188262,7 +190393,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-ai-360",
@@ -188349,7 +190481,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-ai-bullet",
@@ -188429,7 +190562,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-ai-dome",
@@ -188511,7 +190645,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-ai-dslr",
@@ -188592,7 +190727,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-pro",
@@ -188680,7 +190816,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-pro-white",
@@ -188769,7 +190906,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-theta-pro",
@@ -188848,7 +190986,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -188932,7 +191071,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-flex",
@@ -189016,7 +191156,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-instant",
@@ -189101,7 +191242,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-pro",
@@ -189184,7 +191326,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g4-bullet",
@@ -189267,7 +191410,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-dome",
@@ -189349,7 +191493,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g4-doorbell",
@@ -189432,7 +191577,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g4-doorbell-pro",
@@ -189518,7 +191664,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-instant",
@@ -189601,7 +191748,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-pro",
@@ -189684,7 +191832,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-ptz",
@@ -189767,7 +191916,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g5-bullet",
@@ -189849,7 +191999,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-dome",
@@ -189930,7 +192081,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-dome-ultra",
@@ -190007,7 +192159,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-flex",
@@ -190092,7 +192245,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g5-pro",
@@ -190177,7 +192331,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-turret-ultra",
@@ -190259,7 +192414,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -190345,7 +192501,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniarch-ipc-b122-apf28",
@@ -190435,7 +192592,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-ipc-t122-apf28",
@@ -190522,7 +192680,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-ipc-t124-apf28",
@@ -190610,7 +192769,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-b1r-m2f3",
@@ -190681,7 +192841,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-p1a-m3f4d",
@@ -190763,7 +192924,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-s2e",
@@ -190833,7 +192995,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniview-ipc2122le-adf40kmc-wl",
@@ -190916,7 +193079,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc2224se-df40k-wl-i0",
@@ -191000,7 +193164,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc2228se-df40k-wl-i0",
@@ -191083,7 +193248,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3612sb-adf28km-i0",
@@ -191168,7 +193334,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3614sb-adf28km-i0",
@@ -191255,7 +193422,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3615sb-adf28km-i0",
@@ -191342,7 +193510,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3618sb-adf28km-i0",
@@ -191428,7 +193597,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cb62-usa",
@@ -191501,7 +193671,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cd61-usa",
@@ -191572,7 +193743,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cm61",
@@ -191636,7 +193808,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vigi-c340",
@@ -191756,7 +193929,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-30"
   },
   {
     "id": "vigi-c345",
@@ -191882,7 +194056,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c355",
@@ -192008,7 +194183,8 @@
     "status": "available",
     "weight_g": 525,
     "dimensions_mm": "184 x 74 x 74",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c385",
@@ -192131,7 +194307,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c485",
@@ -192258,7 +194435,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c540v",
@@ -192398,7 +194576,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-lpr345z",
@@ -192529,7 +194708,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s225",
@@ -192656,7 +194836,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s245",
@@ -192789,7 +194970,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s245zi",
@@ -192924,7 +195106,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s285",
@@ -193057,7 +195240,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345-4g",
@@ -193191,7 +195375,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345s",
@@ -193327,7 +195512,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345zi",
@@ -193462,7 +195648,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s355",
@@ -193594,7 +195781,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385",
@@ -193724,7 +195912,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385dps",
@@ -193862,7 +196051,8 @@
       }
     },
     "status": "announced",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385pi",
@@ -193998,7 +196188,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445",
@@ -194129,7 +196320,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445s",
@@ -194265,7 +196457,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445zi",
@@ -194400,7 +196593,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s455",
@@ -194532,7 +196726,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s485",
@@ -194662,7 +196857,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s485pi",
@@ -194798,7 +196994,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s655i",
@@ -194924,7 +197121,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vivotek-cc9381-hv",
@@ -195006,7 +197204,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd816c-hf2",
@@ -195079,7 +197278,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd9167-ht-v2",
@@ -195161,7 +197361,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd9389-ehv-v2",
@@ -195245,7 +197446,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fe9391-ev",
@@ -195328,7 +197530,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9387-eht-v2",
@@ -195411,7 +197614,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9388-ht",
@@ -195486,7 +197690,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9389-eht-v2",
@@ -195569,7 +197774,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9399-h",
@@ -195640,7 +197846,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ms9390-hv",
@@ -195724,7 +197931,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-sd9384-ehl",
@@ -195807,7 +198015,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-battery-cam-pro",
@@ -195876,7 +198085,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) for local RTSP proxy. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-floodlight-pro",
@@ -195956,7 +198166,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-og",
@@ -196036,7 +198247,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-og-telephoto",
@@ -196117,7 +198329,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-outdoor-v2",
@@ -196190,7 +198403,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge for local RTSP proxy. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-pan-v2",
@@ -196262,7 +198476,8 @@
         "notes": "No native RTSP. Use docker-wyze-bridge for local RTSP proxy. Pan/tilt control available via bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-pan-v3",
@@ -196345,7 +198560,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v2",
@@ -196414,7 +198630,8 @@
         "notes": "Legacy RTSP firmware was available but is discontinued. Use docker-wyze-bridge for local RTSP proxy."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-v3",
@@ -196497,7 +198714,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v3-pro",
@@ -196581,7 +198799,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v4",
@@ -196667,7 +198886,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-floodlight-cam-v2",
@@ -196736,7 +198956,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge for local RTSP proxy."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-video-doorbell-pro",
@@ -196807,7 +199028,8 @@
         "notes": "No official RTSP or ONVIF support. Wyze doorbells are cloud/app-only by default. For local RTSP, use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) which proxies the P2P stream to a local RTSP endpoint. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-video-doorbell-v2",
@@ -196874,7 +199096,8 @@
         "notes": "No official RTSP or ONVIF support. Wyze doorbells are cloud/app-only by default. For local RTSP, use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) which proxies the P2P stream to a local RTSP endpoint. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "yale-sv-abfx-w",
@@ -196944,7 +199167,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dafx-w",
@@ -197018,7 +199242,8 @@
         "notes": "Yale cameras are primarily cloud-based (Yale Home app). RTSP support is unconfirmed. Check camera settings for ONVIF/RTSP options."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dbc-b",
@@ -197069,7 +199294,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dpfx-w",
@@ -197142,7 +199368,8 @@
         "notes": "Yale cameras are primarily cloud-based (Yale Home app). RTSP support is unconfirmed."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-floodlight",
@@ -197193,7 +199420,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-outdoor-2k",
@@ -197243,7 +199471,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-wipc-303w",
@@ -197313,6 +199542,7 @@
         "notes": "Older Yale model. RTSP support is unconfirmed. May be cloud-only via Yale Home app."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   }
 ]

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -68,7 +68,8 @@
       "https://www.expert-security.de/abus-hdcc35512-analog-hd-mini-tube-5mpx-tn-ir-ip67.html",
       "https://alarm-technik.eu/en/products/abus-analog-hd-mini-tube-5-mpx-2-8-mm-hdcc35512"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-hdcc52512",
@@ -144,7 +145,8 @@
       "https://www.expert-security.de/abus-hdcc52512-analog-hd-mini-dome-ir-1080p-ip67.html",
       "https://www.digitec.ch/en/s1/product/abus-hdcc52512-analog-hd-mini-dome-ir-1080p-ip67-1920-x-1080-pixels-network-camera-61175216"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-hdcc75550",
@@ -211,7 +213,8 @@
       "https://www.expert-security.de/abus-hdcc75550-analog-hd-tube-5mpx-t-n-ir-ip67.html",
       "https://www.abus.com/int/Commercial-Security/Video-surveillance/Analogue-HD/Analog-HD-Tube-5-MPx-2.7-13.5-mm"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34512a",
@@ -317,7 +320,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34512b",
@@ -430,7 +434,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca34612a",
@@ -540,7 +545,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54512a",
@@ -664,7 +670,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54512b",
@@ -782,7 +789,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54572a",
@@ -891,7 +899,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54581b",
@@ -994,7 +1003,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca54612a",
@@ -1106,7 +1116,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64512a",
@@ -1218,7 +1229,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64512b",
@@ -1339,7 +1351,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64581d",
@@ -1451,7 +1464,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipca64612a",
@@ -1584,7 +1598,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34511a",
@@ -1695,7 +1710,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34511b",
@@ -1820,7 +1836,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb34611a",
@@ -1941,7 +1958,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb38511a",
@@ -2066,7 +2084,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb38511b",
@@ -2169,7 +2188,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44510a",
@@ -2263,7 +2283,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44510c",
@@ -2368,7 +2389,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44511a",
@@ -2485,7 +2507,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44511b",
@@ -2600,7 +2623,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44561a",
@@ -2703,7 +2727,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44611a",
@@ -2806,7 +2831,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb44611b",
@@ -2931,7 +2957,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54511a",
@@ -3047,7 +3074,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54511b",
@@ -3158,7 +3186,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb54611b",
@@ -3262,7 +3291,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58511a",
@@ -3388,7 +3418,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58511b",
@@ -3505,7 +3536,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb58611a",
@@ -3618,7 +3650,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb64510a",
@@ -3712,7 +3745,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64510b",
@@ -3805,7 +3839,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64510c",
@@ -3899,7 +3934,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64521",
@@ -4025,7 +4061,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb64620",
@@ -4120,7 +4157,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb64621",
@@ -4226,7 +4264,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb68515a",
@@ -4322,7 +4361,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcb68521",
@@ -4451,7 +4491,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb68621",
@@ -4558,7 +4599,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb74521",
@@ -4687,7 +4729,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcb78521",
@@ -4795,7 +4838,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs24500",
@@ -4890,7 +4934,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs28581a",
@@ -5006,7 +5051,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs29512",
@@ -5137,7 +5183,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs34511a",
@@ -5231,7 +5278,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs34511b",
@@ -5325,7 +5373,8 @@
         "profile": "Hikvision",
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-ipcs34611a",
@@ -5450,7 +5499,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54511a",
@@ -5552,7 +5602,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54511b",
@@ -5662,7 +5713,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs54611a",
@@ -5783,7 +5835,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs58571a",
@@ -5905,7 +5958,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64511b",
@@ -6025,7 +6079,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64531",
@@ -6135,7 +6190,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64541",
@@ -6263,7 +6319,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs64611a",
@@ -6360,7 +6417,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs74511a",
@@ -6461,7 +6519,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84511",
@@ -6582,7 +6641,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84532",
@@ -6690,7 +6750,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ipcs84551",
@@ -6828,7 +6889,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic31020",
@@ -6910,7 +6972,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/ABUS-WLAN-Privacy-Innen-Kamera.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic42520",
@@ -7001,7 +7064,8 @@
     "weight_g": 650,
     "operating_temp_c": "-10 to 50",
     "last_verified": "2026-07-05",
-    "release_notes": "Absorbed the former 'PPIC42520 (Austria)' regional-duplicate entry."
+    "release_notes": "Absorbed the former 'PPIC42520 (Austria)' regional-duplicate entry.",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic44520",
@@ -7072,7 +7136,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic46520",
@@ -7153,7 +7218,8 @@
     "dimensions_mm": "75 x 155 x 180",
     "weight_g": 985,
     "operating_temp_c": "-20 to 50",
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic52520",
@@ -7238,7 +7304,8 @@
       "https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html",
       "https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic54520",
@@ -7321,7 +7388,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/SmartLook-abus.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic90520",
@@ -7394,7 +7462,8 @@
       "solar"
     ],
     "operating_temp_c": "-20 to 50",
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-ppic91000",
@@ -7468,7 +7537,8 @@
     "sources": [
       "https://security.abus.com/Videoueberwachung/ABUS-Akku-Kamera-Pro-mit-Basisstation.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-ppic91520",
@@ -7548,7 +7618,8 @@
         "notes": "App-only ABUS battery camera (App2Cam Plus) — no ONVIF/RTSP; local NVR/Frigate not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "abus-tvcc35512",
@@ -7605,7 +7676,8 @@
       "https://uk.rs-online.com/web/p/cctv-cameras/0633204",
       "https://www.expert-security.de/abus-kameras.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvcc55512",
@@ -7679,7 +7751,8 @@
       "https://www.expert-security.de/abus-tvcc55512-analog-hd-mini-dome-kamera-5mpx-t-n.html",
       "https://www.abus.com/uk/Commercial-Security/Video-surveillance/Analogue-HD/Analog-HD-Mini-Dome-5-MPx-2.8-mm"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip42510",
@@ -7796,7 +7869,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip42520",
@@ -7891,7 +7965,8 @@
         "notes": "Select 'Hikvision' profile. Most ABUS IP cameras use Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "abus-tvip42562",
@@ -7980,7 +8055,8 @@
       "https://www.expert-security.de/abus-tvip42562-ip-kamera-1080p-t-n-ir-wlan-ip66.html",
       "https://toolbrothers.de/products/abus-tvip42562-2mpx-wlan-mini-dome-kamera-mit-12-v-anschluss-full-hd-1080p"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip44510",
@@ -8097,7 +8173,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip44511",
@@ -8213,7 +8290,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip48511",
@@ -8342,7 +8420,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip62510",
@@ -8457,7 +8536,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip62562",
@@ -8564,7 +8644,8 @@
         "profile": "Hikvision",
         "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
-    }
+    },
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip64511",
@@ -8671,7 +8752,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip68511",
@@ -8779,7 +8861,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip82561",
@@ -8885,7 +8968,8 @@
         "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-20"
   },
   {
     "id": "abus-tvip83900",
@@ -8982,7 +9066,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-05"
   },
   {
     "id": "acti-a213",
@@ -9064,7 +9149,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a214",
@@ -9151,7 +9237,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a29",
@@ -9233,7 +9320,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a313",
@@ -9321,7 +9409,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a314",
@@ -9408,7 +9497,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a315",
@@ -9490,7 +9580,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a317",
@@ -9579,7 +9670,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371",
@@ -9669,7 +9761,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371-p1",
@@ -9759,7 +9852,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a371-p2",
@@ -9829,7 +9923,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a372",
@@ -9892,7 +9987,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a372-p1",
@@ -9953,7 +10049,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a374",
@@ -10024,7 +10121,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a374-p1",
@@ -10095,7 +10193,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a377",
@@ -10181,7 +10280,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a410",
@@ -10248,7 +10348,8 @@
     },
     "ip_rating": "IP66, IK10",
     "weight_g": 1600,
-    "operating_temp_c": "-30 to 50"
+    "operating_temp_c": "-30 to 50",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a412",
@@ -10339,7 +10440,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a415",
@@ -10425,7 +10527,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a416",
@@ -10514,7 +10617,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-a421",
@@ -10603,7 +10707,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a422",
@@ -10691,7 +10796,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a423",
@@ -10778,7 +10884,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a424",
@@ -10869,7 +10976,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a425",
@@ -10955,7 +11063,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a426",
@@ -11043,7 +11152,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a427",
@@ -11128,7 +11238,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a428",
@@ -11194,7 +11305,8 @@
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "140 x 378.4",
     "weight_g": 2170,
-    "operating_temp_c": "-40 to 65"
+    "operating_temp_c": "-40 to 65",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a429",
@@ -11281,7 +11393,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a432",
@@ -11343,7 +11456,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a432-p1",
@@ -11398,7 +11512,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570",
@@ -11488,7 +11603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570-p1",
@@ -11557,7 +11673,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a570-p2",
@@ -11626,7 +11743,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573",
@@ -11716,7 +11834,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573-p1",
@@ -11806,7 +11925,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a573-p2",
@@ -11896,7 +12016,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a711",
@@ -11985,7 +12106,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a713",
@@ -12071,7 +12193,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a76",
@@ -12157,7 +12280,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a77",
@@ -12244,7 +12368,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a78",
@@ -12331,7 +12456,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a810",
@@ -12400,7 +12526,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a811",
@@ -12486,7 +12613,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a817",
@@ -12575,7 +12703,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a820",
@@ -12665,7 +12794,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a821",
@@ -12753,7 +12883,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a822",
@@ -12842,7 +12973,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a826",
@@ -12930,7 +13062,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a828",
@@ -13020,7 +13153,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a85",
@@ -13105,7 +13239,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a86",
@@ -13190,7 +13325,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a88",
@@ -13272,7 +13408,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-a912",
@@ -13337,7 +13474,8 @@
     },
     "dimensions_mm": "119.9 x 41.2",
     "weight_g": 320,
-    "operating_temp_c": "-10 to 50"
+    "operating_temp_c": "-10 to 50",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a952",
@@ -13427,7 +13565,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a955",
@@ -13512,7 +13651,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a956",
@@ -13598,7 +13738,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a957",
@@ -13687,7 +13828,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a959",
@@ -13774,7 +13916,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a962",
@@ -13864,7 +14007,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a966",
@@ -13956,7 +14100,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a967",
@@ -14043,7 +14188,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-a972",
@@ -14132,7 +14278,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a973",
@@ -14200,7 +14347,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a981",
@@ -14289,7 +14437,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-a982",
@@ -14375,7 +14524,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b26",
@@ -14457,7 +14607,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b412-k1",
@@ -14546,7 +14697,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b416",
@@ -14634,7 +14786,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-b419",
@@ -14720,7 +14873,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b419-p2",
@@ -14805,7 +14959,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b511a",
@@ -14890,7 +15045,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b57",
@@ -14974,7 +15130,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b64",
@@ -15057,7 +15214,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b76a",
@@ -15144,7 +15302,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-b911",
@@ -15226,7 +15385,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b912",
@@ -15309,7 +15469,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b915",
@@ -15396,7 +15557,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b916",
@@ -15477,7 +15639,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b923",
@@ -15558,7 +15721,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b928",
@@ -15644,7 +15808,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-b934",
@@ -15725,7 +15890,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-c11w",
@@ -15803,7 +15969,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e11",
@@ -15881,7 +16048,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e11a",
@@ -15959,7 +16127,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e13a",
@@ -16037,7 +16206,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e14",
@@ -16117,7 +16287,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e16",
@@ -16197,7 +16368,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e19",
@@ -16275,7 +16447,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e217",
@@ -16357,7 +16530,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e33a",
@@ -16441,7 +16615,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e43b",
@@ -16525,7 +16700,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e54",
@@ -16607,7 +16783,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e618",
@@ -16690,7 +16867,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e815",
@@ -16777,7 +16955,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e816",
@@ -16864,7 +17043,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-e915",
@@ -16948,7 +17128,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e918",
@@ -17028,7 +17209,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e918m",
@@ -17108,7 +17290,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e925m",
@@ -17192,7 +17375,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e93",
@@ -17271,7 +17455,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e933",
@@ -17356,7 +17541,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e933m",
@@ -17441,7 +17627,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e936",
@@ -17522,7 +17709,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e936m",
@@ -17603,7 +17791,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-e96",
@@ -17682,7 +17871,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i42",
@@ -17768,7 +17958,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i47",
@@ -17853,7 +18044,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i915",
@@ -17939,7 +18131,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-i96",
@@ -18022,7 +18215,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-i98",
@@ -18112,7 +18306,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-j41",
@@ -18200,7 +18395,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-j71",
@@ -18287,7 +18483,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j72",
@@ -18374,7 +18571,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j73",
@@ -18462,7 +18660,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-j81",
@@ -18548,7 +18747,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-k31",
@@ -18637,7 +18837,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k31-p1",
@@ -18726,7 +18927,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k32",
@@ -18815,7 +19017,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k33",
@@ -18904,7 +19107,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k372",
@@ -18991,7 +19195,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-k41",
@@ -19079,7 +19284,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k42",
@@ -19167,7 +19373,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k43",
@@ -19257,7 +19464,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k71",
@@ -19345,7 +19553,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k72",
@@ -19433,7 +19642,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k73",
@@ -19522,7 +19732,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k81",
@@ -19610,7 +19821,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k82",
@@ -19698,7 +19910,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k83",
@@ -19788,7 +20001,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k9001",
@@ -19874,7 +20088,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k953",
@@ -19967,7 +20182,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k954",
@@ -20060,7 +20276,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-k958",
@@ -20153,7 +20370,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-kcm-5611",
@@ -20241,7 +20459,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-kcm-7311",
@@ -20321,7 +20540,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l31",
@@ -20409,7 +20629,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l31-p1",
@@ -20497,7 +20718,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l33",
@@ -20585,7 +20807,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l33-p1",
@@ -20673,7 +20896,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l41",
@@ -20761,7 +20985,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l43",
@@ -20849,7 +21074,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l71",
@@ -20937,7 +21163,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l73",
@@ -21025,7 +21252,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l73-p1",
@@ -21113,7 +21341,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l81",
@@ -21201,7 +21430,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-l83",
@@ -21289,7 +21519,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-pcam-1600",
@@ -21372,7 +21603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q113",
@@ -21451,7 +21683,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q115",
@@ -21530,7 +21763,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q12",
@@ -21609,7 +21843,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q120",
@@ -21668,7 +21903,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q121",
@@ -21728,7 +21964,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q150",
@@ -21811,7 +22048,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q150-12mm",
@@ -21892,7 +22130,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q170",
@@ -21951,7 +22190,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q22",
@@ -22032,7 +22272,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q22-k1",
@@ -22112,7 +22353,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q450",
@@ -22192,7 +22434,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q550",
@@ -22280,7 +22523,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q711",
@@ -22347,7 +22591,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q75",
@@ -22414,7 +22659,8 @@
       "dc",
       "ac-mains"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q83",
@@ -22501,7 +22747,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q84",
@@ -22591,7 +22838,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q950",
@@ -22677,7 +22925,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q970",
@@ -22738,7 +22987,8 @@
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "82 x 212 x 47.2",
     "weight_g": 728,
-    "operating_temp_c": "-40 to 55"
+    "operating_temp_c": "-40 to 55",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-q981",
@@ -22826,7 +23076,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982",
@@ -22914,7 +23165,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982-p1",
@@ -23002,7 +23254,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q982-p2",
@@ -23090,7 +23343,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-q992",
@@ -23179,7 +23433,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-359",
@@ -23267,7 +23522,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-359-p1",
@@ -23356,7 +23612,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-370",
@@ -23422,7 +23679,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-371",
@@ -23507,7 +23765,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-vmgb-601",
@@ -23573,7 +23832,8 @@
     },
     "dimensions_mm": "140.5 x 122.6",
     "weight_g": 954,
-    "operating_temp_c": "-30 to 60"
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-vmgb-602",
@@ -23639,7 +23899,8 @@
     },
     "dimensions_mm": "140.5 x 122.6",
     "weight_g": 948,
-    "operating_temp_c": "-30 to 60"
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-y31",
@@ -23701,7 +23962,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y32",
@@ -23763,7 +24025,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y35",
@@ -23825,7 +24088,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y55",
@@ -23890,7 +24154,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y71",
@@ -23955,7 +24220,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-y72",
@@ -24017,7 +24283,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z310",
@@ -24105,7 +24372,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z315",
@@ -24193,7 +24461,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z316",
@@ -24281,7 +24550,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z316-p1",
@@ -24369,7 +24639,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z317",
@@ -24457,7 +24728,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z317-p1",
@@ -24544,7 +24816,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z318",
@@ -24633,7 +24906,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z319",
@@ -24721,7 +24995,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z322",
@@ -24808,7 +25083,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z324",
@@ -24892,7 +25168,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z325",
@@ -24982,7 +25259,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z330",
@@ -25069,7 +25347,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z330-p1",
@@ -25156,7 +25435,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z331",
@@ -25243,7 +25523,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z331-p1",
@@ -25330,7 +25611,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z332",
@@ -25419,7 +25701,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z41",
@@ -25506,7 +25789,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z411",
@@ -25598,7 +25882,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z412",
@@ -25684,7 +25969,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z413-p1",
@@ -25754,7 +26040,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z415",
@@ -25842,7 +26129,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z416",
@@ -25933,7 +26221,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z419",
@@ -26020,7 +26309,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z429",
@@ -26111,7 +26401,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z47",
@@ -26202,7 +26493,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z49",
@@ -26290,7 +26582,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z510",
@@ -26379,7 +26672,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z511",
@@ -26465,7 +26759,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z512",
@@ -26554,7 +26849,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z53",
@@ -26642,7 +26938,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z54",
@@ -26726,7 +27023,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z56",
@@ -26814,7 +27112,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z64",
@@ -26884,7 +27183,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z714",
@@ -26971,7 +27271,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z72",
@@ -27058,7 +27359,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z721",
@@ -27145,7 +27447,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z722",
@@ -27235,7 +27538,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z724",
@@ -27324,7 +27628,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z78",
@@ -27411,7 +27716,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z79",
@@ -27497,7 +27803,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z79-p1",
@@ -27584,7 +27891,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z81",
@@ -27671,7 +27979,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z810",
@@ -27761,7 +28070,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z812",
@@ -27849,7 +28159,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z813",
@@ -27936,7 +28247,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z814",
@@ -28022,7 +28334,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z818",
@@ -28113,7 +28426,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z819",
@@ -28201,7 +28515,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z82",
@@ -28288,7 +28603,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z84",
@@ -28370,7 +28686,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-06-11"
   },
   {
     "id": "acti-z86",
@@ -28458,7 +28775,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z87",
@@ -28544,7 +28862,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z91",
@@ -28612,7 +28931,8 @@
     "ip_rating": "IP67, IK10",
     "dimensions_mm": "108.5 x 81",
     "weight_g": 450,
-    "operating_temp_c": "-35 to 60"
+    "operating_temp_c": "-35 to 60",
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z910",
@@ -28699,7 +29019,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z911",
@@ -28786,7 +29107,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z912",
@@ -28874,7 +29196,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z913",
@@ -28963,7 +29286,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z914",
@@ -29028,7 +29352,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-03"
+    "last_verified": "2026-07-03",
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z952",
@@ -29116,7 +29441,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z953",
@@ -29207,7 +29533,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z954",
@@ -29300,7 +29627,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z956",
@@ -29385,7 +29713,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z957",
@@ -29474,7 +29803,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z958",
@@ -29561,7 +29891,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "acti-z959",
@@ -29651,7 +29982,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-03"
   },
   {
     "id": "acti-z972",
@@ -29737,7 +30069,8 @@
         "profile": "ACTi",
         "notes": "Select 'ACTi' profile. Default RTSP port is 7070."
       }
-    }
+    },
+    "added": "2026-07-11"
   },
   {
     "id": "adt-command-indoor-cam",
@@ -29802,7 +30135,8 @@
     "markets": [
       "US"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "adt-command-outdoor-cam",
@@ -29864,7 +30198,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "adt-doorbell-cam-v2",
@@ -29919,7 +30254,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ajax-bulletcam-hl-5mp-28mm",
@@ -30009,7 +30345,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-5mp-4mm",
@@ -30099,7 +30436,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-8mp-28mm",
@@ -30189,7 +30527,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-bulletcam-hl-8mp-4mm",
@@ -30279,7 +30618,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-hlvf-5mp",
@@ -30370,7 +30710,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-hlvf-8mp",
@@ -30461,7 +30802,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-5mp-28mm",
@@ -30549,7 +30891,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 2.8mm wide lens. Wired PoE/DC. Also supports 4/3/2/0.6MP modes."
+    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 2.8mm wide lens. Wired PoE/DC. Also supports 4/3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-5mp-4mm",
@@ -30637,7 +30980,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 4mm lens (narrower FoV than the 2.8mm). Available in black and white."
+    "release_notes": "Ajax DomeCam Mini, 5MP with fixed 4mm lens (narrower FoV than the 2.8mm). Available in black and white.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-8mp-28mm",
@@ -30725,7 +31069,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 2.8mm wide lens; 4K mode capped at ~20fps."
+    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 2.8mm wide lens; 4K mode capped at ~20fps.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-8mp-4mm",
@@ -30813,7 +31158,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 4mm lens; 4K mode capped at ~20fps."
+    "release_notes": "Ajax DomeCam Mini, 8MP/4K with fixed 4mm lens; 4K mode capped at ~20fps.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-5mp-28mm",
@@ -30903,7 +31249,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-8mp-28mm",
@@ -30993,7 +31340,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-domecam-mini-hl-8mp-4mm",
@@ -31083,7 +31431,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-doorbell",
@@ -31176,7 +31525,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF supported; RTSP not independently confirmed for the doorbell."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-bulletcam-hlvf-4mp",
@@ -31269,7 +31619,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior BulletCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Also supports 3/2/0.6MP modes."
+    "release_notes": "Ajax Superior BulletCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Also supports 3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-bulletcam-hlvf-8mp",
@@ -31362,7 +31713,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior BulletCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. 24-month warranty."
+    "release_notes": "Ajax Superior BulletCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. 24-month warranty.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-domecam-hlvf-4mp",
@@ -31455,7 +31807,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior DomeCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m. Also supports 3/2/0.6MP modes."
+    "release_notes": "Ajax Superior DomeCam HLVF, 4MP, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m. Also supports 3/2/0.6MP modes.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-superior-domecam-hlvf-8mp",
@@ -31548,7 +31901,8 @@
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
     },
-    "release_notes": "Ajax Superior DomeCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m."
+    "release_notes": "Ajax Superior DomeCam HLVF, 8MP/4K, 2.8-12mm motorized varifocal P-Iris lens. Night vision: white LED ~25m + IR ~40m.",
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-5mp-28mm",
@@ -31636,7 +31990,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-5mp-4mm",
@@ -31724,7 +32079,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-8mp-28mm",
@@ -31812,7 +32168,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "ajax-turretcam-8mp-4mm",
@@ -31900,7 +32257,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ad410-doorbell",
@@ -31992,7 +32350,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Portrait 3:4 aspect ratio. Doorbell press triggers alert."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ash42-w",
@@ -32070,7 +32429,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip2m-841b",
@@ -32146,7 +32506,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip4m-1041w",
@@ -32224,7 +32585,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip4m-1051ew",
@@ -32300,7 +32662,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip5m-b1186ew",
@@ -32377,7 +32740,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip5m-t1179e",
@@ -32463,7 +32827,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip5m-t1273ew-ai",
@@ -32541,7 +32906,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ip5m-t1277ew",
@@ -32627,7 +32993,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2493ew",
@@ -32712,7 +33079,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2496e",
@@ -32802,7 +33170,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2693ew",
@@ -32880,7 +33249,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip8m-2779e",
@@ -32967,7 +33337,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "amcrest-ip8m-2899ew-ai",
@@ -33056,7 +33427,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible (PTZ supported)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "amcrest-ip8m-t2599ew",
@@ -33132,7 +33504,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "amcrest-ip8m-vt2879ew-ai",
@@ -33218,7 +33591,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera; Amcrest is ONVIF-compatible."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "annke-ac400",
@@ -33310,7 +33684,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-ac500",
@@ -33401,7 +33776,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-ac800",
@@ -33495,7 +33871,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c1200",
@@ -33598,7 +33975,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-c500",
@@ -33691,7 +34069,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800-bullet",
@@ -33792,7 +34171,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800-turret",
@@ -33893,7 +34273,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-c800x",
@@ -33991,7 +34372,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-i61dq",
@@ -34080,7 +34462,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "annke-nc400",
@@ -34172,7 +34555,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-nc800",
@@ -34265,7 +34649,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "annke-video-doorbell",
@@ -34319,7 +34704,8 @@
     "power_source": [
       "battery",
       "ac-mains"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "annke-wz500",
@@ -34409,7 +34795,8 @@
         "profile": "ONVIF",
         "notes": "Add as an ONVIF/RTSP camera. This is a WiFi (Tuya-based) PTZ, not a Hikvision-protocol camera."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "aqara-camera-hub-g3",
@@ -34480,7 +34867,8 @@
         "notes": "No RTSP or ONVIF. HomeKit Secure Video only. Use HomeKit integration in HA. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "aqara-camera-hub-g5-pro",
@@ -34557,7 +34945,8 @@
         "notes": "No RTSP or ONVIF. HomeKit/Matter only. Use HomeKit integration in HA. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-1st-gen",
@@ -34615,7 +35004,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/arlo/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-baby-monitor",
@@ -34680,7 +35070,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-1st-gen",
@@ -34746,7 +35137,8 @@
     "sources": [
       "https://kb.arlo.com/000062416/Arlo-Essential-Wire-Free-Camera-Series-FAQ"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-essential-indoor-1st-gen",
@@ -34810,7 +35202,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-indoor-2nd-gen",
@@ -34873,7 +35266,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-outdoor-2nd-gen",
@@ -34940,7 +35334,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-spotlight-1st-gen",
@@ -35005,7 +35400,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-essential-video-doorbell-wired",
@@ -35068,7 +35464,8 @@
     "sources": [
       "https://www.arlo.com/en-us/doorbell/video/arlo-wired-video-doorbell.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-essential-xl-v2",
@@ -35134,7 +35531,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-essential-xlr",
@@ -35197,7 +35595,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-go",
@@ -35264,7 +35663,8 @@
     "sources": [
       "https://www.arlo.com/en-us/products/arlo-go/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-go-2",
@@ -35334,7 +35734,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-indoor-plug-in",
@@ -35401,7 +35802,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-pro",
@@ -35467,7 +35869,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/pro/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-pro-2",
@@ -35532,7 +35935,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/pro-2/default.aspx"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-pro-3",
@@ -35597,7 +36001,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-pro-3-floodlight",
@@ -35662,7 +36067,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-pro-4",
@@ -35728,7 +36134,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-pro-5s",
@@ -35795,7 +36202,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-q",
@@ -35863,7 +36271,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/q/arlo-q.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-q-plus",
@@ -35934,7 +36343,8 @@
     "sources": [
       "https://www.arlo.com/en-us/cameras/q/VMC3040S-100NAS.html"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "arlo-ultra",
@@ -36000,7 +36410,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "arlo-ultra-2-spotlight",
@@ -36068,7 +36479,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-video-doorbell-hd",
@@ -36134,7 +36546,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "arlo-wired-floodlight-2025",
@@ -36201,7 +36614,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h4ptze-dp30",
@@ -36287,7 +36701,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo1-ir-2mp",
@@ -36370,7 +36785,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo1-ir-4mp",
@@ -36454,7 +36870,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-bo2-ir-5mp",
@@ -36538,7 +36955,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-d1-2mp",
@@ -36622,7 +37040,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-dh2-ir-10mp",
@@ -36705,7 +37124,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-do",
@@ -36790,7 +37210,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-do1-ir-2mp",
@@ -36874,7 +37295,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-mh-15mp",
@@ -36957,7 +37379,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5a-mh-24mp",
@@ -37040,7 +37463,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h5sl-do1-ir-3mp",
@@ -37125,7 +37549,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-bo1-ir-5mp",
@@ -37209,7 +37634,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-dc1-ir-2mp",
@@ -37293,7 +37719,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6a-do1-ir-5mp",
@@ -37378,7 +37805,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6m-d1-ir-2mp",
@@ -37463,7 +37891,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6ptze-dp30",
@@ -37547,7 +37976,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6sl-bo1-ir-5mp",
@@ -37631,7 +38061,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "avigilon-h6sl-do1-ir-2mp",
@@ -37716,7 +38147,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use Generic/ONVIF profile. RTSP path: /defaultPrimary?streamType=u."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-f4105-re",
@@ -37793,7 +38225,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-fa54",
@@ -37867,7 +38300,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m2025-le",
@@ -37947,7 +38381,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m2035-le",
@@ -38029,7 +38464,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3048-p",
@@ -38107,7 +38543,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3064-v",
@@ -38188,7 +38625,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3077-plve",
@@ -38275,7 +38713,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m3085-v",
@@ -38360,7 +38799,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m3086-v",
@@ -38446,7 +38886,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3088-v",
@@ -38532,7 +38973,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3106-l-mk-ii",
@@ -38619,7 +39061,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3106-lve-mk-ii",
@@ -38704,7 +39147,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3115-lve",
@@ -38786,7 +39230,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m3116-lve",
@@ -38868,7 +39313,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4216-lv",
@@ -38957,7 +39403,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4216-v",
@@ -39045,7 +39492,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m4317-plve",
@@ -39131,7 +39579,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-m4318-plve",
@@ -39218,7 +39667,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-m5526-e",
@@ -39300,7 +39750,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1275",
@@ -39382,7 +39833,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1368-e",
@@ -39460,7 +39912,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1448-le",
@@ -39544,7 +39997,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p1465-le",
@@ -39630,7 +40084,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p1465-le-3",
@@ -39717,7 +40172,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3245-lv",
@@ -39792,7 +40248,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-lve",
@@ -39879,7 +40336,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-lve-3",
@@ -39967,7 +40425,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-v",
@@ -40050,7 +40509,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-v-mena",
@@ -40141,7 +40601,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3245-ve",
@@ -40219,7 +40680,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lv",
@@ -40310,7 +40772,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lve",
@@ -40400,7 +40863,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-lve-3",
@@ -40490,7 +40954,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3265-v",
@@ -40577,7 +41042,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3267-lv",
@@ -40663,7 +41129,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3267-lve",
@@ -40749,7 +41216,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-p3268-lve",
@@ -40825,7 +41293,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3344",
@@ -40900,7 +41369,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3727-ple",
@@ -40987,7 +41457,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3737-ple",
@@ -41072,7 +41543,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p3818-pve",
@@ -41154,7 +41626,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p5655-e",
@@ -41235,7 +41708,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-p5676-le",
@@ -41323,7 +41797,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1656",
@@ -41402,7 +41877,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1656-be",
@@ -41485,7 +41961,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1785-le",
@@ -41570,7 +42047,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1942-e",
@@ -41652,7 +42130,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q1952-e",
@@ -41738,7 +42217,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-q2101-e",
@@ -41821,7 +42301,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3527-lve",
@@ -41904,7 +42385,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3536-lve",
@@ -41988,7 +42470,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3538-lve",
@@ -42078,7 +42561,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3538-slve",
@@ -42166,7 +42650,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q3819-pve",
@@ -42252,7 +42737,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6100-e",
@@ -42334,7 +42820,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6114-e",
@@ -42412,7 +42899,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6135-le",
@@ -42505,7 +42993,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6135-le-mena",
@@ -42597,7 +43086,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6315-le",
@@ -42685,7 +43175,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "axis-q6318-le",
@@ -42774,7 +43265,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "axis-q9307-lv",
@@ -42854,7 +43346,8 @@
         "profile": "Axis",
         "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "blink-indoor",
@@ -42916,7 +43409,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-mini",
@@ -42977,7 +43471,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-mini-2",
@@ -43042,7 +43537,8 @@
     "markets": [
       "AU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-mini-2k-plus",
@@ -43104,7 +43600,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-mini-pan-tilt-mount",
@@ -43166,7 +43663,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-outdoor-2k-plus",
@@ -43231,7 +43729,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-outdoor-3rd-gen",
@@ -43294,7 +43793,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-outdoor-4",
@@ -43363,7 +43863,8 @@
     "markets": [
       "EU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-outdoor-4-floodlight",
@@ -43428,7 +43929,8 @@
       "solar",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-video-doorbell",
@@ -43491,7 +43993,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "blink-wired-floodlight",
@@ -43553,7 +44056,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "blink-xt2",
@@ -43616,7 +44120,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "bosch-fcs-8000-vfd-i",
@@ -43744,7 +44249,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-flexidome-5100i-mena",
@@ -43836,7 +44342,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-mic-550ir55-p",
@@ -43896,7 +44403,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-mic-7504-z12br",
@@ -44037,7 +44545,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7504-z12gr",
@@ -44141,7 +44650,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7504-z12wr",
@@ -44272,7 +44782,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30b",
@@ -44403,7 +44914,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30br",
@@ -44537,7 +45049,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30g",
@@ -44660,7 +45173,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30gr",
@@ -44770,7 +45284,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30w",
@@ -44898,7 +45413,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-7522-z30wr",
@@ -45017,7 +45533,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bqs",
@@ -45135,7 +45652,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvf",
@@ -45263,7 +45781,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvf9",
@@ -45391,7 +45910,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvs",
@@ -45508,7 +46028,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30bvs9",
@@ -45643,7 +46164,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gqs",
@@ -45769,7 +46291,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gvf",
@@ -45906,7 +46429,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30gvf9",
@@ -46030,7 +46554,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wqs",
@@ -46145,7 +46670,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvf",
@@ -46262,7 +46788,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvf9",
@@ -46370,7 +46897,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvs",
@@ -46505,7 +47033,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9502-z30wvs9",
@@ -46637,7 +47166,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b06v",
@@ -46757,7 +47287,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b14v",
@@ -46874,7 +47405,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b18q",
@@ -46990,7 +47522,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30b42v",
@@ -47108,7 +47641,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g06v",
@@ -47222,7 +47756,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g14v",
@@ -47331,7 +47866,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g18q",
@@ -47437,7 +47973,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30g42v",
@@ -47560,7 +48097,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w06v",
@@ -47661,7 +48199,8 @@
         "notes": "Generic ONVIF integration; Bosch CPP cameras are ONVIF Profile S/G compliant. Use the 'service' account."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w14v",
@@ -47773,7 +48312,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w18q",
@@ -47892,7 +48432,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-mic-9803s-z30w42v",
@@ -48011,7 +48552,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-3702-al",
@@ -48120,7 +48662,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-3703-al",
@@ -48224,7 +48767,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-5702-al",
@@ -48307,7 +48851,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-5703-al",
@@ -48391,7 +48936,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-5704-al",
@@ -48515,7 +49061,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7702-alx",
@@ -48641,7 +49188,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7702-alxt",
@@ -48724,7 +49272,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbe-7703-alx",
@@ -48851,7 +49400,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7703-alxt",
@@ -48956,7 +49506,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-al",
@@ -49065,7 +49616,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-alt",
@@ -49187,7 +49739,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbe-7704-alx",
@@ -49312,7 +49865,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7802-ax",
@@ -49432,7 +49986,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7802-axt",
@@ -49542,7 +50097,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803-ax",
@@ -49657,7 +50213,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803-axt",
@@ -49767,7 +50324,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803s-ax",
@@ -49887,7 +50445,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbi-7803s-axt",
@@ -49997,7 +50556,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-63023-b",
@@ -50115,7 +50675,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-73023-ba",
@@ -50233,7 +50794,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbn-9122-p",
@@ -50313,7 +50875,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nbt-8700-f03qf",
@@ -50433,7 +50996,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f05qf",
@@ -50554,7 +51118,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f09qf",
@@ -50673,7 +51238,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8700-f18qf",
@@ -50794,7 +51360,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f06vf",
@@ -50905,7 +51472,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f14vf",
@@ -51030,7 +51598,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f25vf",
@@ -51156,7 +51725,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nbt-8701-f42vf",
@@ -51267,7 +51837,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nce-7703-fk",
@@ -51376,7 +51947,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndc-8502-r-ooh",
@@ -51464,7 +52036,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndd-7802-al",
@@ -51576,7 +52149,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndd-7803-al",
@@ -51695,7 +52269,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3503-f02",
@@ -51815,7 +52390,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3702-al",
@@ -51915,7 +52491,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3703-al",
@@ -52020,7 +52597,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-3703-al-io",
@@ -52137,7 +52715,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5503-al",
@@ -52219,7 +52798,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5702-a",
@@ -52331,7 +52911,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5702-al",
@@ -52413,7 +52994,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5703-a",
@@ -52533,7 +53115,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5703-al",
@@ -52616,7 +53199,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-5704-a",
@@ -52723,7 +53307,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-5704-al",
@@ -52832,7 +53417,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8512-r",
@@ -52918,7 +53504,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-8512-rx",
@@ -53002,7 +53589,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nde-8702-rx",
@@ -53111,7 +53699,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8702-rxl",
@@ -53216,7 +53805,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8702-rxt",
@@ -53332,7 +53922,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-r",
@@ -53458,7 +54049,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rl",
@@ -53569,7 +54161,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rt",
@@ -53695,7 +54288,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rx",
@@ -53812,7 +54406,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rxl",
@@ -53936,7 +54531,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8703-rxt",
@@ -54058,7 +54654,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-r",
@@ -54165,7 +54762,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rl",
@@ -54302,7 +54900,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rt",
@@ -54413,7 +55012,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rx",
@@ -54517,7 +55117,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nde-8704-rxl",
@@ -54640,7 +55241,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-a",
@@ -54743,7 +55345,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-a-io",
@@ -54866,7 +55469,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3702-al",
@@ -54979,7 +55583,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3703-a",
@@ -55083,7 +55688,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndi-3703-al",
@@ -55184,7 +55790,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7702-a",
@@ -55295,7 +55902,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7702-al",
@@ -55427,7 +56035,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7703-a",
@@ -55559,7 +56168,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndm-7703-al",
@@ -55638,7 +56248,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndp-5522-z30",
@@ -55766,7 +56377,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5522-z30c",
@@ -55890,7 +56502,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5522-z30l",
@@ -56026,7 +56639,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-5533-z30l",
@@ -56155,7 +56769,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7802-z40",
@@ -56274,7 +56889,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7802-z40l",
@@ -56398,7 +57014,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndp-7804-z12l",
@@ -56521,7 +57138,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5703-f360",
@@ -56646,7 +57264,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5703-f360le",
@@ -56724,7 +57343,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nds-5704-f360",
@@ -56829,7 +57449,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nds-5704-f360le",
@@ -56963,7 +57584,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5702-a",
@@ -57083,7 +57705,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5702-al",
@@ -57166,7 +57789,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndv-5703-a",
@@ -57278,7 +57902,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5703-al",
@@ -57361,7 +57986,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-ndv-5704-a",
@@ -57474,7 +58100,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-5704-al",
@@ -57591,7 +58218,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8502-r",
@@ -57711,7 +58339,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8502-rx",
@@ -57810,7 +58439,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8503-r",
@@ -57929,7 +58559,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8503-rx",
@@ -58045,7 +58676,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-ndv-8504-r",
@@ -58168,7 +58800,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f07qs",
@@ -58282,7 +58915,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f19qf",
@@ -58403,7 +59037,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8000-f19qs",
@@ -58508,7 +59143,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f09vf",
@@ -58624,7 +59260,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f09vs",
@@ -58739,7 +59376,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f17vf",
@@ -58858,7 +59496,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f35vf",
@@ -58970,7 +59609,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f65vf",
@@ -59076,7 +59716,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nht-8001-f65vs",
@@ -59192,7 +59833,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nti-50022-a3",
@@ -59276,7 +59918,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nti-50022-a3s",
@@ -59357,7 +60000,8 @@
         "notes": "Select 'Bosch' profile. ONVIF discovery supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "bosch-nue-3702-f02",
@@ -59470,7 +60114,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3702-f04",
@@ -59584,7 +60229,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3702-f06",
@@ -59698,7 +60344,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f02",
@@ -59812,7 +60459,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f04",
@@ -59917,7 +60565,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nue-3703-f06",
@@ -60027,7 +60676,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f02",
@@ -60139,7 +60789,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f04",
@@ -60247,7 +60898,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f04h",
@@ -60362,7 +61014,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3702-f06",
@@ -60473,7 +61126,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f02",
@@ -60573,7 +61227,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f02h",
@@ -60685,7 +61340,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f04",
@@ -60793,7 +61449,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-nuv-3703-f06",
@@ -60910,7 +61567,8 @@
         "notes": "Bosch — use the ONVIF/RTSP (or 'Bosch') profile; default admin user is 'service'."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-26"
   },
   {
     "id": "bosch-smart-home-outdoor-cam-2",
@@ -60980,7 +61638,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "camius-boltx-4k",
@@ -61051,7 +61710,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-boltx-5mp",
@@ -61122,7 +61782,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-iris-4k",
@@ -61193,7 +61854,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "camius-iris-5mp",
@@ -61274,7 +61936,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "canon-vb-h47",
@@ -61373,7 +62036,8 @@
         "profile": "Canon",
         "notes": "Select the 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "canon-vb-m46",
@@ -61472,7 +62136,8 @@
         "profile": "Canon",
         "notes": "Select the 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "canon-vb-r13ve",
@@ -61562,7 +62227,8 @@
         "profile": "Canon",
         "notes": "Select 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "canon-vb-s805d-mk2",
@@ -61651,7 +62317,8 @@
         "profile": "Canon",
         "notes": "Select 'Canon' profile if available, otherwise Generic/ONVIF."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "costar-av02cid-200",
@@ -61751,7 +62418,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av02cid-201",
@@ -61851,7 +62519,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cid-200",
@@ -61949,7 +62618,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cid-201",
@@ -62047,7 +62717,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av05cld-200",
@@ -62149,7 +62820,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av10956dn-28",
@@ -62237,7 +62909,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av12cfe-250",
@@ -62332,7 +63005,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av12cpd-236",
@@ -62434,7 +63108,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av16956dn-28",
@@ -62523,7 +63198,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "costar-av4956dn-28",
@@ -62611,7 +63287,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP; ConteraIP stream path /media/video1."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-e35q",
@@ -62692,7 +63369,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-e45q-india",
@@ -62773,7 +63451,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-be51e-vmd-q",
@@ -62855,7 +63534,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da21l3b-lq",
@@ -62945,7 +63625,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da21l3c-q",
@@ -63036,7 +63717,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da21pl3",
@@ -63128,7 +63810,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-lq",
@@ -63219,7 +63902,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-lq2",
@@ -63310,7 +63994,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-d-q2",
@@ -63401,7 +64086,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-da41l3c-lq",
@@ -63493,7 +64179,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ee61l2c-vmd-q",
@@ -63588,7 +64275,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ta21l3b-lq",
@@ -63678,7 +64366,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta21l3c-q",
@@ -63769,7 +64458,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-ta21l6c-q",
@@ -63860,7 +64550,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta21pl3",
@@ -63950,7 +64641,8 @@
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-d-lq",
@@ -64038,7 +64730,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-d-q2",
@@ -64129,7 +64822,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-ta41l3c-lq",
@@ -64219,7 +64913,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "cp-plus-cp-unc-tc21l5c-vmd-lq",
@@ -64313,7 +65008,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc61l5c-vmd-lq",
@@ -64407,7 +65103,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc81l5c-vmd-lq",
@@ -64501,7 +65198,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-tc81zl6c-vmd-lq",
@@ -64595,7 +65293,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-te81zl6c-vmds-q",
@@ -64690,7 +65389,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-vc61l5c-vmd-lq",
@@ -64784,7 +65484,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-unc-vc81zl5c-vmd-q",
@@ -64878,7 +65579,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. CP Plus uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "cp-plus-cp-z43q",
@@ -64963,7 +65665,8 @@
         "notes": "ezyKam+ consumer Wi-Fi camera — app-only (ezyKam+ / P2P cloud). No ONVIF or RTSP is exposed, so Frigate / local-NVR integration is not supported.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-dh-sd49425xb-hnr",
@@ -65054,7 +65757,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-dh-sd6al245xa-hnr",
@@ -65145,7 +65849,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-dh-sdt7425-4p-ad3e-pv-i",
@@ -65273,7 +65978,8 @@
         }
       ]
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-12"
   },
   {
     "id": "dahua-hac-hdw1200trq-il-t",
@@ -65340,7 +66046,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1249sm-a-pro",
@@ -65406,7 +66113,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1500trq-il-t",
@@ -65473,7 +66181,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1509t-a-led",
@@ -65526,7 +66235,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-hac-hdw1549sm-a-pro",
@@ -65593,7 +66303,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1549sm-il-a-pro",
@@ -65660,7 +66371,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hdw1801trq-il-t",
@@ -65727,7 +66439,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw1509t-a-led",
@@ -65780,7 +66493,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-hac-hfw1549sm-a-pro",
@@ -65847,7 +66561,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw1549sm-il-a-pro",
@@ -65914,7 +66629,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-hac-hfw2249e-a-led",
@@ -65981,7 +66697,8 @@
     "sources": [
       "https://www.dahuasecurity.com/asset/upload/uploads/soft/20190506/DH-HAC-HFW2249E-A-LED_Datasheet.pdf"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-hac-hfw2802e-a",
@@ -66053,7 +66770,8 @@
     "sources": [
       "https://www.dahuasecurity.com/products/All-Products/HDCVI-Cameras/Pro-Series/4K/Starlight/HAC-HFW2802E-A"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdbw2441e-s",
@@ -66138,7 +66856,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw2441r-zas",
@@ -66227,7 +66946,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdbw2831e-s-s2",
@@ -66311,7 +67031,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw2849e-s-il",
@@ -66399,7 +67120,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3241e-s",
@@ -66475,7 +67197,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3441dr1-ast-4g-la",
@@ -66562,7 +67285,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3441e-s",
@@ -66639,7 +67363,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3449r1-zas-pv-pro",
@@ -66728,7 +67453,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3649r1-zas-pv-pro",
@@ -66817,7 +67543,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3849e-s-il",
@@ -66893,7 +67620,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3849f-as-il",
@@ -66980,7 +67708,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3849r1-zas-pv",
@@ -67067,7 +67796,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw3849r1-zas-pv-pro",
@@ -67156,7 +67886,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw3866ep-as",
@@ -67244,7 +67975,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3866rp-zas",
@@ -67331,7 +68063,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3867e-as-il",
@@ -67417,7 +68150,8 @@
     },
     "last_verified": "2026-07-06",
     "field_of_view_deg": "110",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw3867r-zas-il",
@@ -67504,7 +68238,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "114-32",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdbw5259r-ase-il",
@@ -67593,7 +68328,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdbw5442r-ze",
@@ -67677,7 +68413,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdbw5842ep-ze-s3",
@@ -67765,7 +68502,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw1230dt-stw",
@@ -67850,7 +68588,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1239t1-led-s6",
@@ -67925,7 +68664,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1339da-saw-il",
@@ -68011,7 +68751,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1339da-sw-pv",
@@ -68098,7 +68839,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1430dt-stw",
@@ -68183,7 +68925,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1439t-a-led-s4",
@@ -68262,7 +69005,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1439t1-led",
@@ -68338,7 +69082,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw1439v-il-k",
@@ -68422,7 +69167,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1539da-saw-il",
@@ -68508,7 +69254,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1539da-sw-pv",
@@ -68595,7 +69342,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw1830t-h",
@@ -68672,7 +69420,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2241t-s",
@@ -68769,7 +69518,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2249t-s-il",
@@ -68856,7 +69606,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw2249t-zs-il",
@@ -68942,7 +69693,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2439t-as-led-s2",
@@ -69018,7 +69770,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2441t-s",
@@ -69115,7 +69868,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2449t-s-il",
@@ -69215,7 +69969,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2449t-zs-il",
@@ -69302,7 +70057,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2449tm-s-il",
@@ -69388,7 +70144,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2549emp-s-pro",
@@ -69471,7 +70228,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw2649t-zs-il",
@@ -69558,7 +70316,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2649tm-s-il",
@@ -69644,7 +70403,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2831t-as-s2",
@@ -69732,7 +70492,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2841t-zs",
@@ -69820,7 +70581,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-il",
@@ -69921,7 +70683,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-il-india",
@@ -70021,7 +70784,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw2849t-s-pro",
@@ -70123,7 +70887,8 @@
       "blue_iris": {
         "profile": "Dahua"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hdw2849t-zs-il",
@@ -70210,7 +70975,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw2849tm-s-il",
@@ -70308,7 +71074,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw3449h-as-pv-pro",
@@ -70398,7 +71165,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3549h-as-pv",
@@ -70482,7 +71250,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3649h-as-pv",
@@ -70572,7 +71341,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3841tp-zas",
@@ -70657,7 +71427,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-as-pv",
@@ -70748,7 +71519,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-as-pv-pro",
@@ -70836,7 +71608,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849h-zas-pv",
@@ -70922,7 +71695,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw3849t-zs-il",
@@ -71010,7 +71784,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw3866emp-s",
@@ -71097,7 +71872,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "110",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3866tp-zs",
@@ -71185,7 +71961,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3867em-s-il",
@@ -71271,7 +72048,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw3867t-zs-il",
@@ -71356,7 +72134,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hdw5259t-ze-il",
@@ -71444,7 +72223,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw5259tm-ase-il",
@@ -71532,7 +72312,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hdw5442t-ze",
@@ -71613,7 +72394,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5442tm-ase",
@@ -71699,7 +72481,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5449h-ase-d2",
@@ -71789,7 +72572,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hdw5842t-ze",
@@ -71875,7 +72659,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hdw5842tm-ase",
@@ -71961,7 +72746,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hf71242f-z-x",
@@ -72049,7 +72835,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1230ds-saw",
@@ -72135,7 +72922,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1239s1-led-s6",
@@ -72209,7 +72997,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1339dtk1-sw-pv",
@@ -72296,7 +73085,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1430dt-stw",
@@ -72381,7 +73171,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1439s-led-s4",
@@ -72456,7 +73247,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1-led",
@@ -72531,7 +73323,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1-led-s4",
@@ -72605,7 +73398,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw1439s1p-led-s4",
@@ -72692,7 +73486,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw1539dtk1-sw-pv",
@@ -72779,7 +73574,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw1830s-s6",
@@ -72855,7 +73651,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2241s-s",
@@ -72930,7 +73727,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2249s-s-il-nl",
@@ -73017,7 +73815,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw2431t-as-s2",
@@ -73105,7 +73904,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2439s-sa-led-b",
@@ -73179,7 +73979,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2441s-s",
@@ -73254,7 +74055,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2449s-s-il",
@@ -73338,7 +74140,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2449t-as-il",
@@ -73424,7 +74227,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2449t-zas-il",
@@ -73511,7 +74315,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2649t-as-il",
@@ -73597,7 +74402,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2649t-zas-il",
@@ -73684,7 +74490,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2831sp-s-s2",
@@ -73771,7 +74578,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw2831t-as-s2-latam",
@@ -73863,7 +74671,8 @@
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2831t-zas-s2",
@@ -73947,7 +74756,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2831tp-zs",
@@ -74030,7 +74840,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw2841t-zas-s2",
@@ -74105,7 +74916,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849s-s-il",
@@ -74189,7 +75001,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849s-s-il-s2",
@@ -74265,7 +75078,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw2849t-as-il",
@@ -74351,7 +75165,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2849t-zas-il",
@@ -74438,7 +75253,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw2849tl-s-pro",
@@ -74546,7 +75362,8 @@
       "blue_iris": {
         "profile": "Dahua"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3241e-s",
@@ -74621,7 +75438,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3441e-s",
@@ -74696,7 +75514,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3449t1-as-pv",
@@ -74804,7 +75623,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3549e-as-led",
@@ -74887,7 +75707,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3549t1-as-pv",
@@ -74993,7 +75814,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-ipc-hfw3649t1-as-pv-s2",
@@ -75081,7 +75903,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-hfw3667t-zas-il",
@@ -75168,7 +75991,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "114-32",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3841t-zas-s2",
@@ -75244,7 +76068,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3841tp-zas",
@@ -75333,7 +76158,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "113-31",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3849e-as-il",
@@ -75416,7 +76242,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849e-s-il",
@@ -75501,7 +76328,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-as-pv",
@@ -75590,7 +76418,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-as-pv-pro",
@@ -75680,7 +76509,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-zas-pv",
@@ -75765,7 +76595,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw3849t1-zas-pv-pro",
@@ -75853,7 +76684,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-ipc-hfw3866ep-as",
@@ -75938,7 +76770,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3866tp-zas",
@@ -76024,7 +76857,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw3867t-zas-il",
@@ -76109,7 +76943,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw5442e-ze",
@@ -76194,7 +77029,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5442e-ze-s3",
@@ -76272,7 +77108,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5842e-ze",
@@ -76358,7 +77195,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5842h-z4he",
@@ -76446,7 +77284,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw5849t1-ase-led",
@@ -76554,7 +77393,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw71242h-z",
@@ -76644,7 +77484,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/1.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-ipc-hfw7442h-z4-x",
@@ -76721,7 +77562,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw7842h-z-x",
@@ -76799,7 +77641,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-hfw7842h-z4-x",
@@ -76887,7 +77730,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pdbw5831-b360",
@@ -76972,7 +77816,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pf83230-a180",
@@ -77057,7 +77902,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-ipc-pfw5849-a180-e2-aste",
@@ -77148,7 +77994,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "dahua-ipc-pfw8802-a180",
@@ -77233,7 +78080,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-itc237-pw1b-irz-lr",
@@ -77319,7 +78167,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd49225xa-hnr-mena",
@@ -77413,7 +78262,8 @@
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd49425db-hny",
@@ -77501,7 +78351,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd49825gb-hnr",
@@ -77586,7 +78437,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd4d225mb-hnr",
@@ -77674,7 +78526,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd4d425mb-hnr",
@@ -77762,7 +78615,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd4d825mb-hnr",
@@ -77851,7 +78705,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-26"
   },
   {
     "id": "dahua-sd5a432gb-hnr",
@@ -77939,7 +78794,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "dahua-sd6c3432gb-hnr-a-pv1",
@@ -78053,7 +78909,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Supports both main and sub streams."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "dahua-sdt3e410-8p-mb-a-pv1",
@@ -78137,7 +78994,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "Panoramic 1/1.8\" + PTZ 1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "dahua-sdt4e425-8p-gb-apv1",
@@ -78222,7 +79080,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "STARVIS CMOS",
-    "field_of_view_deg": "180"
+    "field_of_view_deg": "180",
+    "added": "2026-07-06"
   },
   {
     "id": "eufy-4g-lte-cam-s330",
@@ -78290,7 +79149,8 @@
     "operating_temp_c": "-20 to 50",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-2",
@@ -78366,7 +79226,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase-served RTSP URL on port 554; eufy is not ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-2-pro",
@@ -78452,7 +79313,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app; stream comes from HomeBase IP."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-2c",
@@ -78537,7 +79399,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app; stream comes from HomeBase IP."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-2c-pro",
@@ -78614,7 +79477,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase-served RTSP URL on port 554; eufy is not ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-3",
@@ -78689,7 +79553,8 @@
       "global"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-eufycam-3c",
@@ -78765,7 +79630,8 @@
       "global"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-e",
@@ -78824,7 +79690,8 @@
       "https://service.eufy.com/article-description/Differences-Between-All-Add-on-eufyCams"
     ],
     "last_verified": "2026-07-04",
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-e330-pro",
@@ -78890,7 +79757,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-eufycam-e40",
@@ -78961,7 +79829,8 @@
       "outdoor"
     ],
     "status": "available",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-s3-pro",
@@ -79066,7 +79935,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-eufycam-s4",
@@ -79148,7 +80018,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-1080p",
@@ -79220,7 +80091,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-2-pro",
@@ -79306,7 +80178,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in the Eufy Security app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-floodlight-cam-2k",
@@ -79378,7 +80251,8 @@
       "global"
     ],
     "status": "discontinued",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-e220",
@@ -79447,7 +80321,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-floodlight-cam-e30",
@@ -79516,7 +80391,8 @@
     "status": "available",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-floodlight-cam-e340",
@@ -79585,7 +80461,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-garage-cam-s330",
@@ -79677,7 +80554,8 @@
         "profile": "Generic/RTSP",
         "notes": "Eufy is not a Hikvision/ONVIF brand — use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF)."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-indoor-cam-2k-pan-tilt",
@@ -79771,7 +80649,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-c120",
@@ -79862,7 +80741,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-c210",
@@ -79935,7 +80815,8 @@
       "https://service.eufy.com/article-description/eufy-Security-Indoor-Cam-C210-User-Guide-T8419"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-c220",
@@ -80003,7 +80884,8 @@
       "https://service.eufy.com/article-description/Indoor-Cam-C220-User-Guide-T8W11"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-e220",
@@ -80093,7 +80975,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use Generic/RTSP profile. RTSP must be enabled per camera in Eufy app."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-indoor-cam-e30",
@@ -80156,7 +81039,8 @@
     "status": "available",
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-indoor-cam-mini",
@@ -80224,7 +81108,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "release_notes": "Corrected from 1080p fixed to 2K 360 pan/tilt per eufy's official 'Introducing eufy Indoor Cam Mini 2K' article (360 horizontal / 100 vertical). RTSP not confirmed by an official eufy source; app/cloud (http) only."
+    "release_notes": "Corrected from 1080p fixed to 2K 360 pan/tilt per eufy's official 'Introducing eufy Indoor Cam Mini 2K' article (360 horizontal / 100 vertical). RTSP not confirmed by an official eufy source; app/cloud (http) only.",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-indoor-cam-s350",
@@ -80296,7 +81181,8 @@
       "global"
     ],
     "last_verified": "2026-07-04",
-    "release_notes": "RTSP removed: not confirmed by any official eufy source (eufy 'About NAS/RTSP' article lists only eufyCam 3C/3/E330 Pro; S350 FAQ and product page do not mention RTSP). Community (iSpyConnect) reports /live0 but this is unverified."
+    "release_notes": "RTSP removed: not confirmed by any official eufy source (eufy 'About NAS/RTSP' article lists only eufyCam 3C/3/E330 Pro; S350 FAQ and product page do not mention RTSP). Community (iSpyConnect) reports /live0 but this is unverified.",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-outdoor-cam-e210",
@@ -80389,7 +81275,8 @@
         "profile": "Generic/RTSP",
         "notes": "Add as a Network IP camera with a manual RTSP path (/live0); no ONVIF."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-outdoor-cam-e220",
@@ -80491,7 +81378,8 @@
         "profile": "Generic/RTSP",
         "notes": "Add as a Network IP camera with a manual RTSP path (/live0); no ONVIF."
       }
-    }
+    },
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-s220-solocam",
@@ -80559,7 +81447,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-c210",
@@ -80629,7 +81518,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-e30",
@@ -80690,7 +81580,8 @@
     "status": "available",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-solocam-e40",
@@ -80757,7 +81648,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-e42",
@@ -80831,7 +81723,8 @@
       "https://service.eufy.com/article-description/Basic-Information-of-SoloCam-E42"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-solocam-l20",
@@ -80899,7 +81792,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-l40",
@@ -80967,7 +81861,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-s230",
@@ -81038,7 +81933,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-solocam-s340",
@@ -81107,7 +82003,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-solocam-s40",
@@ -81176,7 +82073,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-c30",
@@ -81242,7 +82140,8 @@
       "https://service.eufy.com/article-description/Video-Doorbell-C30-User-Guide-T8224"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-video-doorbell-c31",
@@ -81312,7 +82211,8 @@
       "https://service.eufy.com/product-description/a08J1000000YA4KIAW"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-04"
   },
   {
     "id": "eufy-video-doorbell-dual",
@@ -81387,7 +82287,8 @@
         "integration": "eufy_security",
         "notes": "Use the eufy_security HACS integration (P2P live stream). Doorbell press exposed as event. No native RTSP/ONVIF — eufy confirms the Video Doorbell Dual does not support RTSP."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-e340",
@@ -81481,7 +82382,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF). Portrait aspect ratio."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-video-doorbell-s220",
@@ -81549,7 +82451,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "eufy-video-doorbell-s330",
@@ -81640,7 +82543,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the HomeBase RTSP URL as a Generic/RTSP source (no ONVIF). Portrait aspect ratio."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "eufy-wall-light-cam-s100",
@@ -81708,7 +82612,8 @@
       "https://www.eufy.com/eu-en/products/t84a1311",
       "https://service.eufy.com/article-description/Introducing-S100-Wall-Light-Cam"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-07-04"
   },
   {
     "id": "ezviz-bc1c-4k",
@@ -81778,7 +82683,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-bc1c-elife",
@@ -81847,7 +82753,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-bc1c-elife-2k",
@@ -81914,7 +82821,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-bc2",
@@ -81978,7 +82886,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c1c-b",
@@ -82040,7 +82949,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c1c-pir",
@@ -82108,7 +83018,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c2c-h265",
@@ -82171,7 +83082,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3tn",
@@ -82237,7 +83149,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3tn-2k",
@@ -82305,7 +83218,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c3w-pro",
@@ -82370,7 +83284,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c3x",
@@ -82433,7 +83348,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c60p-dual-mix-2k",
@@ -82496,7 +83412,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6c-2k",
@@ -82560,7 +83477,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6n",
@@ -82668,7 +83586,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c6n-g1-4k",
@@ -82733,7 +83652,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c6n-pro-2k",
@@ -82798,7 +83718,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c7-dual",
@@ -82862,7 +83783,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c8c",
@@ -82938,7 +83860,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c8c-4k",
@@ -83005,7 +83928,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c8pf",
@@ -83074,7 +83998,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-c8w-pro-2k",
@@ -83152,7 +84077,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c90-dual-2k-plus",
@@ -83219,7 +84145,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-c9c-dual-3k",
@@ -83286,7 +84213,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb1",
@@ -83351,7 +84279,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb2",
@@ -83415,7 +84344,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb2-4g",
@@ -83477,7 +84407,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb3-4g",
@@ -83541,7 +84472,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb3-aov",
@@ -83610,7 +84542,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb5-4k",
@@ -83677,7 +84610,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8",
@@ -83743,7 +84677,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-lite-4g",
@@ -83811,7 +84746,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-lite-4k",
@@ -83878,7 +84814,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb8-pro",
@@ -83945,7 +84882,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb90-dual-kit",
@@ -84012,7 +84950,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cb90x-dual-4g-kit",
@@ -84080,7 +85019,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-cp1-pro",
@@ -84144,7 +85084,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-db2-doorbell",
@@ -84223,7 +85164,8 @@
         "notes": "No RTSP or ONVIF. Cloud-dependent, app-only. EZVIZ integration in HA provides basic status but no local stream. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-db2c-doorbell",
@@ -84297,7 +85239,8 @@
         "notes": "No RTSP or ONVIF. Cloud-dependent, app-only. Not compatible with Frigate or Blue Iris."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-e4p",
@@ -84360,7 +85303,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-e6",
@@ -84426,7 +85370,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb3-4g",
@@ -84490,7 +85435,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb3-aov",
@@ -84560,7 +85506,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb5-4k",
@@ -84628,7 +85575,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-4g",
@@ -84694,7 +85642,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-pro-4g",
@@ -84763,7 +85712,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-eb8-pro-ranger-kit",
@@ -84831,7 +85781,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-el3",
@@ -84895,7 +85846,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h1c",
@@ -84958,7 +85910,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3-2k",
@@ -85024,7 +85977,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3c-2k",
@@ -85089,7 +86043,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h3c-color",
@@ -85154,7 +86109,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h3k-poe-4k",
@@ -85223,7 +86179,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h4",
@@ -85291,7 +86248,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h4-poe-2k",
@@ -85358,7 +86316,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h5-4g",
@@ -85425,7 +86384,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h5-poe-2k",
@@ -85489,7 +86449,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6",
@@ -85555,7 +86516,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c",
@@ -85621,7 +86583,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c-g1-4k",
@@ -85686,7 +86649,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h6c-pro",
@@ -85751,7 +86715,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h7c-dual-2k-plus",
@@ -85816,7 +86781,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8-pro-3k",
@@ -85921,7 +86887,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h80f-multi-2k-plus",
@@ -85986,7 +86953,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h80x-dual",
@@ -86051,7 +87019,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c",
@@ -86156,7 +87125,8 @@
         "notes": "Select 'Hikvision' profile. EZVIZ uses Hikvision protocol. Must enable RTSP in EZVIZ app first."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-4g",
@@ -86222,7 +87192,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-poe-2k",
@@ -86287,7 +87258,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-2k",
@@ -86351,7 +87323,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-2k-plus",
@@ -86425,7 +87398,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-pro-4g",
@@ -86493,7 +87467,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8c-pro-4k",
@@ -86568,7 +87543,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "ezviz-h8c-pro-4k-r210",
@@ -86633,7 +87609,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h8x-2k-plus",
@@ -86698,7 +87675,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h90-dual-2k-plus",
@@ -86763,7 +87741,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h9c-dual-3k",
@@ -86828,7 +87807,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-h9c-dual-4g",
@@ -86896,7 +87876,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8",
@@ -86964,7 +87945,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-lite-4g",
@@ -87031,7 +88013,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-lite-4k",
@@ -87098,7 +88081,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb8-pro",
@@ -87164,7 +88148,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb90-dual-kit",
@@ -87232,7 +88217,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-hb90x-dual-4g-kit",
@@ -87300,7 +88286,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-lc3",
@@ -87364,7 +88351,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-s10",
@@ -87430,7 +88418,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty1-g1-2k",
@@ -87495,7 +88484,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty1-pro",
@@ -87559,7 +88549,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "ezviz-ty7-dual-2k-plus",
@@ -87625,7 +88616,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "flir-elara-fb-324t",
@@ -87702,7 +88694,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fb-632t",
@@ -87779,7 +88772,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-324t",
@@ -87856,7 +88850,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-632t",
@@ -87934,7 +88929,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-elara-fc-648t",
@@ -88012,7 +89008,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6302-11-i",
@@ -88090,7 +89087,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6308-31-i",
@@ -88168,7 +89166,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-quasar-cp-6404-31-i",
@@ -88246,7 +89245,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-saros-dh-390",
@@ -88325,7 +89325,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "flir-saros-dm-390",
@@ -88403,7 +89404,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP path: /avc."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "foscam-c5m",
@@ -88482,7 +89484,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-c8m",
@@ -88561,7 +89564,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d2ep",
@@ -88640,7 +89644,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d4z",
@@ -88715,7 +89720,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d8et",
@@ -88792,7 +89798,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-d8t",
@@ -88875,7 +89882,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-g4c",
@@ -88941,7 +89949,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-pd5",
@@ -89025,7 +90034,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-pd8",
@@ -89119,7 +90129,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-r8m",
@@ -89202,7 +90213,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd4",
@@ -89274,7 +90286,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd4h",
@@ -89358,7 +90371,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd8ep",
@@ -89455,7 +90469,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-sd8p",
@@ -89548,7 +90563,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-t5ep",
@@ -89629,7 +90645,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-t8ep",
@@ -89713,7 +90730,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed working with Blue Iris per retailer product Q&A, using generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v4ec",
@@ -89785,7 +90803,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v5ep",
@@ -89878,7 +90897,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed working with Blue Iris per official product page Q&A."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v8ep",
@@ -89973,7 +90993,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-v8p",
@@ -90048,7 +91069,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Retailer product Q&A states it works with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-w5ep",
@@ -90127,7 +91149,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "No dedicated Foscam profile in Blue Iris; use generic ONVIF/RTSP setup."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "foscam-x5",
@@ -90201,7 +91224,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "geovision-gv-abl2702",
@@ -90280,7 +91304,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-abl4712",
@@ -90359,7 +91384,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-abl8712",
@@ -90438,7 +91464,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-adr2702",
@@ -90517,7 +91544,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-adr4702",
@@ -90596,7 +91624,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-bl2702",
@@ -90674,7 +91703,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-efer3700",
@@ -90753,7 +91783,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-sd2322-ir",
@@ -90831,7 +91862,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-sd4825-ir",
@@ -90910,7 +91942,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr2704",
@@ -90988,7 +92021,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr4704",
@@ -91066,7 +92100,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "geovision-gv-tdr8805",
@@ -91144,7 +92179,8 @@
         "notes": "Select 'GeoVision' profile. Default RTSP port may be 8554."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "godrej-eve-cube",
@@ -91212,7 +92248,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-mini",
@@ -91280,7 +92317,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-nx-pt",
@@ -91351,7 +92389,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "godrej-eve-pro-outdoor",
@@ -91415,7 +92454,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-battery-2",
@@ -91468,7 +92508,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-indoor-1st-gen",
@@ -91530,7 +92571,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-indoor-3rd-gen",
@@ -91595,7 +92637,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-iq-indoor",
@@ -91657,7 +92700,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-iq-outdoor",
@@ -91720,7 +92764,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "google-nest-cam-outdoor-2nd-gen",
@@ -91788,7 +92833,8 @@
     "markets": [
       "EU"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-outdoor-wire",
@@ -91838,7 +92884,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-wired-2021",
@@ -91902,7 +92949,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-cam-with-floodlight",
@@ -91964,7 +93012,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-3rd-gen",
@@ -92030,7 +93079,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-battery",
@@ -92081,7 +93131,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "google-nest-doorbell-wired-2nd-gen",
@@ -92147,7 +93198,8 @@
     "markets": [
       "UK"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-ane-l6012r",
@@ -92260,7 +93312,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-ano-l7082r",
@@ -92368,7 +93421,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-anv-l7082r",
@@ -92476,7 +93530,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnb-a9001",
@@ -92584,7 +93639,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnd-9080r",
@@ -92707,7 +93763,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnd-a9081rv",
@@ -92826,7 +93883,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-pnm-9000vq",
@@ -92933,7 +93991,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnm-9031rv",
@@ -93053,7 +94112,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-9322vqp",
@@ -93162,7 +94222,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-pnm-c16083rvq",
@@ -93283,7 +94344,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-c34404rqpz",
@@ -93408,7 +94470,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnm-c9022rv",
@@ -93529,7 +94592,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pno-a9081r",
@@ -93650,7 +94714,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-pnv-a9081r",
@@ -93770,7 +94835,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qnd-6082r",
@@ -93876,7 +94942,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-6082r1",
@@ -93976,7 +95043,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-8020r",
@@ -94074,7 +95142,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnd-8080r-kr",
@@ -94182,7 +95251,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qne-8021r",
@@ -94290,7 +95360,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "hanwha-qne-c8013rl",
@@ -94403,7 +95474,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qne-c9013rl",
@@ -94517,7 +95589,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-qno-6082r1",
@@ -94624,7 +95697,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8030r",
@@ -94731,7 +95805,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8080r",
@@ -94838,7 +95913,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-8080r-mena",
@@ -94948,7 +96024,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qno-c9083r",
@@ -95057,7 +96134,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-6082r1",
@@ -95161,7 +96239,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8030r",
@@ -95263,7 +96342,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080r",
@@ -95371,7 +96451,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080r-mena",
@@ -95482,7 +96563,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-8080rb",
@@ -95587,7 +96669,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-qnv-c9083r",
@@ -95697,7 +96780,8 @@
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-tnv-8011c",
@@ -95809,7 +96893,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-tnv-c7013rc",
@@ -95930,7 +97015,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xnd-a9085rv",
@@ -96049,7 +97135,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xno-a9084r",
@@ -96165,7 +97252,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xno-c7083r",
@@ -96276,7 +97364,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xno-c9083r",
@@ -96387,7 +97476,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnp-9300rw",
@@ -96508,7 +97598,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-8080r",
@@ -96632,7 +97723,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-8093r",
@@ -96755,7 +97847,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-9083rz",
@@ -96873,7 +97966,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-a9084r",
@@ -96998,7 +98092,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hanwha-xnv-a9084rs",
@@ -97117,7 +98212,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hanwha-xnv-c7083r",
@@ -97239,7 +98335,8 @@
         "profile": "Samsung/Hanwha",
         "notes": "Select 'Samsung' or 'Hanwha' profile depending on Blue Iris version."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "hifocus-hc-ipc-b4262",
@@ -97327,7 +98424,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "105.6",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4212du-vf-x",
@@ -97415,7 +98513,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
     "field_of_view_deg": "112.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4212w-vf",
@@ -97502,7 +98601,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4214dz-vf",
@@ -97589,7 +98689,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "106.25-30.42",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215da-0280",
@@ -97677,7 +98778,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "107.4-29.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215dv-0280",
@@ -97765,7 +98867,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "102",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4215dzs-vf",
@@ -97855,7 +98958,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.5\" progressive-scan CMOS",
     "field_of_view_deg": "80-38",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-d4312dz-vf",
@@ -97943,7 +99047,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94-28",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-di3212dvzk-n5-o",
@@ -98030,7 +99135,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
     "field_of_view_deg": "98.3-32.2",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-di3215dvzk-n5-o",
@@ -98119,7 +99225,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "102.9-31.4",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-dqa4318l-twl-0280",
@@ -98207,7 +99314,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" progressive-scan CMOS",
     "field_of_view_deg": "110.4-89.4",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-dt4215-0280",
@@ -98293,7 +99401,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "115",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-rg31t",
@@ -98357,7 +99466,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "1/3\" color CMOS",
-    "field_of_view_deg": "105"
+    "field_of_view_deg": "105",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-rg31tl",
@@ -98442,7 +99552,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd0440t-al",
@@ -98530,7 +99641,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" BSI CMOS (NIR+)",
     "field_of_view_deg": "97-31",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd3380e",
@@ -98618,7 +99730,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd3820sr",
@@ -98707,7 +99820,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sd4420-x33-ex",
@@ -98793,7 +99907,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP68"
+    "ip_rating": "IP68",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdbg31t",
@@ -98878,7 +99993,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdbg41t",
@@ -98939,7 +100055,8 @@
       "ac-mains"
     ],
     "last_verified": "2026-07-06",
-    "field_of_view_deg": "108"
+    "field_of_view_deg": "108",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdq53320s",
@@ -99028,7 +100145,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-sdqa20540-s",
@@ -99116,7 +100234,8 @@
         "notes": "Hi-Focus PTZ uses the Dahua protocol — select the 'Dahua' profile (or Generic/ONVIF)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4212er5-0600",
@@ -99202,7 +100321,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" progressive-scan CMOS",
     "field_of_view_deg": "106.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4212u-0600",
@@ -99287,7 +100407,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4213d-vf",
@@ -99373,7 +100494,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94-28",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214a-0600",
@@ -99460,7 +100582,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214dz-vf",
@@ -99543,7 +100666,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/3\" progressive-scan CMOS",
     "field_of_view_deg": "105-35",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4214sr5-0600",
@@ -99630,7 +100754,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "93.38-28.56",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-t4215t12-0400",
@@ -99717,7 +100842,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "82",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-ti4312dvzk-n8-o",
@@ -99804,7 +100930,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
     "field_of_view_deg": "102.9-31.4",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-ti4315dvzk-n8-o",
@@ -99893,7 +101020,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" progressive-scan CMOS",
     "field_of_view_deg": "98.3-32.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tqa4415l-twl-0600",
@@ -99980,7 +101108,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "88.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tsa3300n3-pe-dl",
@@ -100065,7 +101194,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
     "field_of_view_deg": "69",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-ipc-tv31e-4g",
@@ -100151,7 +101281,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-lpc-tqa4312l-twl-0400",
@@ -100236,7 +101367,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "77.5",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-lpc-tqa4318l-twl-0400",
@@ -100324,7 +101456,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" progressive-scan CMOS",
     "field_of_view_deg": "99.0-77.5",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg30n3-4g",
@@ -100409,7 +101542,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg31t-4g",
@@ -100474,7 +101608,8 @@
     ],
     "last_verified": "2026-07-06",
     "field_of_view_deg": "98.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hc-sdg42t",
@@ -100559,7 +101694,8 @@
         "profile": "Generic/ONVIF",
         "notes": "Use the Generic/ONVIF/RTSP profile (enable ONVIF in the app)."
       }
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3022-dl-i2",
@@ -100643,7 +101779,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3022e-i2",
@@ -100729,7 +101866,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3024-dl-i2",
@@ -100815,7 +101953,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3024e-i2",
@@ -100899,7 +102038,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3112-dls-i2",
@@ -100987,7 +102127,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3115-dls-i2",
@@ -101075,7 +102216,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3304-dls-r1",
@@ -101162,7 +102304,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3312-dls-i2",
@@ -101248,7 +102391,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3315-dls-i2",
@@ -101334,7 +102478,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-d3512-kvdl-i2",
@@ -101418,7 +102563,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4022-dl-i2",
@@ -101504,7 +102650,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4022e-i2",
@@ -101587,7 +102734,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" Sony Starvis CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4024-dl-i2",
@@ -101671,7 +102819,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4024e-i2",
@@ -101755,7 +102904,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4404-dl-r1",
@@ -101837,7 +102987,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4504-adl-r1",
@@ -101921,7 +103072,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4504-dls-r1",
@@ -102008,7 +103160,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4512-adls-i2",
@@ -102091,7 +103244,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4515-adls-i2",
@@ -102176,7 +103330,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4804-dls-r1",
@@ -102263,7 +103418,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/3\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hifocus-hipc-t4815-kdls-i2",
@@ -102348,7 +103504,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" Sony CMOS",
     "field_of_view_deg": "102.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215itg",
@@ -102408,7 +103565,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215tg",
@@ -102466,7 +103624,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4215tg-3",
@@ -102524,7 +103683,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225itg",
@@ -102584,7 +103744,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225tg",
@@ -102642,7 +103803,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4225tg-3",
@@ -102700,7 +103862,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae4425itg",
@@ -102760,7 +103923,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5225itg",
@@ -102819,7 +103983,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5225tg",
@@ -102877,7 +104042,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5232itg",
@@ -102936,7 +104102,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5232tg",
@@ -102994,7 +104161,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae5425itg",
@@ -103053,7 +104221,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ae7232itg",
@@ -103113,7 +104282,8 @@
       "dc"
     ],
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cc12d9t-a",
@@ -103168,7 +104338,8 @@
     "lens": {
       "count": 1,
       "varifocal": false
-    }
+    },
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cc12d9t-ait3ze",
@@ -103227,7 +104398,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "32.1-98",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd1023g0e-i",
@@ -103343,7 +104515,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2cd1023g2-iuf",
@@ -103441,7 +104614,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
-    "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD."
+    "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1023g2-liu",
@@ -103525,7 +104699,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1023g2-liuf",
@@ -103621,7 +104796,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m."
+    "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1027g2h-liu",
@@ -103744,7 +104920,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2cd1027g2h-liuf",
@@ -103841,7 +105018,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic."
+    "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1043g2-iuf",
@@ -103939,7 +105117,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD."
+    "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1043g2-liu",
@@ -104023,7 +105202,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1043g2-liuf",
@@ -104121,7 +105301,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic."
+    "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1047g0-luf",
@@ -104219,7 +105400,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense."
+    "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1047g2h-liuf",
@@ -104318,7 +105500,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense."
+    "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1067g2h-liuf",
@@ -104417,7 +105600,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res."
+    "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1123g2-i",
@@ -104514,7 +105698,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot."
+    "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1123g2-liu",
@@ -104598,7 +105783,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1123g2-liuf",
@@ -104697,7 +105883,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08."
+    "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1127g0-luf-d",
@@ -104796,7 +105983,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR."
+    "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1127g2h-liuf",
@@ -104895,7 +106083,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08."
+    "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-i",
@@ -104994,7 +106183,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD."
+    "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-iuf",
@@ -105095,7 +106285,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I."
+    "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liu",
@@ -105179,7 +106370,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf",
@@ -105278,7 +106470,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08."
+    "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf-india",
@@ -105369,7 +106562,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1143g2-liuf-n",
@@ -105440,7 +106634,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1147g0-luf-d",
@@ -105539,7 +106734,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic."
+    "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1147g2h-liuf",
@@ -105638,7 +106834,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08."
+    "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1153g2-liuf",
@@ -105709,7 +106906,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1167g2h-liuf",
@@ -105808,7 +107006,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps."
+    "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1183g2-liuf",
@@ -105879,7 +107078,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd1323g2-iuf",
@@ -105977,7 +107177,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR."
+    "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1323g2-liuf",
@@ -106075,7 +107276,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
+    "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1327g2h-liuf",
@@ -106173,7 +107375,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic."
+    "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1343g2-iuf",
@@ -106272,7 +107475,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP."
+    "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1343g2-liuf",
@@ -106370,7 +107574,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
+    "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1347g2h-liuf",
@@ -106468,7 +107673,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic."
+    "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1367g2h-liuf",
@@ -106567,7 +107773,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps."
+    "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1623g2-izs",
@@ -106667,7 +107874,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD."
+    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1643g2-izs",
@@ -106767,7 +107975,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1723g2-izs",
@@ -106866,7 +108075,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10."
+    "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1743g2-izs",
@@ -106966,7 +108176,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1h43g2-izs",
@@ -107065,7 +108276,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD."
+    "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd1t27g0-luf-c",
@@ -107164,7 +108376,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic."
+    "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2021g1-i",
@@ -107262,7 +108475,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal",
-    "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense."
+    "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2023g0-i",
@@ -107336,7 +108550,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2023g2-iu",
@@ -107409,7 +108624,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2025fwd-i",
@@ -107482,7 +108698,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2026g2-iu",
@@ -107580,7 +108797,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U)."
+    "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2027g2-lu",
@@ -107665,7 +108883,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2027g2h-liu",
@@ -107752,7 +108971,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-i",
@@ -107835,7 +109055,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-iu",
@@ -107933,7 +109154,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
-    "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U)."
+    "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2043g2-l",
@@ -108032,7 +109254,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102 (2.8mm) horizontal",
-    "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR)."
+    "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2043g2-li",
@@ -108116,7 +109339,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2043g2-li2u",
@@ -108214,7 +109438,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
-    "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone."
+    "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2-iu",
@@ -108313,7 +109538,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U)."
+    "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2-iu-sl",
@@ -108438,7 +109664,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2h-i2u-slrb",
@@ -108536,7 +109763,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
-    "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio."
+    "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2046g2h-iu",
@@ -108634,7 +109862,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U)."
+    "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g2-l",
@@ -108719,7 +109948,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2047g2-lu",
@@ -108803,7 +110033,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2-lu-sl-mena",
@@ -108896,7 +110127,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-li",
@@ -108981,7 +110213,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-liu",
@@ -109079,7 +110312,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence)."
+    "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g2h-liu-sl",
@@ -109178,7 +110412,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2047g3-li2uy-slrb",
@@ -109278,7 +110513,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2063g2-li",
@@ -109362,7 +110598,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2066g2-iu-sl",
@@ -109488,7 +110725,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2067g2h-liu",
@@ -109576,7 +110814,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2067g2h-liu-sl",
@@ -109676,7 +110915,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio."
+    "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2083g2-i",
@@ -109759,7 +110999,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2083g2-iu",
@@ -109856,7 +111097,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
-    "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."
+    "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2083g2-li",
@@ -109940,7 +111182,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2085g1-i",
@@ -110023,7 +111266,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2086g2-iu",
@@ -110121,7 +111365,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm)/51 (6mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2-iu-sl",
@@ -110220,7 +111465,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "110 (2.8mm)/88 (4mm)/60 (6mm) horizontal",
-    "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR."
+    "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2h-i2u-slrb",
@@ -110319,7 +111565,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio."
+    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2086g2h-iu",
@@ -110417,7 +111664,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+    "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2087g2-l",
@@ -110503,7 +111751,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2087g2-lu",
@@ -110589,7 +111838,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2-su",
@@ -110673,7 +111923,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-li",
@@ -110759,7 +112010,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-liu",
@@ -110857,7 +112109,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U)."
+    "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2087g2h-liu-sl",
@@ -110944,7 +112197,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2087g3-li2uy-sl",
@@ -111032,7 +112286,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2087g3-li2uy-slrb",
@@ -111132,7 +112387,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2123g0-is",
@@ -111207,7 +112463,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2123g2-i",
@@ -111290,7 +112547,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2123g2-is",
@@ -111388,7 +112646,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic)."
+    "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2123g2-iu",
@@ -111462,7 +112721,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2125g0-ims",
@@ -111562,7 +112822,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm)/52 (6mm) horizontal",
-    "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only."
+    "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2126g2-i",
@@ -111661,7 +112922,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10."
+    "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2126g2-isu",
@@ -111761,7 +113023,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
-    "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O."
+    "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2143g2-i",
@@ -111850,7 +113113,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-is",
@@ -111924,7 +113188,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-iu",
@@ -112007,7 +113272,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2143g2-li",
@@ -112091,7 +113357,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2146g2-isu",
@@ -112174,7 +113441,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2146g2h-isu",
@@ -112274,7 +113542,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
-    "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2-su",
@@ -112373,7 +113642,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
-    "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-li-su",
@@ -112462,7 +113732,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-lisu",
@@ -112562,7 +113833,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2147g2h-liu-eu",
@@ -112660,7 +113932,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2147g3-lis2uy",
@@ -112762,7 +114035,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2163g2-i",
@@ -112844,7 +114118,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2163g2-is",
@@ -112918,7 +114193,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2166g2-isu",
@@ -113043,7 +114319,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2167g2h-lisu",
@@ -113143,7 +114420,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2167g2h-liu",
@@ -113232,7 +114510,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2183g2-is",
@@ -113331,7 +114610,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O."
+    "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2183g2-iu",
@@ -113418,7 +114698,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2183g2-li",
@@ -113503,7 +114784,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2185fwd-is",
@@ -113576,7 +114858,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2186g2-isu",
@@ -113676,7 +114959,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2186g2h-isu",
@@ -113777,7 +115061,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2-lsu",
@@ -113878,7 +115163,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "109 (2.8mm)/93 (4mm) horizontal",
-    "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-li",
@@ -113965,7 +115251,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "105.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-lisu",
@@ -114066,7 +115353,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O."
+    "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2187g2h-liu",
@@ -114156,7 +115444,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2187g3-lis2uy",
@@ -114244,7 +115533,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd23166g3-i2uy",
@@ -114379,7 +115669,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2323g2-iu",
@@ -114477,7 +115768,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR."
+    "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2326g2-iu",
@@ -114576,7 +115868,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR."
+    "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2327g2-lu",
@@ -114675,7 +115968,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic."
+    "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2343g2-iu",
@@ -114773,7 +116067,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR."
+    "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2343g2-li",
@@ -114856,7 +116151,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2345g0p-i",
@@ -114954,7 +116250,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
-    "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor)."
+    "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2-isu-sl",
@@ -115055,7 +116352,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio."
+    "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2-iu",
@@ -115139,7 +116437,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2346g2h-is2u-slrb",
@@ -115239,7 +116538,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio."
+    "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2h-iu",
@@ -115338,7 +116638,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U)."
+    "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2346g2p-isu-sl",
@@ -115422,7 +116723,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-l",
@@ -115507,7 +116809,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-lsu-sl",
@@ -115593,7 +116896,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2-lu",
@@ -115678,7 +116982,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2h-lisu-sl",
@@ -115765,7 +117070,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2h-liu",
@@ -115852,7 +117158,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2347g2p-lsu-sl",
@@ -115952,7 +117259,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "180 horizontal / 81 vertical (dual-lens panoramic)",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2347g3-lis2uy-slrb",
@@ -116054,7 +117362,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2367g2-l",
@@ -116139,7 +117448,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2367g2h-lisu-sl",
@@ -116224,7 +117534,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "112.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2367g2h-liu",
@@ -116322,7 +117633,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U)."
+    "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2367g2p-lsu-sl",
@@ -116408,7 +117720,8 @@
     "last_verified": "2026-07-06",
     "sensor": "Dual 1/2.7\" CMOS",
     "field_of_view_deg": "180",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2367g3-lis2uy-sl",
@@ -116495,7 +117808,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2383g2-i",
@@ -116579,7 +117893,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2383g2-iu",
@@ -116677,7 +117992,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."
+    "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2383g2-li",
@@ -116761,7 +118077,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2385g1-i",
@@ -116846,7 +118163,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-i",
@@ -116928,7 +118246,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-isu-sl2",
@@ -117013,7 +118332,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2-iu",
@@ -117096,7 +118416,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2386g2h-is2u-slrb",
@@ -117196,7 +118517,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence."
+    "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2386g2h-iu",
@@ -117294,7 +118616,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U)."
+    "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2387g2-lu",
@@ -117380,7 +118703,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2387g2h-lisu-sl",
@@ -117480,7 +118804,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio."
+    "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2387g2h-liu",
@@ -117568,7 +118893,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2387g2p-lsu-sl",
@@ -117654,7 +118980,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2 x 1/1.8\" CMOS",
     "field_of_view_deg": "180",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2387g3-lis2uy-sl",
@@ -117739,7 +119066,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2387g3-lis2uy-slrb",
@@ -117840,7 +119168,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2421g0-idw",
@@ -117939,7 +119268,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107 (2.8mm) horizontal",
-    "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE)."
+    "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2423g2-i",
@@ -118038,7 +119368,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108.8 (2.8mm)/87.6 (4mm) horizontal",
-    "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection."
+    "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2423g2-iw",
@@ -118138,7 +119469,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "92 (2.8mm)/75 (4mm) horizontal",
-    "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio."
+    "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2443g2-i",
@@ -118237,7 +119569,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "104.3 (2.8mm)/83.7 (4mm) horizontal",
-    "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I)."
+    "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2443g2-iw",
@@ -118312,7 +119645,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2446g2-i",
@@ -118412,7 +119746,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
-    "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio."
+    "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2447g2-lu",
@@ -118497,7 +119832,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2483g2-i",
@@ -118596,7 +119932,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "107.8 (2.8mm)/82.8 (4mm) horizontal",
-    "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio."
+    "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2523g2-is",
@@ -118696,7 +120033,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S)."
+    "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2526g2-is",
@@ -118778,7 +120116,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2542fwd-is",
@@ -118853,7 +120192,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2543g2-is",
@@ -118924,7 +120264,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2543g2-iws",
@@ -119011,7 +120352,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2546g2-iws",
@@ -119113,7 +120455,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08."
+    "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2547g2-ls",
@@ -119215,7 +120558,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O."
+    "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2566g2-is",
@@ -119341,7 +120685,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2583g2-is",
@@ -119441,7 +120786,8 @@
     "last_verified": "2026-07-07",
     "field_of_view_deg": "106.4 (2.8mm)/87.6 (4mm) horizontal",
     "ip_rating": "IP67",
-    "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O."
+    "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2583g2-izs",
@@ -119524,7 +120870,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2586g2-is",
@@ -119624,7 +120971,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic."
+    "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2623g2-izs",
@@ -119723,7 +121071,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "107°-32° (H)",
-    "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10."
+    "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2626g2-izs",
@@ -119806,7 +121155,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2643g2-izs",
@@ -119905,7 +121255,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR."
+    "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2-izs",
@@ -120005,7 +121356,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "108°-30° horizontal",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2h-izs",
@@ -120103,7 +121455,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H)."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2ht-izs",
@@ -120202,7 +121555,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2646g2t-izs",
@@ -120301,7 +121655,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2647g2-lzs",
@@ -120386,7 +121741,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2647g2ht-lizs",
@@ -120485,7 +121841,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m."
+    "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2647g3-lizs2uy-slrb",
@@ -120585,7 +121942,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2667g2ht-lizs",
@@ -120684,7 +122042,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m."
+    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2683g2-izs",
@@ -120767,7 +122126,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2686g2-izs",
@@ -120893,7 +122253,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2h-izs",
@@ -120993,7 +122354,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "112.3°-41.2° (H)",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2ht-izs",
@@ -121092,7 +122454,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2686g2t-izs",
@@ -121192,7 +122555,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "108°-46° horizontal",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2687g2ht-lizs",
@@ -121280,7 +122644,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2687g2t-lzs",
@@ -121377,7 +122742,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K."
+    "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2687g3-lizs2uy-slrb",
@@ -121477,7 +122843,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2723g2-izs",
@@ -121575,7 +122942,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2726g2-izs",
@@ -121658,7 +123026,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2726g2t-izs",
@@ -121757,7 +123126,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2743g2-izs",
@@ -121840,7 +123210,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2746g2-izs",
@@ -121939,7 +123310,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2746g2h-iptrzs2u-slrb",
@@ -122039,7 +123411,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2746g2ht-izs",
@@ -122140,7 +123513,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "105.4°-34.3° (H)",
-    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
+    "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2h-liptrzs2u-slrb",
@@ -122240,7 +123614,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2ht-lizs",
@@ -122341,7 +123716,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "114.6°-41.8° horizontal",
-    "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m."
+    "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2747g2t-lzs",
@@ -122439,7 +123815,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light."
+    "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2763g2-izs",
@@ -122525,7 +123902,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2767g2ht-lizs",
@@ -122624,7 +124002,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m."
+    "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2783g2-izs",
@@ -122722,7 +124101,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR."
+    "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2-izs",
@@ -122821,7 +124201,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2h-iptrzs2u-slrb",
@@ -122922,7 +124303,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
+    "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2786g2ht-izs",
@@ -123021,7 +124403,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2h-liptrzs2u-slrb",
@@ -123123,7 +124506,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "112.3°-41.2° (H)",
-    "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2ht-lizs",
@@ -123222,7 +124606,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g2t-lzs",
@@ -123323,7 +124708,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103.3°-40° horizontal",
-    "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K."
+    "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2787g3-izs",
@@ -123410,7 +124796,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2955fwd-is",
@@ -123499,7 +124886,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2955g0-isu",
@@ -123595,7 +124983,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic."
+    "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2d25g1-d-nf",
@@ -123689,7 +125078,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only."
+    "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2e23g2-u",
@@ -123785,7 +125175,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
+    "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2e43g2-u",
@@ -123881,7 +125272,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
+    "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h23g2-izs",
@@ -123979,7 +125371,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR."
+    "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h43g2-izs",
@@ -124078,7 +125471,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR."
+    "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h43g2-izs-uk",
@@ -124169,7 +125563,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h46g2-izs",
@@ -124253,7 +125648,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h83g2-izs",
@@ -124337,7 +125733,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2h86g2-izs",
@@ -124438,7 +125835,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "108°-46° (H)",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h86g2t-izs",
@@ -124537,7 +125935,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K."
+    "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h87g3-lizs2uy-slrb",
@@ -124639,7 +126038,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "112.3°-41.2° horizontal",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2h87g3-lizsy",
@@ -124727,7 +126127,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-2i",
@@ -124811,7 +126212,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-2i-4i",
@@ -124907,7 +126309,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens."
+    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-4i",
@@ -124989,7 +126392,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t23g2-4is",
@@ -125061,7 +126465,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t26g2-2i-4i",
@@ -125158,7 +126563,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t26g2-isu-sl",
@@ -125241,7 +126647,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t27g2-l",
@@ -125339,7 +126746,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "2MP ColorVu fixed bullet, 60m white light."
+    "release_notes": "2MP ColorVu fixed bullet, 60m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t43g2-2i-4i",
@@ -125435,7 +126843,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t43g2-4i",
@@ -125518,7 +126927,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t45g0p-i",
@@ -125614,7 +127024,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR."
+    "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-2i-4i",
@@ -125711,7 +127122,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-4i",
@@ -125793,7 +127205,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t46g2-isu-sl",
@@ -125892,7 +127305,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103°/83°/53° (H)",
-    "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR."
+    "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2h-2i-4i",
@@ -125989,7 +127403,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+    "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2h-is2u-slrb",
@@ -126088,7 +127503,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "100° (2.8mm)/81° (4mm) horizontal",
-    "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio."
+    "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t46g2p-isu-sl",
@@ -126187,7 +127603,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-l",
@@ -126272,7 +127689,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-l-sl",
@@ -126359,7 +127777,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-lse",
@@ -126447,7 +127866,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2-lsu-sl",
@@ -126532,7 +127952,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-li",
@@ -126619,7 +128040,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-lisu-sl",
@@ -126717,7 +128139,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio."
+    "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g2h-liu",
@@ -126801,7 +128224,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g2p-lsu-sl",
@@ -126901,7 +128325,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio."
+    "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-lis2uy-sl",
@@ -126990,7 +128415,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-lis2uy-slrb",
@@ -127090,7 +128516,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio."
+    "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t47g3-liy",
@@ -127179,7 +128606,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t63g2-4i",
@@ -127261,7 +128689,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t67g2-l",
@@ -127345,7 +128774,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t67g2h-li",
@@ -127441,7 +128871,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP."
+    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t67g2h-lisu-sl",
@@ -127540,7 +128971,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio."
+    "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t83g2-2i-4i",
@@ -127638,7 +129070,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "107°/87°/54° (H)",
-    "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t83g2-4i",
@@ -127721,7 +129154,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t85g1-i8",
@@ -127805,7 +129239,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-2i-4i",
@@ -127902,7 +129337,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-4i",
@@ -127985,7 +129421,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t86g2-isu-sl",
@@ -128085,7 +129522,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "110°/88°/59° horizontal",
-    "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K."
+    "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2h-2i-4i",
@@ -128181,7 +129619,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
+    "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t86g2h-is2u-slrb",
@@ -128279,7 +129718,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio."
+    "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-4i",
@@ -128364,7 +129804,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-l",
@@ -128451,7 +129892,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g2-lsu-sl",
@@ -128537,7 +129979,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g2h-li",
@@ -128634,7 +130077,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2h-lisu-sl",
@@ -128733,7 +130177,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K."
+    "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g2p-lsu-sl",
@@ -128833,7 +130278,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio."
+    "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-li",
@@ -128922,7 +130368,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-lis2uy-sl",
@@ -129006,7 +130453,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cd2t87g3-lis2uy-slrb",
@@ -129105,7 +130553,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K."
+    "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3043g2-iu",
@@ -129203,7 +130652,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "103°/84°/52° (H)",
-    "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR."
+    "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3056g2-is",
@@ -129335,7 +130785,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3086g2-is",
@@ -129468,7 +130919,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3143g2-iu",
@@ -129543,7 +130995,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3156g2-is-u",
@@ -129676,7 +131129,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3343g2-isu",
@@ -129773,7 +131227,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR."
+    "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3347g2-lu",
@@ -129846,7 +131301,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3386g2-is-u",
@@ -129975,7 +131431,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3387g2-lu",
@@ -130048,7 +131505,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3523g2-is",
@@ -130123,7 +131581,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3686g2t-izsy-h",
@@ -130225,7 +131684,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
     "field_of_view_deg": "108°-46° horizontal",
-    "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K."
+    "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3746g2-izs",
@@ -130360,7 +131820,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3766g2t-izs-y",
@@ -130495,7 +131956,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd3t47g2-lzs",
@@ -130568,7 +132030,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd3t87g2-lzs",
@@ -130641,7 +132104,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6365g0e-ivs",
@@ -130716,7 +132180,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6365g1-ivs",
@@ -130817,7 +132282,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR."
+    "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd6365g1-s-rc",
@@ -130915,7 +132381,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics."
+    "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd63c5g1-ivs",
@@ -131002,7 +132469,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd63c5g1-s-rc",
@@ -131101,7 +132569,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating."
+    "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd6944g0-ihs",
@@ -131175,7 +132644,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2cd6w65g1-ivs",
@@ -131275,7 +132745,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP67",
-    "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR."
+    "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cd7a87g0-xzs",
@@ -131348,7 +132819,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-exif",
@@ -131415,7 +132887,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-it3e",
@@ -131484,7 +132957,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-itfs",
@@ -131553,7 +133027,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lfs",
@@ -131609,7 +133084,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lpfs",
@@ -131665,7 +133141,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16d0t-lxts",
@@ -131734,7 +133211,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d0t-vfir3e",
@@ -131803,7 +133281,8 @@
     "operating_temp_c": "-40 to 60",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2ce16d8t-it3f",
@@ -131852,7 +133331,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16d9t-airazh",
@@ -131911,7 +133391,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "6-59",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16h0t-itec",
@@ -131969,7 +133450,8 @@
     "last_verified": "2026-07-06",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "93 / 77",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16h8t-it3f",
@@ -132017,7 +133499,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-itf",
@@ -132065,7 +133548,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-lfs",
@@ -132121,7 +133605,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16k0t-lpfs",
@@ -132177,7 +133662,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16u0t-itf",
@@ -132235,7 +133721,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce16u0t-itpf",
@@ -132294,7 +133781,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce17d0t-lfs",
@@ -132350,7 +133838,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78 / 49.2",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce17k0t-lfs",
@@ -132406,7 +133895,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 (2.8mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce18k0t-lfs",
@@ -132463,7 +133953,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3 / 51.8",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19h0t-it3zec",
@@ -132521,7 +134012,8 @@
     "last_verified": "2026-07-06",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "95-26",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19u1t-it3zf",
@@ -132580,7 +134072,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP progressive-scan CMOS",
     "field_of_view_deg": "108.1-45.6",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce19u8t-ait3z",
@@ -132639,7 +134132,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "45.6-108.1",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce57u0t-vpitf",
@@ -132697,7 +134191,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76d0t-lmfs",
@@ -132753,7 +134248,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76d0t-lpfs",
@@ -132808,7 +134304,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
-    "field_of_view_deg": "101 / 78"
+    "field_of_view_deg": "101 / 78",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-itmfs",
@@ -132857,7 +134354,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-lmfs",
@@ -132913,7 +134411,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2ce76k0t-lpfs",
@@ -132968,7 +134467,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
-    "field_of_view_deg": "104.9 / 81.3"
+    "field_of_view_deg": "104.9 / 81.3",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76u0t-itmf",
@@ -133027,7 +134527,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce76u0t-itpf",
@@ -133085,7 +134586,8 @@
     ],
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
-    "field_of_view_deg": "102.9 / 79 / 44.7"
+    "field_of_view_deg": "102.9 / 79 / 44.7",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78d0t-lfs",
@@ -133141,7 +134643,8 @@
     "last_verified": "2026-07-06",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "100 / 80",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78k0t-lfs",
@@ -133197,7 +134700,8 @@
     "last_verified": "2026-07-06",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2ce78u0t-it3f",
@@ -133255,7 +134759,8 @@
     "last_verified": "2026-07-06",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2cv2041g2-idw",
@@ -133352,7 +134857,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR."
+    "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cv2141g2-idw-e",
@@ -133449,7 +134955,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR."
+    "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2cv2q21g1-idw",
@@ -133548,7 +135055,8 @@
     ],
     "last_verified": "2026-07-07",
     "field_of_view_deg": "75° (H)",
-    "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor)."
+    "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2a204iw-de3-w",
@@ -133632,7 +135140,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de2a404iw-de3-ws6",
@@ -133737,7 +135246,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "96.7°-31.6° horizontal",
-    "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°."
+    "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2a404iw-de3s6",
@@ -133840,7 +135350,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic."
+    "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de2c400iwg",
@@ -133938,7 +135449,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V."
+    "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3404w-det5",
@@ -134038,7 +135550,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR)."
+    "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bw-de",
@@ -134124,7 +135637,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de3a400bw-de-wt5",
@@ -134223,7 +135737,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light."
+    "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bw-det5",
@@ -134322,7 +135837,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light."
+    "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a400bwg-e",
@@ -134408,7 +135924,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de3a404iwg-e",
@@ -134510,7 +136027,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR."
+    "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de3a404iwg-e-w",
@@ -134613,7 +136131,8 @@
       "outdoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR)."
+    "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR).",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4215iw-det5",
@@ -134717,7 +136236,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "57.6°-4° (H)",
-    "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°."
+    "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4225iw-det5",
@@ -134818,7 +136338,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE."
+    "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4425iw-de",
@@ -134908,7 +136429,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4425iw-de-t5-india",
@@ -134999,7 +136521,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4425iw-det5",
@@ -135102,7 +136625,8 @@
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
     "field_of_view_deg": "55°-2.4° horizontal",
-    "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°."
+    "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4825wg-e3",
@@ -135188,7 +136712,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP54"
+    "ip_rating": "IP54",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iw-de",
@@ -135274,7 +136799,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iw-des6",
@@ -135374,7 +136900,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR."
+    "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de4a225iwg-e",
@@ -135461,7 +136988,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a225iwg1-e",
@@ -135548,7 +137076,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a404iwg-e",
@@ -135635,7 +137164,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4a425iw-de",
@@ -135721,7 +137251,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de4a425iwg-e",
@@ -135806,7 +137337,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de4a425iwg1-e",
@@ -135893,7 +137425,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de5225w-ae3t5",
@@ -135994,7 +137527,8 @@
       "indoor"
     ],
     "last_verified": "2026-07-07",
-    "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE."
+    "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de5425iw-aet5",
@@ -136095,7 +137629,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE."
+    "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de5a425iwg-e",
@@ -136180,7 +137715,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de5a425iwg-eb",
@@ -136262,7 +137798,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2de7a225iw-aebt5",
@@ -136363,7 +137900,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a225iwg-eb-sl",
@@ -136450,7 +137988,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a225iwg1-e",
@@ -136537,7 +138076,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a232iw-aebt5",
@@ -136640,7 +138180,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a232iwg-eb-sl",
@@ -136727,7 +138268,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a232iwg1-e",
@@ -136816,7 +138358,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a425iwg-eb-sl",
@@ -136904,7 +138447,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a432iw-aeb",
@@ -136990,7 +138534,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "hikvision-ds-2de7a432iw-aebt5",
@@ -137093,7 +138638,8 @@
     ],
     "last_verified": "2026-07-07",
     "ip_rating": "IP66",
-    "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+    "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "added": "2026-07-07"
   },
   {
     "id": "hikvision-ds-2de7a632iwg1-e",
@@ -137181,7 +138727,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2de7a825iwg1-e",
@@ -137269,7 +138816,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2pt3q27iwx-de",
@@ -137351,7 +138899,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se4c215mwg-e",
@@ -137436,7 +138985,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c225mwg-e",
@@ -137522,7 +139072,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c425mwg-4g",
@@ -137610,7 +139161,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2se4c425mwg-e",
@@ -137690,7 +139242,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se4c430mwg-e",
@@ -137769,7 +139322,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ds-2se7c432mwg-eb",
@@ -137855,7 +139409,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2sf7c425mxg2-lm-el",
@@ -137985,7 +139540,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "hikvision-ds-2sf8c442mxg1-elw",
@@ -138072,7 +139628,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2sf8c848mxg1-elw",
@@ -138160,7 +139717,8 @@
       }
     },
     "last_verified": "2026-07-06",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hikvision-ds-2xs6a25g0-i",
@@ -138235,7 +139793,8 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hikvision-ids-2cd7a46g0-p-izhs-y",
@@ -138373,7 +139932,8 @@
         "profile": "Hikvision",
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
-    }
+    },
+    "added": "2026-07-07"
   },
   {
     "id": "hilook-ipc-b129haa-lu",
@@ -138461,7 +140021,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-b140h",
@@ -138549,7 +140110,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b180ha-lu",
@@ -138638,7 +140200,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b429haa-lu",
@@ -138726,7 +140289,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-b480h",
@@ -138813,7 +140377,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-b529haa-lu",
@@ -138901,7 +140466,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-c340ha-dw",
@@ -138985,7 +140551,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d121h-m",
@@ -139072,7 +140639,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "112.1 (2.8mm) / 90.2 (4mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-d140h",
@@ -139160,7 +140728,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d140ha-lu",
@@ -139247,7 +140816,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-d150h-m",
@@ -139333,7 +140903,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-d180h",
@@ -139420,7 +140991,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t140h",
@@ -139508,7 +141080,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t229haa-lu",
@@ -139596,7 +141169,8 @@
         "notes": "HiLook uses the Hikvision protocol — select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-t240h",
@@ -139682,7 +141256,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t240ha",
@@ -139769,7 +141344,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t241h-c",
@@ -139855,7 +141431,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "104 (2.8mm) / 82 (4mm)",
-    "ip_rating": "IP67"
+    "ip_rating": "IP67",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ipc-t280h",
@@ -139943,7 +141520,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ipc-t280ha-lu",
@@ -140033,7 +141611,8 @@
         "notes": "Select 'Hikvision' profile. HiLook uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hilook-ptz-n2c200m-de",
@@ -140119,7 +141698,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.7\" CMOS",
     "field_of_view_deg": "111.4 (2.8mm) / 91.5 (4mm)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2c400m-de",
@@ -140206,7 +141786,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
     "field_of_view_deg": "97 (2.8mm) / 79 (4mm)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2d200m-de",
@@ -140291,7 +141872,8 @@
     },
     "last_verified": "2026-07-06",
     "sensor": "1/2.9\" CMOS",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hilook-ptz-n2d400m-de",
@@ -140378,7 +141960,8 @@
     "last_verified": "2026-07-06",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "94 (panoramic) / 44 (PT)",
-    "ip_rating": "IP66"
+    "ip_rating": "IP66",
+    "added": "2026-07-06"
   },
   {
     "id": "hive-view-indoor",
@@ -140444,7 +142027,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "hive-view-outdoor",
@@ -140511,7 +142095,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "honeywell-hcc-ip-3mp-dome",
@@ -140600,7 +142185,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "honeywell-hcc-ip-4mp-bullet",
@@ -140689,7 +142275,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-s2236l",
@@ -140783,7 +142370,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -140877,7 +142465,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "i-pro-wv-x2251l",
@@ -140968,7 +142557,8 @@
         "notes": "Select 'Panasonic' profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "idis-dc-d4516wrx",
@@ -141058,7 +142648,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-a1-pro-4k",
@@ -141143,7 +142734,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-dual",
@@ -141209,7 +142801,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-4k",
@@ -141286,7 +142879,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-5mp",
@@ -141369,7 +142963,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-lite",
@@ -141447,7 +143042,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-aov-pt-pro",
@@ -141529,7 +143125,8 @@
         "notes": "Battery AOV camera — the official datasheet states no browser/local access, so no RTSP or ONVIF stream is exposed. Use the Imou Life app + cloud (or on-device microSD).",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2-4mp",
@@ -141616,7 +143213,8 @@
     },
     "release_notes": "Bullet 2 4MP. Wi-Fi variant is IPC-F42FEP(-D); the PoE variant (matching this entry) is IPC-F42EAP. Night vision is smart dual-mode (IR + full-color spotlight).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-bullet-2-pro-4mp",
@@ -141710,7 +143308,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2c-5mp",
@@ -141797,7 +143396,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2c-pro-5mp",
@@ -141884,7 +143484,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-2e-5mp",
@@ -141977,7 +143578,8 @@
     },
     "release_notes": "Bullet 2E 5MP (IPC-K3DP-5H0WF). Corrected from a fabricated code (IPC-F57FEP-D, which returns no matching product).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-bullet-2e-pro-5mp",
@@ -142064,7 +143666,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-3-5mp",
@@ -142157,7 +143760,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-bullet-3c-5mp",
@@ -142246,7 +143850,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-2",
@@ -142331,7 +143936,8 @@
     },
     "aliases": [
       "IPC-B46LP"
-    ]
+    ],
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3",
@@ -142409,7 +144015,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3c-5mp",
@@ -142491,7 +144098,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-3c-all-in-one-5mp",
@@ -142573,7 +144181,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-go",
@@ -142648,7 +144257,8 @@
       }
     },
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cell-go-full-color",
@@ -142723,7 +144333,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt",
@@ -142793,7 +144404,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-2c-5mp",
@@ -142866,7 +144478,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-4g-2nd",
@@ -142943,7 +144556,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cell-pt-lite",
@@ -143020,7 +144634,8 @@
         "notes": "100% wire-free battery camera — it sleeps between events and does not expose a continuous local RTSP stream, so Frigate/local-NVR use is not supported. Recording is via the Imou Life app + cloud and on-device microSD.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser",
@@ -143112,7 +144727,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-2-5mp",
@@ -143206,7 +144822,8 @@
     },
     "release_notes": "Single-lens Cruiser 2 5MP (IPC-GS7EP-5M0WE). Corrected from a fabricated code (IPC-S7XEP-5M0WED, which is the dual-lens Cruiser Dual 2) and wrong 2.7mm lens. Absorbed the former MENA regional-duplicate entry.",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-2c-5mp",
@@ -143298,7 +144915,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-4g",
@@ -143360,7 +144978,8 @@
     ],
     "release_notes": "Cruiser 4G (IPC-S21FTP): a 1080p/2MP MAINS-POWERED 4G LTE pan/tilt camera. Corrected from a fabricated 4MP battery+solar spec block (that described a different Imou solar model).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-dual",
@@ -143453,7 +145072,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-dual-2",
@@ -143548,7 +145168,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-dual-2c-4g",
@@ -143641,7 +145262,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-pano-z",
@@ -143737,7 +145359,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-sc-4g-5mp",
@@ -143830,7 +145453,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-sc-8mp",
@@ -143922,7 +145546,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-se-plus",
@@ -144006,7 +145631,8 @@
     },
     "release_notes": "Cruiser SE+ 4MP (IPC-S41FEP). Corrected from a wrong 'bullet' form factor (it is a 355/0-90 pan/tilt) and a wrong 'PoE' claim (it is DC 12V + Wi-Fi/LAN).",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-cruiser-triple",
@@ -144101,7 +145727,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-cruiser-z-5mp",
@@ -144190,7 +145817,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-dk3-3mp",
@@ -144279,7 +145907,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-dk7-5mp",
@@ -144370,7 +145999,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-indoor-2k",
@@ -144444,7 +146074,8 @@
       }
     },
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-knight-8mp",
@@ -144538,7 +146169,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps2m-5mp",
@@ -144624,7 +146256,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps3d-5mp",
@@ -144713,7 +146346,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps3e-8mp",
@@ -144802,7 +146436,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps70f-10mp",
@@ -144893,7 +146528,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps7f-5mp",
@@ -144985,7 +146621,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ps8d-5mp",
@@ -145073,7 +146710,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2",
@@ -145165,7 +146803,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. IMOU uses Dahua protocol."
       }
-    }
+    },
+    "added": "2026-06-06"
   },
   {
     "id": "imou-ranger-2-4mp",
@@ -145254,7 +146893,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2-pro-4k",
@@ -145345,7 +146985,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-2c-pro-4k",
@@ -145436,7 +147077,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-rc-r1",
@@ -145514,7 +147156,8 @@
         "notes": "Plugged-in Wi-Fi 6 indoor camera. RTSP is not documented for this new (2026) SKU; the older Ranger RC exposed the Dahua realmonitor path (rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0), which will likely work here too but is unverified.",
         "verified": false
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-ranger-s2",
@@ -145609,7 +147252,8 @@
     },
     "release_notes": "Ranger S2 3MP indoor pan/tilt (IPC-DK2-3H1W). Corrected from a fabricated code (IPC-GS7EP-3M0WE, which is actually the Cruiser 2) and a wrong 'color' night-vision claim (it is IR). Absorbed the former MENA regional-duplicate entry.",
     "last_verified": "2026-07-05",
-    "status": "available"
+    "status": "available",
+    "added": "2026-06-06"
   },
   {
     "id": "imou-rex-3d-r1-5mp",
@@ -145696,7 +147340,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-titan-pro-6mp",
@@ -145790,7 +147435,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "imou-versa-2mp",
@@ -145880,7 +147526,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile — IMOU uses the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8003-full-hd",
@@ -145957,7 +147604,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8015-full-hd",
@@ -146038,7 +147686,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8401-2k-plus",
@@ -146122,7 +147771,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8403-2k-plus",
@@ -146207,7 +147857,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8415-2k-plus",
@@ -146292,7 +147943,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-8815-4k",
@@ -146377,7 +148029,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9008-full-hd",
@@ -146469,7 +148122,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9020-full-hd",
@@ -146562,7 +148216,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model, but the confirmed RTSP URL should work with a generic RTSP camera profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9408-2k-plus",
@@ -146660,7 +148315,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF Profile S support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9420-2k-plus",
@@ -146756,7 +148412,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9808-4k",
@@ -146838,7 +148495,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "instar-in-9820-4k",
@@ -146931,7 +148589,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "intelbras-im3-wifi-indoor",
@@ -147027,7 +148686,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-im5-wifi-outdoor",
@@ -147120,7 +148780,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1230-b-g4",
@@ -147214,7 +148875,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1230-d-g5",
@@ -147307,7 +148969,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-1430-b-g2",
@@ -147400,7 +149063,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-3230-b-sl",
@@ -147473,7 +149137,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-3830-b-ai",
@@ -147546,7 +149211,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "intelbras-vip-s4020-g2",
@@ -147621,7 +149287,8 @@
         "notes": "Select 'Dahua' profile. Intelbras uses Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "kasa-kc420ws",
@@ -147682,7 +149349,8 @@
       "https://www.kasasmart.com/us/products/security-cameras/kasa-cam-product-kc420ws",
       "https://www.tp-link.com/us/support/faq/1959/"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "kedacom-ipc121-ei7n",
@@ -147761,7 +149429,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc123-ei7n",
@@ -147840,7 +149509,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc123-fi4n",
@@ -147925,7 +149595,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc143-hn",
@@ -148012,7 +149683,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-an",
@@ -148104,7 +149776,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-an-ir1",
@@ -148194,7 +149867,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-dn-ir",
@@ -148298,7 +149972,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2131-dn-l",
@@ -148390,7 +150065,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2132-an",
@@ -148488,7 +150164,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2150-an",
@@ -148580,7 +150257,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2151-an-bn",
@@ -148673,7 +150351,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2151-an-bn-d",
@@ -148762,7 +150441,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-fn-dir",
@@ -148850,7 +150530,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-hn-dir",
@@ -148950,7 +150631,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2211-hn-pir",
@@ -149040,7 +150722,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-dn",
@@ -149139,7 +150822,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-dn-ir",
@@ -149231,7 +150915,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-en-l",
@@ -149319,7 +151004,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-fn-s",
@@ -149412,7 +151098,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-fn-sir40",
@@ -149507,7 +151194,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-hn-s",
@@ -149599,7 +151287,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2231-hn-sir40",
@@ -149690,7 +151379,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2232-an-dl",
@@ -149775,7 +151465,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2233-fn-s",
@@ -149865,7 +151556,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2233-fn-sir40-z2712",
@@ -149972,7 +151664,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-p",
@@ -150062,7 +151755,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-pir30",
@@ -150151,7 +151845,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-s",
@@ -150238,7 +151933,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2240-hn-sir30",
@@ -150327,7 +152023,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2241-fn-sir",
@@ -150438,7 +152135,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2250-an",
@@ -150530,7 +152228,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2251-hn",
@@ -150637,7 +152336,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2252-fn-dir",
@@ -150719,7 +152419,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2252-hn-pir",
@@ -150806,7 +152507,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2431-hn-s",
@@ -150900,7 +152602,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2433-hn-sir40",
@@ -150993,7 +152696,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2440-hn-s",
@@ -151080,7 +152784,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2440-hn-sir30",
@@ -151187,7 +152892,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2451-fi4n-sir50",
@@ -151286,7 +152992,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2452-hn-hnb-sir50",
@@ -151383,7 +153090,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2452-hn-pir",
@@ -151479,7 +153187,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2511-fn-sir",
@@ -151577,7 +153286,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2533-fn-sir50-z2812",
@@ -151670,7 +153380,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2533-fn-sir50-z6022-l",
@@ -151779,7 +153490,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2552-fn-sir50-z2812",
@@ -151878,7 +153590,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2655-gi4n",
@@ -151969,7 +153682,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2655-gi7n",
@@ -152060,7 +153774,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2833-fi4n-sir50-z6022",
@@ -152160,7 +153875,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2833-fn-sir50-l",
@@ -152252,7 +153968,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2852-fn-sir50-z",
@@ -152352,7 +154069,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc2855-gi4n",
@@ -152444,7 +154162,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-f223-n",
@@ -152540,7 +154259,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-f233-n",
@@ -152640,7 +154360,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc425-g223-n",
@@ -152737,7 +154458,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-ipc442-i405-np",
@@ -152829,7 +154551,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2110-an",
@@ -152932,7 +154655,8 @@
       "blue_iris": {
         "profile": "ONVIF"
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2110-bn-d",
@@ -153010,7 +154734,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "kedacom-lc2150-an-d",
@@ -153095,7 +154820,8 @@
         "profile": "ONVIF"
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "laview-f1",
@@ -153142,7 +154868,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-l2",
@@ -153189,7 +154916,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-n3",
@@ -153246,7 +154974,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r12",
@@ -153294,7 +155023,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r18",
@@ -153340,7 +155070,8 @@
     "power_source": [
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "laview-r28",
@@ -153394,7 +155125,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "longse-lbe905xss500",
@@ -153468,7 +155200,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbf30sv800",
@@ -153562,7 +155295,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbh30ss500",
@@ -153645,7 +155379,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "longse-lbp60ss500",
@@ -153724,7 +155459,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lorex-b862aj",
@@ -153794,7 +155530,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e841cd",
@@ -153860,7 +155597,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-e842cab",
@@ -153926,7 +155664,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e842cdb",
@@ -153992,7 +155731,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e871ab",
@@ -154058,7 +155798,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e872sb",
@@ -154123,7 +155864,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e891ab",
@@ -154186,7 +155928,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-e893ab",
@@ -154255,7 +155998,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-e896ab",
@@ -154320,7 +156064,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-e920sb",
@@ -154360,7 +156105,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-e920sd",
@@ -154405,7 +156151,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-f461aqd-e",
@@ -154473,7 +156220,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-f861asd",
@@ -154543,7 +156291,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lnb9242b",
@@ -154607,7 +156356,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lnb9292b",
@@ -154703,7 +156453,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-lnb9393",
@@ -154790,7 +156541,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-lne9242b",
@@ -154855,7 +156607,8 @@
       "poe",
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-lne9292b",
@@ -154951,7 +156704,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-lne9393",
@@ -155039,7 +156793,8 @@
         "notes": "Select 'Dahua' profile. Most Lorex IP cameras use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-u3-2k-bullet",
@@ -155135,7 +156890,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-2k-turret",
@@ -155232,7 +156988,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-4k-bullet",
@@ -155328,7 +157085,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u3-4k-turret",
@@ -155425,7 +157183,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-u471aa",
@@ -155493,7 +157252,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-v3-bullet",
@@ -155593,7 +157353,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v3-turret",
@@ -155692,7 +157453,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v5-bullet",
@@ -155792,7 +157554,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-v5-turret",
@@ -155892,7 +157655,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-w452asd",
@@ -155961,7 +157725,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w461asc",
@@ -156025,7 +157790,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lorex-w462aqc-e-pantilt",
@@ -156118,7 +157884,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-w482cad",
@@ -156197,7 +157964,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w881aad",
@@ -156259,7 +158027,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-w891uad",
@@ -156328,7 +158097,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lorex-x-ptz-4k",
@@ -156428,7 +158198,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-dual-lens-turret",
@@ -156528,7 +158299,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-mvf-bullet",
@@ -156626,7 +158398,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x3-mvf-turret",
@@ -156723,7 +158496,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x5-bullet",
@@ -156823,7 +158597,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lorex-x5-turret",
@@ -156923,7 +158698,8 @@
         "profile": "ONVIF",
         "notes": "Add as ONVIF/RTSP; enable RTSP in the Lorex web UI first."
       }
-    }
+    },
+    "added": "2026-07-01"
   },
   {
     "id": "lts-ltcmip3c8pw-sdl",
@@ -157013,7 +158789,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-ltcmip9783nw-sz",
@@ -157110,7 +158887,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model, but Hikvision-OEM hardware typically works with Blue Iris's generic Hikvision camera profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-lxip3c82w-28aisp",
@@ -157186,7 +158964,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-lxptzip4c8wi-x25sdl",
@@ -157272,7 +159051,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-ptzip688x36",
@@ -157363,7 +159143,8 @@
         "profile": "Hikvision (generic)",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-vsip3442w-28ma",
@@ -157457,7 +159238,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit, though not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "lts-vsip75122f-se",
@@ -157542,7 +159324,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "luma-lum-210-ptz",
@@ -157614,7 +159397,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-310-drb",
@@ -157686,7 +159470,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-410-fis",
@@ -157757,7 +159542,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-bul",
@@ -157828,7 +159614,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-dom",
@@ -157899,7 +159686,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-510-tur",
@@ -157970,7 +159758,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-810-bul",
@@ -158042,7 +159831,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "luma-lum-810-dom",
@@ -158114,7 +159904,8 @@
         "notes": "Select 'Hikvision' profile. Luma uses Hikvision protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "lupus-le201-wlan",
@@ -158208,7 +159999,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le202-wlan",
@@ -158302,7 +160094,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le203-poe",
@@ -158396,7 +160189,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le204-wlan",
@@ -158489,7 +160283,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le213-ai",
@@ -158581,7 +160376,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le221-poe",
@@ -158677,7 +160473,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le224-poe",
@@ -158773,7 +160570,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le228-poe",
@@ -158868,7 +160666,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "lupus-le232-alarm",
@@ -158964,7 +160763,8 @@
         "notes": "Select 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "march-networks-me4-series",
@@ -159034,7 +160834,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-me8",
@@ -159105,7 +160906,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-se2",
@@ -159175,7 +160977,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "march-networks-se4",
@@ -159245,7 +161048,8 @@
         "notes": "Use Generic/ONVIF profile."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2942-epb",
@@ -159322,7 +161126,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2961-rlpb",
@@ -159401,7 +161206,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2962-fpb",
@@ -159481,7 +161287,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2964-fpd",
@@ -159560,7 +161367,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2972-fpb",
@@ -159640,7 +161448,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c2983-pb",
@@ -159720,7 +161529,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c4462-fpb",
@@ -159799,7 +161609,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c5362-fpa",
@@ -159879,7 +161690,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c5383-pb",
@@ -159959,7 +161771,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c8172-fpa",
@@ -160039,7 +161852,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c8262-fpb",
@@ -160119,7 +161933,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "milesight-ms-c9674-pb",
@@ -160198,7 +162013,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /main (main), /sub (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "mobotix-c71",
@@ -160270,7 +162086,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-d71",
@@ -160350,7 +162167,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-m73",
@@ -160435,7 +162253,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-p71",
@@ -160516,7 +162335,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-q71",
@@ -160601,7 +162421,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-s74",
@@ -160681,7 +162502,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-s74-dual",
@@ -160758,7 +162580,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "mobotix-v71",
@@ -160828,7 +162651,8 @@
         "notes": "Select 'Mobotix' profile. Uses MxPEG codec by default; switch to H.264 in camera settings for Blue Iris."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-indoor-camera",
@@ -160900,7 +162724,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-outdoor-camera",
@@ -160975,7 +162800,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-outdoor-camera-with-siren",
@@ -161047,7 +162873,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netatmo-smart-video-doorbell",
@@ -161121,7 +162948,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "netcamcenter-ndm-7702-a",
@@ -161212,7 +163040,8 @@
         "notes": "Bosch OEM — use the ONVIF/RTSP (or 'Bosch') profile; add each imager as a separate camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "netcamcenter-ndm-7703-al",
@@ -161308,7 +163137,8 @@
         "notes": "Bosch OEM — use the ONVIF/RTSP (or 'Bosch') profile; add each imager as a separate camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "pelco-optera-4k-imo-panoramic",
@@ -161386,7 +163216,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-optera-imm12027-1ep",
@@ -161463,7 +163294,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-enhanced-4-ibv532-1er",
@@ -161540,7 +163372,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-enhanced-4-ime832-1irs",
@@ -161618,7 +163451,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp231-1ers",
@@ -161696,7 +163530,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp531-1ers",
@@ -161774,7 +163609,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-sarix-professional-4-imp831-1irs",
@@ -161852,7 +163688,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-enhanced-7-s7230l-ew1",
@@ -161930,7 +163767,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-enhanced-7-s7240l-ew1",
@@ -162008,7 +163846,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "pelco-spectra-professional-4k-s6230-fwl1",
@@ -162086,7 +163925,8 @@
         "notes": "Select 'Pelco' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "qubo-bullet-cam-pro",
@@ -162154,7 +163994,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-doorbell-cam",
@@ -162217,7 +164058,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-smart-cam-360-3mp",
@@ -162289,7 +164131,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "qubo-smart-cam-360-pro-4mp",
@@ -162360,7 +164203,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-altas",
@@ -162438,7 +164282,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-altas-go-pt",
@@ -162517,7 +164362,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-altas-pt-ultra",
@@ -162605,7 +164451,8 @@
     ],
     "dimensions_mm": "178 x 151 x 102",
     "weight_g": 853,
-    "operating_temp_c": "-20 to 55"
+    "operating_temp_c": "-20 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-2",
@@ -162684,7 +164531,8 @@
     ],
     "dimensions_mm": "96 x 58 x 59",
     "weight_g": 260,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-2e",
@@ -162763,7 +164611,8 @@
     ],
     "dimensions_mm": "105 x 105 x 58",
     "weight_g": 310,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-2k",
@@ -162843,7 +164692,8 @@
     ],
     "dimensions_mm": "121 x 90 x 56",
     "weight_g": 330,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-pro",
@@ -162959,7 +164809,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-pro-au",
@@ -163074,7 +164925,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-3-ultra",
@@ -163179,7 +165031,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-4-pro",
@@ -163262,7 +165115,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-4-pro-at",
@@ -163384,7 +165238,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-eco",
@@ -163462,7 +165317,8 @@
     "dimensions_mm": "Φ71 x 186",
     "weight_g": 360,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-eco-ultra",
@@ -163542,7 +165398,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-argus-magicam",
@@ -163633,7 +165490,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pro",
@@ -163711,7 +165569,8 @@
     ],
     "dimensions_mm": "96 x 58 x 59",
     "weight_g": 230,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt",
@@ -163790,7 +165649,8 @@
     "dimensions_mm": "Φ98 x 122",
     "weight_g": 477,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt-2k",
@@ -163867,7 +165727,8 @@
     ],
     "dimensions_mm": "Φ98 x 112",
     "weight_g": 470,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-pt-ultra",
@@ -163953,7 +165814,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-argus-solar",
@@ -164035,7 +165897,8 @@
     "operating_temp_c": "-20 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-07-04"
   },
   {
     "id": "reolink-argus-track",
@@ -164128,7 +165991,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b1200",
@@ -164226,7 +166090,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b400",
@@ -164325,7 +166190,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b500",
@@ -164425,7 +166291,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-b800",
@@ -164525,7 +166392,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx410",
@@ -164635,7 +166503,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx410w",
@@ -164735,7 +166604,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-cx810",
@@ -164843,7 +166713,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-cx820",
@@ -164953,7 +166824,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d1200",
@@ -165044,7 +166916,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d400",
@@ -165140,7 +167013,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d500",
@@ -165231,7 +167105,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-d800",
@@ -165322,7 +167197,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-battery",
@@ -165405,7 +167281,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-duo-2-lte",
@@ -165484,7 +167361,8 @@
     ],
     "dimensions_mm": "228 x 132 x 120",
     "weight_g": 900,
-    "operating_temp_c": "-10 to 55"
+    "operating_temp_c": "-10 to 55",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-poe",
@@ -165591,7 +167469,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2-wifi",
@@ -165691,7 +167570,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-2v-poe",
@@ -165797,7 +167677,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3-poe",
@@ -165903,7 +167784,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3-wifi",
@@ -166003,7 +167885,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-3v-poe",
@@ -166105,7 +167988,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-4g",
@@ -166183,7 +168067,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-floodlight-poe",
@@ -166284,7 +168169,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-duo-floodlight-wifi",
@@ -166381,7 +168267,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-e1-indoor",
@@ -166462,7 +168349,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-cx",
@@ -166566,7 +168454,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-poe",
@@ -166669,7 +168558,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-outdoor-pro",
@@ -166773,7 +168663,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-e1-outdoor-se-poe",
@@ -166872,7 +168763,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-e1-outdoor-wifi",
@@ -166981,7 +168873,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-e1-pro",
@@ -167085,7 +168978,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-e1-zoom",
@@ -167185,7 +169079,8 @@
     },
     "environment": [
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-floodlight-wifi",
@@ -167290,7 +169185,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-pro-floodlight-poe",
@@ -167396,7 +169292,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-elite-wifi",
@@ -167495,7 +169392,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-fe-p",
@@ -167602,7 +169500,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-fe-w",
@@ -167699,7 +169598,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-go-4g",
@@ -167785,7 +169685,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt",
@@ -167866,7 +169767,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt-plus",
@@ -167952,7 +169854,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-pt-s-lite",
@@ -168030,7 +169933,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-go-pt-ultra",
@@ -168112,7 +170016,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-go-ranger-pt",
@@ -168191,7 +170096,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-home-hub",
@@ -168262,7 +170168,8 @@
       "indoor"
     ],
     "release_notes": "This is Reolink's NVR/hub accessory (used with Reolink WiFi/battery/PoE cameras for local storage + AI features without a cloud subscription), not a camera. The camera schema is a poor fit for several fields: resolution/lens/night_vision/field_of_view/ip_rating describe the hub itself (which has no image sensor), not the cameras it manages. 'type': 'box' is used only because the schema has no dedicated hub/NVR enum value. 'connectivity' reflects only the hub's own uplink (wired Ethernet to the router); the hub separately hosts its own private Wi-Fi 6 access point to talk to its cameras, which is a distinct function from network uplink and not the same as the hub itself being a Wi-Fi client. No official IP rating is published by Reolink for this indoor-only device, so ip_rating has been left unset rather than guessed.",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-keen-ranger-pt",
@@ -168344,7 +170251,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-lumus",
@@ -168454,7 +170362,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-lumus-pro",
@@ -168553,7 +170462,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-omvi-3i-poe",
@@ -168672,7 +170582,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-omvi-3i-wifi",
@@ -168787,7 +170698,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-omvi-x16-poe",
@@ -168870,7 +170782,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-p340",
@@ -168980,7 +170893,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-p430",
@@ -169088,7 +171002,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-p830",
@@ -169193,7 +171108,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-reolink-go-plus",
@@ -169282,7 +171198,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1210a",
@@ -169396,7 +171313,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1212a-dome",
@@ -169502,7 +171420,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1220a",
@@ -169611,7 +171530,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1224a",
@@ -169718,7 +171638,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-1240a",
@@ -169825,7 +171746,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-410",
@@ -169937,7 +171859,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-410s",
@@ -170046,7 +171969,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-410w",
@@ -170149,7 +172073,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-422",
@@ -170259,7 +172184,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-423",
@@ -170372,7 +172298,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-510a",
@@ -170483,7 +172410,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-510wa",
@@ -170584,7 +172512,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511",
@@ -170696,7 +172625,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511w",
@@ -170808,7 +172738,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-511wa",
@@ -170923,7 +172854,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-520",
@@ -171034,7 +172966,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-520a",
@@ -171148,7 +173081,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-522",
@@ -171260,7 +173194,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-523wa",
@@ -171368,7 +173303,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-540a",
@@ -171476,7 +173412,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-542wa",
@@ -171582,7 +173519,8 @@
     "environment": [
       "outdoor",
       "indoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-810a",
@@ -171697,7 +173635,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-810wa",
@@ -171803,7 +173742,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-811a",
@@ -171915,7 +173855,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-811wa",
@@ -172011,7 +173952,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-rlc-812a",
@@ -172120,7 +174062,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-81ma",
@@ -172231,7 +174174,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-81pa",
@@ -172341,7 +174285,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-820a",
@@ -172452,7 +174397,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-822a",
@@ -172560,7 +174506,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823a",
@@ -172682,7 +174629,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823a-16x",
@@ -172789,7 +174737,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s1",
@@ -172901,7 +174850,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s1w",
@@ -173013,7 +174963,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-823s2",
@@ -173120,7 +175071,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-824a",
@@ -173221,7 +175173,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-830a",
@@ -173328,7 +175281,8 @@
     "operating_temp_c": "-10 to 55",
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-833a",
@@ -173439,7 +175393,8 @@
     "environment": [
       "indoor",
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-840a",
@@ -173549,7 +175504,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-840wa",
@@ -173651,7 +175607,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-842a",
@@ -173751,7 +175708,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-843a",
@@ -173855,7 +175813,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-rlc-843wa",
@@ -173957,7 +175916,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-solar-floodlight-cam",
@@ -174058,7 +176018,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-talon-pro",
@@ -174133,7 +176094,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-trackflex-floodlight-wifi",
@@ -174244,7 +176206,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-lte",
@@ -174328,7 +176291,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-lte-c",
@@ -174406,7 +176370,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-07-06"
   },
   {
     "id": "reolink-trackmix-lte-plus",
@@ -174490,7 +176455,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-11"
   },
   {
     "id": "reolink-trackmix-poe",
@@ -174604,7 +176570,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-trackmix-wifi",
@@ -174716,7 +176683,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-2nd-gen",
@@ -174768,7 +176736,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-poe",
@@ -174891,7 +176860,8 @@
     "dimensions_mm": "133 x 48 x 23",
     "weight_g": 96,
     "operating_temp_c": "-10 to 55",
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "reolink-video-doorbell-wifi",
@@ -175007,7 +176977,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-06-06"
   },
   {
     "id": "ring-battery-doorbell-pro-2025",
@@ -175074,7 +177045,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-doorbell-elite",
@@ -175139,7 +177111,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-floodlight-cam-wired-plus",
@@ -175203,7 +177176,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-floodlight-cam-wired-pro",
@@ -175264,7 +177238,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-indoor-cam-2nd-gen",
@@ -175325,7 +177300,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-outdoor-cam-plus",
@@ -175393,7 +177369,8 @@
       "https://ring.com/support/products/cameras/outdoor-cam-plus"
     ],
     "last_verified": "2026-07-04",
-    "status": "available"
+    "status": "available",
+    "added": "2026-07-05"
   },
   {
     "id": "ring-pan-tilt-indoor-cam",
@@ -175455,7 +177432,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-peephole-cam",
@@ -175521,7 +177499,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-plus-battery",
@@ -175583,7 +177562,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-spotlight-cam-plus-eu",
@@ -175651,7 +177631,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-spotlight-cam-plus-plug-in",
@@ -175716,7 +177697,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-plus-solar",
@@ -175782,7 +177764,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-spotlight-cam-pro",
@@ -175849,7 +177832,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-stick-up-cam-battery-2nd-gen",
@@ -175913,7 +177897,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-stick-up-cam-battery-3rd-gen",
@@ -175979,7 +177964,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-stick-up-cam-plug-in",
@@ -176043,7 +178029,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-stick-up-cam-pro",
@@ -176110,7 +178097,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-video-doorbell-2nd-gen",
@@ -176175,7 +178163,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-video-doorbell-3-plus",
@@ -176239,7 +178228,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "ring-video-doorbell-4",
@@ -176314,7 +178304,8 @@
       "UK",
       "US"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-06"
   },
   {
     "id": "ring-video-doorbell-wired",
@@ -176377,7 +178368,8 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04"
+    "last_verified": "2026-07-04",
+    "added": "2026-06-09"
   },
   {
     "id": "simplisafe-indoor-cam-v2",
@@ -176430,7 +178422,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-outdoor-cam",
@@ -176494,7 +178487,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-outdoor-cam-v2",
@@ -176555,7 +178549,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "simplisafe-smart-alarm-indoor-cam",
@@ -176614,7 +178609,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-indoor-camera",
@@ -176686,7 +178682,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-one-plus",
@@ -176748,7 +178745,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "somfy-outdoor-camera",
@@ -176821,7 +178819,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "speco-o12b1m",
@@ -176908,7 +178907,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o12mdp4",
@@ -177002,7 +179002,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o2db1",
@@ -177084,7 +179085,8 @@
         "profile": "Generic RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4b9m",
@@ -177172,7 +179174,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4bdd1m",
@@ -177260,7 +179263,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4bxlp1m",
@@ -177353,7 +179357,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4d9",
@@ -177441,7 +179446,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4d9m",
@@ -177529,7 +179535,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4fdms1",
@@ -177616,7 +179623,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4p25x2",
@@ -177716,7 +179724,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4t9",
@@ -177815,7 +179824,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Confirmed RTSP protocol support and strong ONVIF conformance make this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4tdd2",
@@ -177906,7 +179916,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o4vt2",
@@ -178001,7 +180012,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o84s",
@@ -178088,7 +180100,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8b9",
@@ -178171,7 +180184,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8b9m",
@@ -178258,7 +180272,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8d9",
@@ -178343,7 +180358,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8d9m",
@@ -178430,7 +180446,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fb1",
@@ -178515,7 +180532,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fb1m",
@@ -178601,7 +180619,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fbms1",
@@ -178687,7 +180706,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed with Blue Iris specifically; advanced analytics features require a Speco NRE recorder rather than a third-party NVR."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fd1",
@@ -178774,7 +180794,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8fd1m",
@@ -178858,7 +180879,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8ft1",
@@ -178944,7 +180966,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8ft1m",
@@ -179031,7 +181054,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8kt1",
@@ -179113,7 +181137,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8kt1b",
@@ -179195,7 +181220,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8lmst1",
@@ -179279,7 +181305,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vd3",
@@ -179374,7 +181401,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vlt1",
@@ -179457,7 +181485,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "ONVIF/RTSP supported; not independently confirmed with Blue Iris."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "speco-o8vt3",
@@ -179555,7 +181584,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Strong ONVIF conformance makes this a likely good fit; not independently confirmed with Blue Iris specifically. Speco's own recorders are the officially supported pairing (Speco Blue Series NVR)."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "steinel-l-620-cam-sc",
@@ -179620,7 +181650,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "steinel-l-625-cam",
@@ -179694,7 +181725,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "sv3c-b04poe",
@@ -179775,7 +181807,8 @@
     "sources": [
       "https://www.sv3c.com/Upgraded-SV3C-IP-POE-Camera-Security-Outdoor-4-Megapixels-Super-HD-2560x1440-H-265-Waterproof-Video-Camera-IR-Night-Vision-Motion-Detection-Wired-p1743568.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b05poe",
@@ -179848,7 +181881,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-POE-IP-Camera-5-Megapixels-Security-Camera-Outdoor-with-2-Way-Audio-Humanoid-Detection-IP66-Waterproof-Power-Over-Ethernet-Cameras-Support-Max-128G-SD-Card-Record-Browser-View-No-WiFi-p2437989.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b05w",
@@ -179923,7 +181957,8 @@
     "sources": [
       "https://www.sv3c.com/5MP-8MP-Outdoor-Security-Camera-SV3C-WiFi-Wireless-5-8-Megapixels-HD-Night-Vision-Surveillance-Cameras-2-Way-Audio-IP-Camera-Motion-Detection-CCTV-Weatherproof-Outside-Camera-Support-Max-128GB-SD-Card-p395185.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-b06w",
@@ -180017,7 +182052,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-b08poe",
@@ -180113,7 +182149,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-POE-IP-Camera-Outdoor-8MP-POE-Security-Camera-with-Smart-Motion-Detection-IR-Color-Night-Vision-120-Wide-Angle-2-Way-Audio-Metal-Shell-RTSP-SD-Card-Record-Wired-p2471515.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-c12",
@@ -180195,7 +182232,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-PTZ-WiFi-Security-Camera-Outdoor-15X-Optical-Zoom-Auto-Tracking-5MP-8MP-Floodlight-Color-Night-Vision-Wireless-IP-Cam-2-Way-Audio-Metal-Shell-RTSP-FTP-SD-Card-Record-BlueIris-p2032033.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-c22-4k",
@@ -180289,7 +182327,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-c25",
@@ -180391,7 +182430,8 @@
         }
       ]
     },
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-d08poe",
@@ -180468,7 +182508,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-POE-Camera-Outdoor-IP-Dome-Wired-Security-Indoor-Camera-with-Human-Vehicle-Detection-8MP-HD-Color-Night-Vision-Two-Way-Audio-Waterproof-24-7-Recording-RTSP-Up-to-512GB-SD-Card-p2471510.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-hx03",
@@ -180561,7 +182602,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-ptz-1080p-wifi-4x",
@@ -180631,7 +182673,8 @@
     "sources": [
       "https://www.sv3c.com/1080P-Wifi-Surveillance-Camera-SV3C-Wireless-Home-Security-PTZ-Camera-IP-CCTV-4X-Digital-ZOOM-AI-Human-Detect-CamHi-p2058778.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-4k-dual-network",
@@ -180705,7 +182748,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-4K-PTZ-POE-Wired-WiFi-Security-Camera-Outdoor-Dual-Network-Support-Auto-Tracking-Security-Cam-Color-Night-Vision-Human-Vehicle-Detection-2-Way-Audio-Waterproof-24-7-Record-CamHiPro-p2707179.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-5mp-wifi-5x",
@@ -180775,7 +182819,8 @@
     "sources": [
       "https://www.sv3c.com/New-Auto-Track-PTZ-WiFi-Camera-Outdoor-Wireless-5MP-5X-Zoom-Spotlight-Color-Night-Vision-Camera-IP66-Waterproof-Playback-p1737238.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-poe-15x",
@@ -180845,7 +182890,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-8MP-POE-PTZ-Security-Camera-Outdoor-15X-Optical-Zoom-5MP-4k-Auto-Tracking-Floodlight-Color-Night-Vision-IP-Camera-2-Way-Audio-Metal-Shell-RTSP-FTP-SD-Card-Record-BlueIris-Wired-p2302126.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-ptz-poe-36x",
@@ -180938,7 +182984,8 @@
         "profile": "Generic/RTSP",
         "notes": "Use the Generic/RTSP (or ONVIF) profile."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "sv3c-ptz-wifi-track",
@@ -181013,7 +183060,8 @@
     "sources": [
       "https://www.sv3c.com/SV3C-5MP-8MP-WiFi-IP-Camera-Outdoor-Metal-Motion-Track-PTZ-Security-Surveillance-Camera-Spotlight-Full-Color-Night-Vision-IP-Camera-p2010092.html"
     ],
-    "last_verified": "2026-07-05"
+    "last_verified": "2026-07-05",
+    "added": "2026-06-12"
   },
   {
     "id": "sv3c-solar-dual-lens-2k",
@@ -181071,7 +183119,8 @@
         "verified": false
       }
     },
-    "release_notes": "App-only solar/battery camera (CamHiPro + local hub) — no ONVIF/RTSP."
+    "release_notes": "App-only solar/battery camera (CamHiPro + local hub) — no ONVIF/RTSP.",
+    "added": "2026-06-12"
   },
   {
     "id": "swann-4k-bullet",
@@ -181152,7 +183201,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-4k-dome",
@@ -181233,7 +183283,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-buddy-doorbell",
@@ -181289,7 +183340,8 @@
       "battery",
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-corecam",
@@ -181353,7 +183405,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-doorbell-camera",
@@ -181415,7 +183468,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-pan-and-tilt-indoor",
@@ -181477,7 +183531,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-swpro-1080msfb",
@@ -181544,7 +183599,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swpro-4kmsb",
@@ -181611,7 +183667,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swwhd-intcam",
@@ -181679,7 +183736,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-swwhd-outcam",
@@ -181768,7 +183826,8 @@
         "notes": "Use 'Dahua' profile. Some Swann models use Dahua protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "swann-wifi-spotlight",
@@ -181831,7 +183890,8 @@
     "power_source": [
       "usb"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "swann-xtreem-solar",
@@ -181894,7 +183954,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "synology-bc500",
@@ -181981,7 +184042,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-bc800z",
@@ -182070,7 +184132,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-cc400w",
@@ -182155,7 +184218,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "synology-tc500",
@@ -182242,7 +184306,8 @@
         "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c100",
@@ -182333,7 +184398,8 @@
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
     "dimensions_mm": "67.6 x 54.6 x 98.9",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c110",
@@ -182432,7 +184498,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c120",
@@ -182532,7 +184599,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c121",
@@ -182625,7 +184693,8 @@
     "operating_temp_c": "-25 to 45",
     "dimensions_mm": "67.4 x 57.4 x 44.1",
     "weight_g": 100,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-c125",
@@ -182727,7 +184796,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c200",
@@ -182830,7 +184900,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c207",
@@ -182924,7 +184995,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c210",
@@ -183027,7 +185099,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c216",
@@ -183136,7 +185209,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c220",
@@ -183228,7 +185302,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c222",
@@ -183319,7 +185394,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c225",
@@ -183416,7 +185492,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c230",
@@ -183518,7 +185595,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c246d",
@@ -183631,7 +185709,8 @@
       "indoor",
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c260",
@@ -183730,7 +185809,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c310",
@@ -183833,7 +185913,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c320ws",
@@ -183928,7 +186009,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "142.3 x 103.4 x 64.3",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb",
@@ -184031,7 +186113,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb-ca",
@@ -184136,7 +186219,8 @@
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c325wb-india",
@@ -184241,7 +186325,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c400-kit",
@@ -184317,7 +186402,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed on the official spec page. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c402",
@@ -184394,7 +186480,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D60 x 89 (diameter x height)",
     "weight_g": 230,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c420",
@@ -184478,7 +186565,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "110.6 x 64.2 x 64.2",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c425",
@@ -184568,7 +186656,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "116.2 x 64.8 x 64.8",
     "weight_g": 335,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c460",
@@ -184656,7 +186745,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
     "weight_g": 327,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c465",
@@ -184732,7 +186822,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF -- confirmed explicitly on the official spec page (RTSP: No, ONVIF: No). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c500",
@@ -184836,7 +186927,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c510w",
@@ -184941,7 +187033,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c520ws",
@@ -185040,7 +187133,8 @@
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
     "dimensions_mm": "123.8 x 123 x 90",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c530ws",
@@ -185138,7 +187232,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c560ws",
@@ -185239,7 +187334,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c566wb",
@@ -185315,7 +187411,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c615f-kit",
@@ -185408,7 +187505,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-20 to 45",
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c645d-kit",
@@ -185495,7 +187593,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ, which explicitly names the C645D). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tapo-c660-kit",
@@ -185585,7 +187684,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c675d-kit",
@@ -185683,7 +187783,8 @@
       "outdoor"
     ],
     "status": "available",
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c720",
@@ -185781,7 +187882,8 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-c840",
@@ -185896,7 +187998,8 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d130",
@@ -185966,7 +188069,8 @@
       "https://www.tp-link.com/us/support/faq/4329/",
       "https://www.tapo.com/en/product/smart-camera/tapo-d130/"
     ],
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-d225",
@@ -186073,7 +188177,8 @@
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d230s1",
@@ -186153,7 +188258,8 @@
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "146 x 54.5 x 35.5",
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-d235",
@@ -186252,7 +188358,8 @@
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "150 x 50 x 38.4 (doorbell unit only, excludes chime)",
     "weight_g": 297,
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc40",
@@ -186338,7 +188445,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc55",
@@ -186424,7 +188532,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable ONVIF in Tapo app."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-09"
   },
   {
     "id": "tapo-tc82-global",
@@ -186506,7 +188615,8 @@
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tc85",
@@ -186587,7 +188697,8 @@
         "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
       }
     },
-    "last_verified": "2026-06-30"
+    "last_verified": "2026-06-30",
+    "added": "2026-06-06"
   },
   {
     "id": "tapo-tcw90-kit",
@@ -186662,7 +188773,8 @@
         "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ) -- not mentioned on the official spec page for this model either. Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
       }
     },
-    "last_verified": "2026-07-01"
+    "last_verified": "2026-07-01",
+    "added": "2026-07-01"
   },
   {
     "id": "tiandy-tc-c32gn",
@@ -186741,7 +188853,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32gp",
@@ -186821,7 +188934,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32ms",
@@ -186900,7 +189014,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c32qn",
@@ -186979,7 +189094,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34gs",
@@ -187060,7 +189176,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34hn",
@@ -187140,7 +189257,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c34sp",
@@ -187221,7 +189339,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c35ms",
@@ -187302,7 +189421,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-c38ls",
@@ -187384,7 +189504,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-h326m",
@@ -187465,7 +189586,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tiandy-tc-h388m",
@@ -187545,7 +189667,8 @@
         "notes": "Select 'Hikvision' profile. Most Tiandy models use Hikvision-compatible protocol."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8423is-a",
@@ -187625,7 +189748,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8443is-a",
@@ -187705,7 +189829,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-8483is-a",
@@ -187786,7 +189911,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9422e3-a",
@@ -187865,7 +189991,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9423e3-a",
@@ -187944,7 +190071,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9443e3-a",
@@ -188023,7 +190151,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9452e3-a",
@@ -188102,7 +190231,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9482e3-a",
@@ -188182,7 +190312,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "tvt-td-9483e3-a",
@@ -188262,7 +190393,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /ch01/0 (main), /ch01/1 (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-ai-360",
@@ -188349,7 +190481,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-ai-bullet",
@@ -188429,7 +190562,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-ai-dome",
@@ -188511,7 +190645,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-ai-dslr",
@@ -188592,7 +190727,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-pro",
@@ -188680,7 +190816,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-pro-white",
@@ -188769,7 +190906,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-ai-theta-pro",
@@ -188848,7 +190986,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -188932,7 +191071,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-flex",
@@ -189016,7 +191156,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-instant",
@@ -189101,7 +191242,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g3-pro",
@@ -189184,7 +191326,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g4-bullet",
@@ -189267,7 +191410,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-dome",
@@ -189349,7 +191493,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g4-doorbell",
@@ -189432,7 +191577,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g4-doorbell-pro",
@@ -189518,7 +191664,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-instant",
@@ -189601,7 +191748,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-pro",
@@ -189684,7 +191832,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g4-ptz",
@@ -189767,7 +191916,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g5-bullet",
@@ -189849,7 +191999,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-dome",
@@ -189930,7 +192081,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-dome-ultra",
@@ -190007,7 +192159,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-flex",
@@ -190092,7 +192245,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "ubiquiti-g5-pro",
@@ -190177,7 +192331,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-11"
   },
   {
     "id": "ubiquiti-g5-turret-ultra",
@@ -190259,7 +192414,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -190345,7 +192501,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniarch-ipc-b122-apf28",
@@ -190435,7 +192592,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-ipc-t122-apf28",
@@ -190522,7 +192680,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model, but ONVIF support makes it a likely fit."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-ipc-t124-apf28",
@@ -190610,7 +192769,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-b1r-m2f3",
@@ -190681,7 +192841,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-p1a-m3f4d",
@@ -190763,7 +192924,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniarch-uho-s2e",
@@ -190833,7 +192995,8 @@
         "profile": "Generic ONVIF/RTSP",
         "notes": "Not independently confirmed for this specific model."
       }
-    }
+    },
+    "added": "2026-07-05"
   },
   {
     "id": "uniview-ipc2122le-adf40kmc-wl",
@@ -190916,7 +193079,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc2224se-df40k-wl-i0",
@@ -191000,7 +193164,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc2228se-df40k-wl-i0",
@@ -191083,7 +193248,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3612sb-adf28km-i0",
@@ -191168,7 +193334,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3614sb-adf28km-i0",
@@ -191255,7 +193422,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3615sb-adf28km-i0",
@@ -191342,7 +193510,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "uniview-ipc3618sb-adf28km-i0",
@@ -191428,7 +193597,8 @@
         "notes": "Use Generic/ONVIF profile. RTSP paths: /unicast/c1/s0/live (main), /unicast/c1/s1/live (sub)."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cb62-usa",
@@ -191501,7 +193671,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cd61-usa",
@@ -191572,7 +193743,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "verkada-cm61",
@@ -191636,7 +193808,8 @@
     "power_source": [
       "poe"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vigi-c340",
@@ -191756,7 +193929,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-30"
   },
   {
     "id": "vigi-c345",
@@ -191882,7 +194056,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c355",
@@ -192008,7 +194183,8 @@
     "status": "available",
     "weight_g": 525,
     "dimensions_mm": "184 x 74 x 74",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c385",
@@ -192131,7 +194307,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c485",
@@ -192258,7 +194435,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-c540v",
@@ -192398,7 +194576,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-lpr345z",
@@ -192529,7 +194708,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s225",
@@ -192656,7 +194836,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s245",
@@ -192789,7 +194970,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s245zi",
@@ -192924,7 +195106,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s285",
@@ -193057,7 +195240,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345-4g",
@@ -193191,7 +195375,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345s",
@@ -193327,7 +195512,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s345zi",
@@ -193462,7 +195648,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s355",
@@ -193594,7 +195781,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385",
@@ -193724,7 +195912,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385dps",
@@ -193862,7 +196051,8 @@
       }
     },
     "status": "announced",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s385pi",
@@ -193998,7 +196188,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445",
@@ -194129,7 +196320,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445s",
@@ -194265,7 +196457,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s445zi",
@@ -194400,7 +196593,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s455",
@@ -194532,7 +196726,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s485",
@@ -194662,7 +196857,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s485pi",
@@ -194798,7 +196994,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vigi-insight-s655i",
@@ -194924,7 +197121,8 @@
       }
     },
     "status": "available",
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-22"
   },
   {
     "id": "vivotek-cc9381-hv",
@@ -195006,7 +197204,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd816c-hf2",
@@ -195079,7 +197278,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd9167-ht-v2",
@@ -195161,7 +197361,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fd9389-ehv-v2",
@@ -195245,7 +197446,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-fe9391-ev",
@@ -195328,7 +197530,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9387-eht-v2",
@@ -195411,7 +197614,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9388-ht",
@@ -195486,7 +197690,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9389-eht-v2",
@@ -195569,7 +197774,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ib9399-h",
@@ -195640,7 +197846,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-ms9390-hv",
@@ -195724,7 +197931,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "vivotek-sd9384-ehl",
@@ -195807,7 +198015,8 @@
         "notes": "Select 'Vivotek' profile. ONVIF supported."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-battery-cam-pro",
@@ -195876,7 +198085,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) for local RTSP proxy. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-floodlight-pro",
@@ -195956,7 +198166,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-og",
@@ -196036,7 +198247,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-og-telephoto",
@@ -196117,7 +198329,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-outdoor-v2",
@@ -196190,7 +198403,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge for local RTSP proxy. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-pan-v2",
@@ -196262,7 +198476,8 @@
         "notes": "No native RTSP. Use docker-wyze-bridge for local RTSP proxy. Pan/tilt control available via bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-pan-v3",
@@ -196345,7 +198560,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v2",
@@ -196414,7 +198630,8 @@
         "notes": "Legacy RTSP firmware was available but is discontinued. Use docker-wyze-bridge for local RTSP proxy."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-cam-v3",
@@ -196497,7 +198714,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v3-pro",
@@ -196581,7 +198799,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-cam-v4",
@@ -196667,7 +198886,8 @@
         "notes": "Use Generic/RTSP profile. Requires wz_mini_hacks firmware or wyze-bridge Docker container for RTSP."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-floodlight-cam-v2",
@@ -196736,7 +198956,8 @@
         "notes": "No official RTSP. Use docker-wyze-bridge for local RTSP proxy."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "wyze-video-doorbell-pro",
@@ -196807,7 +199028,8 @@
         "notes": "No official RTSP or ONVIF support. Wyze doorbells are cloud/app-only by default. For local RTSP, use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) which proxies the P2P stream to a local RTSP endpoint. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "wyze-video-doorbell-v2",
@@ -196874,7 +199096,8 @@
         "notes": "No official RTSP or ONVIF support. Wyze doorbells are cloud/app-only by default. For local RTSP, use docker-wyze-bridge (https://github.com/mrlt8/docker-wyze-bridge) which proxies the P2P stream to a local RTSP endpoint. Not compatible with Frigate or Blue Iris without the bridge."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-09"
   },
   {
     "id": "yale-sv-abfx-w",
@@ -196944,7 +199167,8 @@
       "battery",
       "solar"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dafx-w",
@@ -197018,7 +199242,8 @@
         "notes": "Yale cameras are primarily cloud-based (Yale Home app). RTSP support is unconfirmed. Check camera settings for ONVIF/RTSP options."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dbc-b",
@@ -197069,7 +199294,8 @@
     "power_source": [
       "battery"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-dpfx-w",
@@ -197142,7 +199368,8 @@
         "notes": "Yale cameras are primarily cloud-based (Yale Home app). RTSP support is unconfirmed."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-floodlight",
@@ -197193,7 +199420,8 @@
     "power_source": [
       "ac-mains"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-sv-outdoor-2k",
@@ -197243,7 +199471,8 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   },
   {
     "id": "yale-wipc-303w",
@@ -197313,6 +199542,7 @@
         "notes": "Older Yale model. RTSP support is unconfirmed. May be cloud-only via Yale Home app."
       }
     },
-    "last_verified": "2026-07-06"
+    "last_verified": "2026-07-06",
+    "added": "2026-06-06"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -9,6 +9,7 @@
  */
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 const Ajv = require("ajv");
 const addFormats = require("ajv-formats");
 
@@ -48,13 +49,56 @@ function loadCameras() {
   return walk(CAMERAS_DIR)
     .map((f) => {
       try {
-        return JSON.parse(fs.readFileSync(f, "utf8"));
+        return { file: path.relative(ROOT, f), cam: JSON.parse(fs.readFileSync(f, "utf8")) };
       } catch (err) {
         console.error(`Failed to parse ${f}: ${err.message}`);
         process.exit(1);
       }
     })
-    .sort((a, b) => a.id.localeCompare(b.id));
+    .sort((a, b) => a.cam.id.localeCompare(b.cam.id));
+}
+
+// Repo-relative camera file -> date (YYYY-MM-DD) the file was first added to
+// git. Powers the `added` field injected into the *generated* aggregate for
+// downstream consumers (RSS feed / "recently added" page). Returns an empty
+// map — feature silently degrades — when history is unavailable or shallow;
+// CI must therefore checkout with fetch-depth: 0 (see build.yml) or its
+// "generated files are stale" rebuild would compute different dates.
+function addedDates() {
+  try {
+    const shallow = execSync("git rev-parse --is-shallow-repository", { cwd: ROOT })
+      .toString().trim();
+    if (shallow === "true") return {};
+    const out = execSync(
+      "git log --diff-filter=A --name-only --format=__%ad --date=short -- cameras",
+      { cwd: ROOT, maxBuffer: 64 * 1024 * 1024 }
+    ).toString();
+    const map = {};
+    let date = null;
+    for (const line of out.split("\n")) {
+      if (line.startsWith("__")) date = line.slice(2).trim();
+      // git log is newest-first: keep overwriting so a file re-added later
+      // (e.g. after a rename) resolves to its oldest add date.
+      else if (line.endsWith(".json") && date) map[line.trim()] = date;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+// Fallback for files whose add is hidden behind a git rename (the bulk pass
+// attributes the A to the old path): follow the file's history individually.
+function addedDateFollow(file) {
+  try {
+    const out = execSync(
+      `git log --follow --diff-filter=A --format=%ad --date=short -- "${file}"`,
+      { cwd: ROOT }
+    ).toString().trim().split("\n");
+    return out[out.length - 1] || null; // oldest add
+  } catch {
+    return null;
+  }
 }
 
 function validate(cameras) {
@@ -114,8 +158,20 @@ function toCsv(cameras) {
 }
 
 function main() {
-  const cameras = loadCameras();
+  const entries = loadCameras();
+  const cameras = entries.map((e) => e.cam);
   validate(cameras);
+  // Inject the git-derived `added` date into the generated aggregate only —
+  // never into the per-camera source files (the schema stays authoritative
+  // there; `added` is provenance metadata, not dataset content). Injected
+  // after validation because the schema's additionalProperties: false would
+  // otherwise reject it.
+  const added = addedDates();
+  const haveHistory = Object.keys(added).length > 0;
+  for (const { file, cam } of entries) {
+    const d = added[file] || (haveHistory ? addedDateFollow(file) : null);
+    if (d) cam.added = d;
+  }
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
   const jsonData = JSON.stringify(cameras, null, 2) + "\n";
   fs.writeFileSync(path.join(DATA_DIR, "cameras.json"), jsonData);


### PR DESCRIPTION
Adds an `added` (YYYY-MM-DD) field to every camera in the **generated** aggregate — derived from git history at build time (`git log --diff-filter=A`, `--follow` fallback for renamed files; 2,230/2,230 coverage, build +0.5s).

- **Source files & schema untouched** — injected after AJV validation; provenance metadata, not dataset content.
- **CI**: checkout now `fetch-depth: 0` so the stale-artifact rebuild computes identical dates (shallow clones skip injection entirely rather than produce wrong dates).
- Purpose: powers the frontend's new RSS feed + /recent/ page (separate web-repo PR).