### PR TITLE
Separate camera-side vs Frigate autotracking — schema + migration (v1.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.35.0] — 2026-07-15
+
+Separate **camera-side** autotracking from **Frigate-based** autotracking (#124, part 1).
+
+### Added
+- Schema **`ptz`** object — `ptz.autotracking` (camera-side, onboard subject tracking) and `ptz.onvif_ptz` (`relative`|`absolute`|`continuous`|`none`, the ONVIF movement model that gates Frigate compatibility).
+- Schema **`configs.frigate.autotracking`** — whether Frigate can drive PTZ autotracking (requires ONVIF relative movement; distinct from the camera-side flag).
+
+### Changed
+- Migrated **153** PTZ/dual-lens cameras from free-text `features[]` autotracking tags to **`ptz.autotracking: true`**; removed 84 now-redundant pure-autotracking feature strings (versioned/descriptive strings like "Autotracking 2" retained).
+
+### Notes
+- `onvif_ptz` and `configs.frigate.autotracking` are intentionally left **unset** pending part 2 (community-sourced ONVIF-move / Frigate-compat data — Reolink → false, Frigate known-working → true). 16 non-PTZ cameras with autotracking mentions (digital/e-PTZ or fixed) were **not** migrated — flagged for manual review in #124.
 ## [1.34.0] — 2026-07-14
 
 Generated-artifact feature: each camera in the **generated** `cameras.json` (data/, docs/, and downstream mirrors) now carries an **`added`** date (YYYY-MM-DD) — derived at build time from git history (`git log --diff-filter=A`, with `--follow` fallback for renamed files). Per-camera **source files are unchanged** and the schema is untouched; `added` is provenance metadata injected after validation. Powers downstream "recently added" listings and RSS feeds. CI now checks out with full history (`fetch-depth: 0`) so the stale-artifact check reproduces identical dates.

--- a/cameras/acti/b916.json
+++ b/cameras/acti/b916.json
@@ -57,6 +57,9 @@
   "last_verified": "2026-07-11",
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "field_of_view_deg": "62 - 2.8 horizontal / 36.4 - 1.4 vertical",
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP67, IK10",
   "weight_g": 2605,
   "operating_temp_c": "-52 to 60",

--- a/cameras/acti/b934.json
+++ b/cameras/acti/b934.json
@@ -57,6 +57,9 @@
   "last_verified": "2026-07-11",
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "field_of_view_deg": "62.4 - 3.5 horizontal / 37.6 - 2 vertical",
+  "ptz": {
+    "autotracking": true
+  },
   "dimensions_mm": "150 x 170",
   "weight_g": 1574,
   "operating_temp_c": "-20 to 50",

--- a/cameras/acti/i915.json
+++ b/cameras/acti/i915.json
@@ -61,6 +61,9 @@
     "type": "ir",
     "range_m": 160
   },
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP66, IK10",
   "dimensions_mm": "170 x 260",
   "weight_g": 3135,

--- a/cameras/acti/i98.json
+++ b/cameras/acti/i98.json
@@ -24,6 +24,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 48V / AC 24V / High PoE 60W; 50 W (PoE, heater, fan and IR on), 62 W (AC, heater, fan and IR on)"
   },

--- a/cameras/acti/z952.json
+++ b/cameras/acti/z952.json
@@ -63,6 +63,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP68, IK10",
   "dimensions_mm": "166 x 295",
   "weight_g": 3200,

--- a/cameras/acti/z953.json
+++ b/cameras/acti/z953.json
@@ -24,6 +24,9 @@
     "type": "ir",
     "range_m": 250
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 24V / AC 24V / High PoE (IEEE 802.3bt); 61 W (PoE)"
   },

--- a/cameras/acti/z954.json
+++ b/cameras/acti/z954.json
@@ -24,6 +24,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "AC 24V / DC 24V / PoE Class 5 (IEEE 802.3bt); 58 W (PoE)"
   },

--- a/cameras/acti/z956.json
+++ b/cameras/acti/z956.json
@@ -60,6 +60,9 @@
   "last_verified": "2026-07-11",
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "field_of_view_deg": "51.4 - 2.5 horizontal / 30.3 - 1.4 vertical",
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP68, IK10",
   "dimensions_mm": "218 x 297",
   "weight_g": 4070,

--- a/cameras/acti/z957.json
+++ b/cameras/acti/z957.json
@@ -64,6 +64,9 @@
     "type": "ir",
     "range_m": 250
   },
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP66, IK10",
   "dimensions_mm": "227 x 384.8",
   "weight_g": 5280,

--- a/cameras/acti/z958.json
+++ b/cameras/acti/z958.json
@@ -63,6 +63,9 @@
     "type": "ir",
     "range_m": 120
   },
+  "ptz": {
+    "autotracking": true
+  },
   "ip_rating": "IP66, IK10",
   "dimensions_mm": "162 x 293",
   "operating_temp_c": "-40 to 65",

--- a/cameras/acti/z959.json
+++ b/cameras/acti/z959.json
@@ -24,6 +24,9 @@
     "type": "ir",
     "range_m": 120
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V / High PoE (IEEE 802.3at); 23 W (PoE)"
   },

--- a/cameras/annke/wz500.json
+++ b/cameras/annke/wz500.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },

--- a/cameras/axis/p5676-le.json
+++ b/cameras/axis/p5676-le.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3bt)"
   },

--- a/cameras/axis/q6135-le-mena.json
+++ b/cameras/axis/q6135-le-mena.json
@@ -34,6 +34,9 @@
     "type": "ir",
     "range_m": 250
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3bt) / 3-axis multi-connector cable"
   },
@@ -60,7 +63,6 @@
     "Zipstream H.265",
     "Axis Edge Vault TPM cybersecurity (FIPS 140-2 Level 2)",
     "sharpdome design (20deg above horizon)",
-    "auto-tracking",
     "used in NEOM/smart city Saudi Arabia & UAE critical infra"
   ],
   "sources": [

--- a/cameras/axis/q6135-le-mena.md
+++ b/cameras/axis/q6135-le-mena.md
@@ -29,7 +29,6 @@
 - Zipstream H.265
 - Axis Edge Vault TPM cybersecurity (FIPS 140-2 Level 2)
 - sharpdome design (20deg above horizon)
-- auto-tracking
 - used in NEOM/smart city Saudi Arabia & UAE critical infra
 
 ## Sources

--- a/cameras/axis/q6135-le.json
+++ b/cameras/axis/q6135-le.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 250
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3bt)"
   },

--- a/cameras/axis/q6315-le.json
+++ b/cameras/axis/q6315-le.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 300
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3bt)"
   },

--- a/cameras/axis/q6318-le.json
+++ b/cameras/axis/q6318-le.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 300
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3bt)"
   },

--- a/cameras/bosch/mic-9803s-z30g06v.json
+++ b/cameras/bosch/mic-9803s-z30g06v.json
@@ -40,6 +40,9 @@
   "night_vision": {
     "type": "none"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (High PoE) via single Ethernet cable"
   },
@@ -62,7 +65,7 @@
     "Thermal frame rate 30 Hz",
     "Metadata fusion combining thermal and optical object detection in one view",
     "Bosch Intelligent Video Analytics (IVA)",
-    "Intelligent on-board video tracking / auto-tracking",
+    "Intelligent on-board video tracking",
     "360 degree endless pan, full PTZ",
     "Object detection up to ~4517 m (DRI criteria)",
     "Audio support",

--- a/cameras/bosch/mic-9803s-z30g06v.md
+++ b/cameras/bosch/mic-9803s-z30g06v.md
@@ -24,7 +24,7 @@
 - Thermal frame rate 30 Hz
 - Metadata fusion combining thermal and optical object detection in one view
 - Bosch Intelligent Video Analytics (IVA)
-- Intelligent on-board video tracking / auto-tracking
+- Intelligent on-board video tracking
 - 360 degree endless pan, full PTZ
 - Object detection up to ~4517 m (DRI criteria)
 - Audio support

--- a/cameras/dahua/dh-sd49425xb-hnr.json
+++ b/cameras/dahua/dh-sd49425xb-hnr.json
@@ -28,6 +28,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / AC 24V"
   },
@@ -52,7 +55,6 @@
     "WizMind 4MP 25x Starlight PTZ",
     "face detection",
     "perimeter protection",
-    "auto-tracking",
     "H.265+",
     "IP66",
     "100m IR"

--- a/cameras/dahua/dh-sd49425xb-hnr.md
+++ b/cameras/dahua/dh-sd49425xb-hnr.md
@@ -26,7 +26,6 @@
 - WizMind 4MP 25x Starlight PTZ
 - face detection
 - perimeter protection
-- auto-tracking
 - H.265+
 - IP66
 - 100m IR

--- a/cameras/dahua/dh-sd6al245xa-hnr.json
+++ b/cameras/dahua/dh-sd6al245xa-hnr.json
@@ -26,6 +26,9 @@
     "type": "ir",
     "range_m": 550
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (802.3bt) / AC 24V"
   },
@@ -48,7 +51,6 @@
   "features": [
     "45x optical zoom PTZ",
     "Starlight low-light sensor",
-    "AI auto-tracking",
     "face detection",
     "perimeter protection",
     "550m laser range",

--- a/cameras/dahua/dh-sd6al245xa-hnr.md
+++ b/cameras/dahua/dh-sd6al245xa-hnr.md
@@ -23,7 +23,6 @@
 
 - 45x optical zoom PTZ
 - Starlight low-light sensor
-- AI auto-tracking
 - face detection
 - perimeter protection
 - 550m laser range

--- a/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
+++ b/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 36V/2.23A (±25%)",
     "consumption_w": 35,
@@ -50,7 +53,6 @@
     "dual-channel: 180° panoramic 4MP stitched + 4MP PTZ 25x zoom",
     "starlight 0.001 lux color @F1.0",
     "150m IR (PTZ) + 30m white light (panoramic)",
-    "auto-tracking (single-ball tracking)",
     "face detection with attributes (6 attributes, 8 expressions)",
     "9 IVS rules: tripwire, intrusion, loitering, parking, crowd",
     "human/vehicle classification",

--- a/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.md
+++ b/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.md
@@ -24,7 +24,6 @@
 - dual-channel: 180° panoramic 4MP stitched + 4MP PTZ 25x zoom
 - starlight 0.001 lux color @F1.0
 - 150m IR (PTZ) + 30m white light (panoramic)
-- auto-tracking (single-ball tracking)
 - face detection with attributes (6 attributes, 8 expressions)
 - 9 IVS rules: tripwire, intrusion, loitering, parking, crowd
 - human/vehicle classification

--- a/cameras/dahua/sd49225xa-hnr-mena.json
+++ b/cameras/dahua/sd49225xa-hnr-mena.json
@@ -34,6 +34,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / AC 24V"
   },

--- a/cameras/dahua/sd49425db-hny.json
+++ b/cameras/dahua/sd49425db-hny.json
@@ -28,6 +28,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12VDC/PoE+",
     "consumption_w": 21,
@@ -53,7 +56,6 @@
     "25x optical zoom",
     "Starlight",
     "WizSense",
-    "auto-tracking",
     "pan 240 deg/s",
     "H.265+"
   ],

--- a/cameras/dahua/sd49425db-hny.md
+++ b/cameras/dahua/sd49425db-hny.md
@@ -23,7 +23,6 @@
 - 25x optical zoom
 - Starlight
 - WizSense
-- auto-tracking
 - pan 240 deg/s
 - H.265+
 

--- a/cameras/dahua/sd49825gb-hnr.json
+++ b/cameras/dahua/sd49825gb-hnr.json
@@ -16,6 +16,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at)"
   },
@@ -39,7 +42,6 @@
     "pan/tilt/zoom",
     "WizMind 4K 8MP 25x PTZ SMD 4.0",
     "face recognition",
-    "auto-tracking",
     "100m IR",
     "H.265+",
     "IP66"

--- a/cameras/dahua/sd49825gb-hnr.md
+++ b/cameras/dahua/sd49825gb-hnr.md
@@ -23,7 +23,6 @@
 - pan/tilt/zoom
 - WizMind 4K 8MP 25x PTZ SMD 4.0
 - face recognition
-- auto-tracking
 - 100m IR
 - H.265+
 - IP66

--- a/cameras/dahua/sd4d225mb-hnr.json
+++ b/cameras/dahua/sd4d225mb-hnr.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12VDC/PoE+",
     "consumption_w": 23,
@@ -53,7 +56,6 @@
     "25x optical zoom",
     "Smart Dual Light",
     "WizSense",
-    "auto-tracking",
     "pan 240 deg/s",
     "H.265+"
   ],

--- a/cameras/dahua/sd4d225mb-hnr.md
+++ b/cameras/dahua/sd4d225mb-hnr.md
@@ -23,7 +23,6 @@
 - 25x optical zoom
 - Smart Dual Light
 - WizSense
-- auto-tracking
 - pan 240 deg/s
 - H.265+
 

--- a/cameras/dahua/sd4d425mb-hnr.json
+++ b/cameras/dahua/sd4d425mb-hnr.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12VDC/PoE+",
     "consumption_w": 23,
@@ -53,7 +56,6 @@
     "25x optical zoom",
     "Smart Dual Light",
     "WizSense",
-    "auto-tracking",
     "pan 240 deg/s",
     "H.265+"
   ],

--- a/cameras/dahua/sd4d425mb-hnr.md
+++ b/cameras/dahua/sd4d425mb-hnr.md
@@ -23,7 +23,6 @@
 - 25x optical zoom
 - Smart Dual Light
 - WizSense
-- auto-tracking
 - pan 240 deg/s
 - H.265+
 

--- a/cameras/dahua/sd4d825mb-hnr.json
+++ b/cameras/dahua/sd4d825mb-hnr.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12VDC/PoE+",
     "consumption_w": 23,
@@ -54,7 +57,6 @@
     "Smart Dual Light",
     "WizSense",
     "4K PTZ",
-    "auto-tracking",
     "pan 240 deg/s",
     "H.265+"
   ],

--- a/cameras/dahua/sd4d825mb-hnr.md
+++ b/cameras/dahua/sd4d825mb-hnr.md
@@ -24,7 +24,6 @@
 - Smart Dual Light
 - WizSense
 - 4K PTZ
-- auto-tracking
 - pan 240 deg/s
 - H.265+
 

--- a/cameras/dahua/sd5a432gb-hnr.json
+++ b/cameras/dahua/sd5a432gb-hnr.json
@@ -25,6 +25,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V / AC 24V"
   },
@@ -49,7 +52,6 @@
     "WizSense AI",
     "Starlight low-light",
     "SMD Plus",
-    "auto-tracking",
     "IVS analytics",
     "H.265",
     "IK10"

--- a/cameras/dahua/sd5a432gb-hnr.md
+++ b/cameras/dahua/sd5a432gb-hnr.md
@@ -24,7 +24,6 @@
 - WizSense AI
 - Starlight low-light
 - SMD Plus
-- auto-tracking
 - IVS analytics
 - H.265
 - IK10

--- a/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
@@ -2,10 +2,18 @@
   "id": "dahua-sd6c3432gb-hnr-a-pv1",
   "brand": "Dahua",
   "model": "SD6C3432GB-HNR-A-PV1",
-  "aliases": ["DH-SD6C3432GB-HNR-A-PV1", "WizSense 4MP 32x TiOC Starlight PTZ"],
+  "aliases": [
+    "DH-SD6C3432GB-HNR-A-PV1",
+    "WizSense 4MP 32x TiOC Starlight PTZ"
+  ],
   "type": "ptz",
-  "connectivity": ["ethernet"],
-  "power_source": ["poe", "ac-mains"],
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
   "resolution": {
     "megapixels": 4,
     "max_width": 2688,
@@ -13,7 +21,11 @@
     "label": "4MP"
   },
   "video": {
-    "codecs": ["H.265", "H.264", "MJPEG"],
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
     "max_fps": 30
   },
   "sensor": "1/2.8\" STARVIS CMOS",
@@ -28,6 +40,9 @@
     "type": "hybrid",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "24VAC / PoE+ (802.3at)",
     "consumption_w": 23,
@@ -40,7 +55,11 @@
     "nvr_compatible": true,
     "cloud": false
   },
-  "protocols": ["onvif", "rtsp", "http"],
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
   "ip_rating": "IP66",
   "audio": {
     "microphone": false,
@@ -64,8 +83,12 @@
   ],
   "dimensions_mm": "202 x 202 x 325.3",
   "weight_g": 4600,
-  "environment": ["outdoor"],
-  "markets": ["global"],
+  "environment": [
+    "outdoor"
+  ],
+  "markets": [
+    "global"
+  ],
   "status": "discontinued",
   "sources": [
     "https://materialfile.dahuasecurity.com/uploads/cpq/prm-os-srv-res/smart/datasheetzipfiles/SD6C3432GB-HNR-A-PV1_S0_datasheet_20250123.pdf"
@@ -73,7 +96,11 @@
   "last_verified": "2026-07-04",
   "configs": {
     "frigate": {
-      "detect": { "width": 1280, "height": 720, "fps": 5 },
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs."

--- a/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
@@ -19,6 +19,9 @@
   "night_vision": {
     "type": "hybrid"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE (802.3bt) / 24 VAC"
   },

--- a/cameras/dahua/sdt4e425-8p-gb-apv1.json
+++ b/cameras/dahua/sdt4e425-8p-gb-apv1.json
@@ -20,6 +20,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE (802.3bt) / 24 VAC"
   },

--- a/cameras/eufy/4g-lte-cam-s330.json
+++ b/cameras/eufy/4g-lte-cam-s330.json
@@ -26,6 +26,9 @@
     "type": "hybrid",
     "range_m": 8
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "9400mAh battery + 5W solar panel"
   },

--- a/cameras/eufy/eufycam-s4.json
+++ b/cameras/eufy/eufycam-s4.json
@@ -29,6 +29,9 @@
     "type": "color",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Quick-swap 10000mAh battery + 5.5W SolarPlus 2.0 panel"
   },

--- a/cameras/eufy/indoor-cam-c210.json
+++ b/cameras/eufy/indoor-cam-c210.json
@@ -2,11 +2,20 @@
   "id": "eufy-indoor-cam-c210",
   "brand": "Eufy",
   "model": "Indoor Cam C210",
-  "aliases": ["T8419", "T8419121"],
+  "aliases": [
+    "T8419",
+    "T8419121"
+  ],
   "type": "ptz",
-  "connectivity": ["wifi"],
-  "environment": ["indoor"],
-  "power_source": ["usb"],
+  "connectivity": [
+    "wifi"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "power_source": [
+    "usb"
+  ],
   "resolution": {
     "megapixels": 2,
     "max_width": 1920,
@@ -21,6 +30,9 @@
     "type": "ir",
     "range_m": 8
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "5V/1A (USB, plug-in)"
   },
@@ -31,7 +43,9 @@
     "cloud": false,
     "notes": "microSD up to 128 GB; compatible with HomeBase 3 for local storage; no monthly subscription."
   },
-  "protocols": ["http"],
+  "protocols": [
+    "http"
+  ],
   "ip_rating": "IP20",
   "audio": {
     "microphone": true,
@@ -50,7 +64,9 @@
     "Alexa / Google Assistant"
   ],
   "release_year": 2023,
-  "markets": ["global"],
+  "markets": [
+    "global"
+  ],
   "sources": [
     "https://www.eufy.com/products/t8419121",
     "https://service.eufy.com/article-description/eufy-Security-Indoor-Cam-C210-User-Guide-T8419"

--- a/cameras/eufy/indoor-cam-c220.json
+++ b/cameras/eufy/indoor-cam-c220.json
@@ -2,10 +2,17 @@
   "id": "eufy-indoor-cam-c220",
   "brand": "Eufy",
   "model": "Indoor Cam C220",
-  "aliases": ["T8W11", "T8W11321"],
+  "aliases": [
+    "T8W11",
+    "T8W11321"
+  ],
   "type": "ptz",
-  "connectivity": ["wifi"],
-  "power_source": ["usb"],
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "usb"
+  ],
   "resolution": {
     "megapixels": 3.7,
     "max_width": 2560,
@@ -20,6 +27,9 @@
   "night_vision": {
     "type": "ir"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "micro-USB"
   },
@@ -29,15 +39,27 @@
     "cloud": false,
     "notes": "microSD up to 128 GB; compatible with HomeBase 3 for local storage; no monthly subscription."
   },
-  "protocols": ["http"],
+  "protocols": [
+    "http"
+  ],
   "audio": {
     "microphone": true,
     "speaker": true,
     "two_way": true
   },
-  "features": ["person detection", "pet detection", "crying detection", "auto-tracking", "privacy mode", "360 pan / 75 tilt (no HomeKit)"],
-  "environment": ["indoor"],
-  "markets": ["global"],
+  "features": [
+    "person detection",
+    "pet detection",
+    "crying detection",
+    "privacy mode",
+    "360 pan / 75 tilt (no HomeKit)"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "markets": [
+    "global"
+  ],
   "release_year": 2024,
   "sources": [
     "https://www.eufy.com/eu-en/products/t8w11321",

--- a/cameras/eufy/indoor-cam-c220.md
+++ b/cameras/eufy/indoor-cam-c220.md
@@ -23,7 +23,6 @@
 - person detection
 - pet detection
 - crying detection
-- auto-tracking
 - privacy mode
 - 360 pan / 75 tilt (no HomeKit)
 

--- a/cameras/eufy/indoor-cam-e30.json
+++ b/cameras/eufy/indoor-cam-e30.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 5
   },
+  "ptz": {
+    "autotracking": true
+  },
   "storage": {
     "onboard": true,
     "max_microsd_gb": 128,

--- a/cameras/eufy/indoor-cam-s350.json
+++ b/cameras/eufy/indoor-cam-s350.json
@@ -31,6 +31,9 @@
     "type": "hybrid",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V (USB-C, hardwired)"
   },
@@ -51,7 +54,6 @@
   "features": [
     "4K dual-lens indoor pan/tilt",
     "8x hybrid zoom (3x optical tele)",
-    "AI auto-tracking",
     "on-device human/pet/crying detection",
     "color night vision + IR",
     "no subscription",

--- a/cameras/eufy/indoor-cam-s350.md
+++ b/cameras/eufy/indoor-cam-s350.md
@@ -22,7 +22,6 @@
 
 - 4K dual-lens indoor pan/tilt
 - 8x hybrid zoom (3x optical tele)
-- AI auto-tracking
 - on-device human/pet/crying detection
 - color night vision + IR
 - no subscription

--- a/cameras/eufy/solocam-e30.json
+++ b/cameras/eufy/solocam-e30.json
@@ -26,6 +26,9 @@
   "night_vision": {
     "type": "ir"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "storage": {
     "onboard": true,
     "max_microsd_gb": 128,

--- a/cameras/eufy/solocam-s340.json
+++ b/cameras/eufy/solocam-s340.json
@@ -30,6 +30,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Adjustable/removable 2.2W solar panel + built-in rechargeable battery"
   },

--- a/cameras/ezviz/c6n.json
+++ b/cameras/ezviz/c6n.json
@@ -41,6 +41,9 @@
     "type": "ir",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V/1A (Micro USB)"
   },
@@ -68,7 +71,6 @@
   "features": [
     "340deg pan/55deg tilt indoor camera",
     "AI person detection",
-    "auto-tracking",
     "EZVIZ App",
     "Alexa / Google / Hikvision NVR compatible",
     "RTSP (manual app enable) / ONVIF (firmware >= V5.3.2 build 231228)",

--- a/cameras/ezviz/c6n.md
+++ b/cameras/ezviz/c6n.md
@@ -24,7 +24,6 @@
 
 - 340deg pan/55deg tilt indoor camera
 - AI person detection
-- auto-tracking
 - EZVIZ App
 - Alexa / Google / Hikvision NVR compatible
 - RTSP (manual app enable) / ONVIF (firmware >= V5.3.2 build 231228)

--- a/cameras/ezviz/c8c.json
+++ b/cameras/ezviz/c8c.json
@@ -33,6 +33,9 @@
     "type": "color",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A (max 6W, outdoor adapter)"
   },
@@ -61,7 +64,6 @@
     "AI person detection",
     "spotlight color night vision",
     "strobe light deterrence",
-    "auto-tracking",
     "Alexa / Google",
     "no officially confirmed RTSP/ONVIF -- official datasheet lists only 'EZVIZ Cloud Proprietary Protocol'"
   ],

--- a/cameras/ezviz/c8c.md
+++ b/cameras/ezviz/c8c.md
@@ -27,7 +27,6 @@
 - AI person detection
 - spotlight color night vision
 - strobe light deterrence
-- auto-tracking
 - Alexa / Google
 - no officially confirmed RTSP/ONVIF -- official datasheet lists only 'EZVIZ Cloud Proprietary Protocol'
 

--- a/cameras/ezviz/c8w-pro-2k.json
+++ b/cameras/ezviz/c8w-pro-2k.json
@@ -36,6 +36,9 @@
     "type": "color",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V adapter (RJ45 Ethernet port is data-only, no PoE)"
   },
@@ -62,7 +65,6 @@
     "outdoor pan/tilt WiFi",
     "F1.6 color night vision 30m",
     "AI person/vehicle detection",
-    "auto-tracking",
     "dual spotlights",
     "sound + light deterrence",
     "no officially confirmed RTSP/ONVIF -- official docs list only 'EZVIZ Cloud Proprietary Protocol'",

--- a/cameras/ezviz/c8w-pro-2k.md
+++ b/cameras/ezviz/c8w-pro-2k.md
@@ -25,7 +25,6 @@
 - outdoor pan/tilt WiFi
 - F1.6 color night vision 30m
 - AI person/vehicle detection
-- auto-tracking
 - dual spotlights
 - sound + light deterrence
 - no officially confirmed RTSP/ONVIF -- official docs list only 'EZVIZ Cloud Proprietary Protocol'

--- a/cameras/ezviz/cb8-pro.json
+++ b/cameras/ezviz/cb8-pro.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 15
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (EZVIZ Solar Panel, Type-C versions)"
   },

--- a/cameras/ezviz/cp1-pro.json
+++ b/cameras/ezviz/cp1-pro.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V/1A (Type-C)"
   },

--- a/cameras/ezviz/eb8-pro-4g.json
+++ b/cameras/ezviz/eb8-pro-4g.json
@@ -29,6 +29,9 @@
     "type": "hybrid",
     "range_m": 15
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (8W IP65 solar panel, sold separately)"
   },

--- a/cameras/ezviz/h8c-4g.json
+++ b/cameras/ezviz/h8c-4g.json
@@ -29,6 +29,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A"
   },

--- a/cameras/ezviz/h8c-pro-4g.json
+++ b/cameras/ezviz/h8c-pro-4g.json
@@ -30,6 +30,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A (max 12W)"
   },

--- a/cameras/ezviz/h8c.json
+++ b/cameras/ezviz/h8c.json
@@ -37,6 +37,9 @@
     "type": "color",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A (outdoor adapter)"
   },
@@ -65,7 +68,6 @@
     "1080p outdoor pan/tilt",
     "dual spotlights color night vision",
     "AI person/vehicle detection",
-    "auto-tracking",
     "strobe deterrence",
     "RTSP / ONVIF (official ONVIF compatibility FAQ lists H8c firmware builds)",
     "Alexa / Google"

--- a/cameras/ezviz/h8c.md
+++ b/cameras/ezviz/h8c.md
@@ -24,7 +24,6 @@
 - 1080p outdoor pan/tilt
 - dual spotlights color night vision
 - AI person/vehicle detection
-- auto-tracking
 - strobe deterrence
 - RTSP / ONVIF (official ONVIF compatibility FAQ lists H8c firmware builds)
 - Alexa / Google

--- a/cameras/ezviz/h9c-dual-3k.json
+++ b/cameras/ezviz/h9c-dual-3k.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 40
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1.5A (max 12W)"
   },

--- a/cameras/ezviz/hb8.json
+++ b/cameras/ezviz/hb8.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 15
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter; solar-compatible (EZVIZ Solar Panel, optional)"
   },

--- a/cameras/ezviz/hb90-dual-kit.json
+++ b/cameras/ezviz/hb90-dual-kit.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 35
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (10,400mAh); kit includes 8W solar panel (Type-C connection); DC 5V/2A adapter (sold separately)"
   },

--- a/cameras/foscam/foscam-pd5.json
+++ b/cameras/foscam/foscam-pd5.json
@@ -26,6 +26,9 @@
     "type": "hybrid",
     "range_m": 20
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC"
   },

--- a/cameras/foscam/foscam-r8m.json
+++ b/cameras/foscam/foscam-r8m.json
@@ -25,6 +25,9 @@
     "type": "ir",
     "range_m": 8
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V/2A",
     "consumption_w": 10,
@@ -33,7 +36,7 @@
   "storage": {
     "onboard": false,
     "cloud": true,
-    "notes": "Also supports FTP storage. Exact microSD capacity not confirmed \u2014 verify before publishing. Indoor-use only per the official user manual; no IP rating applies."
+    "notes": "Also supports FTP storage. Exact microSD capacity not confirmed — verify before publishing. Indoor-use only per the official user manual; no IP rating applies."
   },
   "protocols": [
     "rtsp"
@@ -67,7 +70,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
-      "notes": "Not yet verified against a physical unit. Full native resolution/sensor numbers were not found in the official spec table snippet reviewed \u2014 confirm against us.foscam.com/R8M.html Tech Specs Table before publishing.",
+      "notes": "Not yet verified against a physical unit. Full native resolution/sensor numbers were not found in the official spec table snippet reviewed — confirm against us.foscam.com/R8M.html Tech Specs Table before publishing.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/foscam/foscam-sd4h.json
+++ b/cameras/foscam/foscam-sd4h.json
@@ -26,6 +26,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/4A",
     "consumption_w": 30,
@@ -73,7 +76,7 @@
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "ONVIF support not explicitly confirmed in sources reviewed \u2014 verify before publishing.",
+      "notes": "ONVIF support not explicitly confirmed in sources reviewed — verify before publishing.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/foscam/foscam-sd8ep.json
+++ b/cameras/foscam/foscam-sd8ep.json
@@ -36,6 +36,9 @@
     "type": "hybrid",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) or DC 12V/2A",
     "consumption_w": 20,
@@ -86,7 +89,7 @@
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "No native Foscam integration in HA core; use the generic ONVIF integration. ONVIF support stated on Foscam's site but not itemized in this model's spec table \u2014 confirm before publishing.",
+      "notes": "No native Foscam integration in HA core; use the generic ONVIF integration. ONVIF support stated on Foscam's site but not itemized in this model's spec table — confirm before publishing.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/foscam/foscam-sd8p.json
+++ b/cameras/foscam/foscam-sd8p.json
@@ -34,6 +34,9 @@
     "type": "hybrid",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/2A",
     "consumption_w": 20,
@@ -77,12 +80,12 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
-      "notes": "Sourced spec table lists 'Network: Ethernet, One 10/100Mbps RJ45 port' which looks like a copy-paste artifact from a PoE-model template reused by the retailer \u2014 SD8P is marketed as a WiFi camera. Cross-check against us.foscam.com/SD8P.html before publishing. RTSP path not yet verified.",
+      "notes": "Sourced spec table lists 'Network: Ethernet, One 10/100Mbps RJ45 port' which looks like a copy-paste artifact from a PoE-model template reused by the retailer — SD8P is marketed as a WiFi camera. Cross-check against us.foscam.com/SD8P.html before publishing. RTSP path not yet verified.",
       "verified": false
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "ONVIF support not itemized in the source spec table \u2014 verify before publishing.",
+      "notes": "ONVIF support not itemized in the source spec table — verify before publishing.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/geovision/gv-sd2322-ir.json
+++ b/cameras/geovision/gv-sd2322-ir.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / AC 24V"
   },
@@ -45,7 +48,6 @@
   "features": [
     "22x optical zoom",
     "360° continuous pan",
-    "autotracking",
     "H.265 compression",
     "preset tours"
   ],

--- a/cameras/geovision/gv-sd2322-ir.md
+++ b/cameras/geovision/gv-sd2322-ir.md
@@ -22,7 +22,6 @@
 
 - 22x optical zoom
 - 360° continuous pan
-- autotracking
 - H.265 compression
 - preset tours
 

--- a/cameras/geovision/gv-sd4825-ir.json
+++ b/cameras/geovision/gv-sd4825-ir.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) / AC 24V"
   },
@@ -45,7 +48,6 @@
   "features": [
     "25x optical zoom",
     "360° continuous pan",
-    "autotracking",
     "H.265 compression",
     "preset tours",
     "WDR"

--- a/cameras/geovision/gv-sd4825-ir.md
+++ b/cameras/geovision/gv-sd4825-ir.md
@@ -22,7 +22,6 @@
 
 - 25x optical zoom
 - 360° continuous pan
-- autotracking
 - H.265 compression
 - preset tours
 - WDR

--- a/cameras/hanwha/pnm-9322vqp.json
+++ b/cameras/hanwha/pnm-9322vqp.json
@@ -34,6 +34,9 @@
   "night_vision": {
     "type": "none"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "HPoE (IEEE 802.3bt, Class 8), injector included",
     "consumption_w": 65,

--- a/cameras/hanwha/pnm-c34404rqpz.json
+++ b/cameras/hanwha/pnm-c34404rqpz.json
@@ -30,6 +30,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt Type 4, Class 8)",
     "consumption_w": 64,

--- a/cameras/hanwha/xnp-9300rw.json
+++ b/cameras/hanwha/xnp-9300rw.json
@@ -30,6 +30,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt Type 3, Class 6)",
     "consumption_w": 42,

--- a/cameras/hi-focus/hc-ipc-sd3380e.json
+++ b/cameras/hi-focus/hc-ipc-sd3380e.json
@@ -22,6 +22,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (802.3at) / AC 24V / DC 24V"
   },
@@ -44,7 +47,7 @@
     "200m Smart IR",
     "360 presets, 8 patrol patterns",
     "endless 360 pan",
-    "auto-tracking / object detection",
+    "object detection",
     "120dB WDR",
     "snow-removing (defog)",
     "ICR day/night"

--- a/cameras/hi-focus/hc-ipc-sd3380e.md
+++ b/cameras/hi-focus/hc-ipc-sd3380e.md
@@ -22,7 +22,7 @@
 - 200m Smart IR
 - 360 presets, 8 patrol patterns
 - endless 360 pan
-- auto-tracking / object detection
+- object detection
 - 120dB WDR
 - snow-removing (defog)
 - ICR day/night

--- a/cameras/hi-focus/hc-ipc-sdq53320s.json
+++ b/cameras/hi-focus/hc-ipc-sdq53320s.json
@@ -22,6 +22,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC / PoE"
   },
@@ -44,7 +47,6 @@
     "150m Smart IR (850nm)",
     "1024 presets",
     "endless 360 pan",
-    "auto tracking",
     "line-crossing / intrusion / area analytics",
     "120dB optical WDR",
     "two-way audio",

--- a/cameras/hi-focus/hc-ipc-sdq53320s.md
+++ b/cameras/hi-focus/hc-ipc-sdq53320s.md
@@ -22,7 +22,6 @@
 - 150m Smart IR (850nm)
 - 1024 presets
 - endless 360 pan
-- auto tracking
 - line-crossing / intrusion / area analytics
 - 120dB optical WDR
 - two-way audio

--- a/cameras/hikvision/ds-2de2a204iw-de3-w.json
+++ b/cameras/hikvision/ds-2de2a204iw-de3-w.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V / PoE"
   },

--- a/cameras/hikvision/ds-2de3a400bw-de.json
+++ b/cameras/hikvision/ds-2de3a400bw-de.json
@@ -28,6 +28,9 @@
     "type": "color",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/hikvision/ds-2de3a400bwg-e.json
+++ b/cameras/hikvision/ds-2de3a400bwg-e.json
@@ -27,6 +27,9 @@
     "type": "color",
     "range_m": 40
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/hikvision/ds-2de4425iw-de-t5-india.json
+++ b/cameras/hikvision/ds-2de4425iw-de-t5-india.json
@@ -32,6 +32,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / AC 24V"
   },
@@ -57,7 +60,6 @@
     "AcuSense",
     "IP66",
     "H.265+",
-    "auto-tracking",
     "very popular commercial India PTZ",
     "₹25,000–35,000"
   ],

--- a/cameras/hikvision/ds-2de4425iw-de-t5-india.md
+++ b/cameras/hikvision/ds-2de4425iw-de-t5-india.md
@@ -27,7 +27,6 @@
 - AcuSense
 - IP66
 - H.265+
-- auto-tracking
 - very popular commercial India PTZ
 - ₹25,000–35,000
 

--- a/cameras/hikvision/ds-2de4425iw-de.json
+++ b/cameras/hikvision/ds-2de4425iw-de.json
@@ -28,6 +28,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
     "voltage": "12V (DC) / PoE+"

--- a/cameras/hikvision/ds-2de4825wg-e3.json
+++ b/cameras/hikvision/ds-2de4825wg-e3.json
@@ -20,6 +20,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE / 12 VDC"
   },

--- a/cameras/hikvision/ds-2de4a225iwg-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ / 12 VDC"
   },
@@ -43,7 +46,6 @@
     "pan/tilt: pan 360 / tilt -5 to 90",
     "DarkFighter low-light",
     "AcuSense human/vehicle classification",
-    "auto-tracking",
     "IR to 50m (850nm)",
     "120dB WDR",
     "3D positioning",

--- a/cameras/hikvision/ds-2de4a225iwg-e.md
+++ b/cameras/hikvision/ds-2de4a225iwg-e.md
@@ -22,7 +22,6 @@
 - pan/tilt: pan 360 / tilt -5 to 90
 - DarkFighter low-light
 - AcuSense human/vehicle classification
-- auto-tracking
 - IR to 50m (850nm)
 - 120dB WDR
 - 3D positioning

--- a/cameras/hikvision/ds-2de4a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / 12 VDC"
   },
@@ -43,7 +46,6 @@
     "pan/tilt: pan 360 / tilt -5 to 90",
     "DarkFighter low-light",
     "AcuSense human/vehicle classification",
-    "auto-tracking",
     "IR to 50m (850nm, smart supplement)",
     "120dB WDR",
     "3D positioning",

--- a/cameras/hikvision/ds-2de4a225iwg1-e.md
+++ b/cameras/hikvision/ds-2de4a225iwg1-e.md
@@ -22,7 +22,6 @@
 - pan/tilt: pan 360 / tilt -5 to 90
 - DarkFighter low-light
 - AcuSense human/vehicle classification
-- auto-tracking
 - IR to 50m (850nm, smart supplement)
 - 120dB WDR
 - 3D positioning

--- a/cameras/hikvision/ds-2de4a404iwg-e.json
+++ b/cameras/hikvision/ds-2de4a404iwg-e.json
@@ -28,6 +28,9 @@
     "type": "ir",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / DC 12V"
   },
@@ -53,7 +56,6 @@
     "50m IR",
     "H.265+",
     "IP66",
-    "auto-tracking",
     "most affordable Hikvision PoE mini PTZ"
   ],
   "sources": [

--- a/cameras/hikvision/ds-2de4a404iwg-e.md
+++ b/cameras/hikvision/ds-2de4a404iwg-e.md
@@ -27,7 +27,6 @@
 - 50m IR
 - H.265+
 - IP66
-- auto-tracking
 - most affordable Hikvision PoE mini PTZ
 
 ## Sources

--- a/cameras/hikvision/ds-2de4a425iwg-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg-e.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V"
   },

--- a/cameras/hikvision/ds-2de4a425iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 50
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / 12 VDC"
   },
@@ -43,7 +46,6 @@
     "pan/tilt: pan 360 / tilt -5 to 90",
     "powered-by-DarkFighter low-light",
     "AcuSense human/vehicle classification",
-    "auto-tracking (Smart Tracking)",
     "face capture, regional people counting",
     "IR to 50m (850nm)",
     "120dB WDR",

--- a/cameras/hikvision/ds-2de4a425iwg1-e.md
+++ b/cameras/hikvision/ds-2de4a425iwg1-e.md
@@ -22,7 +22,6 @@
 - pan/tilt: pan 360 / tilt -5 to 90
 - powered-by-DarkFighter low-light
 - AcuSense human/vehicle classification
-- auto-tracking (Smart Tracking)
 - face capture, regional people counting
 - IR to 50m (850nm)
 - 120dB WDR

--- a/cameras/hikvision/ds-2de5a425iwg-e.json
+++ b/cameras/hikvision/ds-2de5a425iwg-e.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V"
   },

--- a/cameras/hikvision/ds-2de5a425iwg-eb.json
+++ b/cameras/hikvision/ds-2de5a425iwg-eb.json
@@ -16,6 +16,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at)"
   },
@@ -40,10 +43,8 @@
     "4MP 25x PTZ DeepinView",
     "100m IR",
     "AcuSense AI",
-    "auto-tracking",
     "H.265+",
-    "IP66",
-    "smart tracking"
+    "IP66"
   ],
   "sources": [
     "https://www.hikvision.com/en/products/"

--- a/cameras/hikvision/ds-2de5a425iwg-eb.md
+++ b/cameras/hikvision/ds-2de5a425iwg-eb.md
@@ -24,10 +24,8 @@
 - 4MP 25x PTZ DeepinView
 - 100m IR
 - AcuSense AI
-- auto-tracking
 - H.265+
 - IP66
-- smart tracking
 
 ## Sources
 

--- a/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE / 36 VDC"
   },
@@ -44,7 +47,6 @@
     "AcuSense human/vehicle classification",
     "active deterrence strobe + audible warning to 100m",
     "2 built-in speakers",
-    "auto-tracking",
     "300 presets",
     "IR up to 200m",
     "pan/tilt: pan 360 / tilt -15 to 90",

--- a/cameras/hikvision/ds-2de7a225iwg-eb-sl.md
+++ b/cameras/hikvision/ds-2de7a225iwg-eb-sl.md
@@ -23,7 +23,6 @@
 - AcuSense human/vehicle classification
 - active deterrence strobe + audible warning to 100m
 - 2 built-in speakers
-- auto-tracking
 - 300 presets
 - IR up to 200m
 - pan/tilt: pan 360 / tilt -15 to 90

--- a/cameras/hikvision/ds-2de7a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a225iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE / 36 VDC"
   },
@@ -44,7 +47,6 @@
     "AcuSense human/vehicle classification",
     "arrayed dual-mic two-way audio",
     "white-light + audible audio-visual alarm",
-    "auto-tracking",
     "300 presets",
     "IR up to 200m",
     "pan/tilt: pan 360 / tilt -15 to 90",

--- a/cameras/hikvision/ds-2de7a225iwg1-e.md
+++ b/cameras/hikvision/ds-2de7a225iwg1-e.md
@@ -23,7 +23,6 @@
 - AcuSense human/vehicle classification
 - arrayed dual-mic two-way audio
 - white-light + audible audio-visual alarm
-- auto-tracking
 - 300 presets
 - IR up to 200m
 - pan/tilt: pan 360 / tilt -15 to 90

--- a/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE / 36 VDC"
   },
@@ -44,7 +47,6 @@
     "AcuSense human/vehicle classification",
     "active deterrence strobe + audible warning to 100m",
     "2 built-in speakers",
-    "auto-tracking",
     "300 presets",
     "IR up to 200m",
     "pan/tilt: pan 360 / tilt -15 to 90",

--- a/cameras/hikvision/ds-2de7a232iwg-eb-sl.md
+++ b/cameras/hikvision/ds-2de7a232iwg-eb-sl.md
@@ -23,7 +23,6 @@
 - AcuSense human/vehicle classification
 - active deterrence strobe + audible warning to 100m
 - 2 built-in speakers
-- auto-tracking
 - 300 presets
 - IR up to 200m
 - pan/tilt: pan 360 / tilt -15 to 90

--- a/cameras/hikvision/ds-2de7a232iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a232iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE (802.3bt Type3) / 36 VDC"
   },
@@ -45,7 +48,6 @@
     "arrayed dual-mic (8m) + speaker (30m)",
     "audio-visual alarm (white-light flash + audible)",
     "IR up to 200m",
-    "auto-tracking",
     "300 presets",
     "regional people counting",
     "360 VR panoramic view",

--- a/cameras/hikvision/ds-2de7a232iwg1-e.md
+++ b/cameras/hikvision/ds-2de7a232iwg1-e.md
@@ -24,7 +24,6 @@
 - arrayed dual-mic (8m) + speaker (30m)
 - audio-visual alarm (white-light flash + audible)
 - IR up to 200m
-- auto-tracking
 - 300 presets
 - regional people counting
 - 360 VR panoramic view

--- a/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE / 36 VDC"
   },
@@ -45,7 +48,6 @@
     "active deterrence: sound + strobe light to 100m",
     "IR up to 200m (850nm)",
     "2 built-in speakers",
-    "auto-tracking",
     "300 presets",
     "face capture",
     "pan/tilt: pan 360 / tilt -15 to 90",

--- a/cameras/hikvision/ds-2de7a425iwg-eb-sl.md
+++ b/cameras/hikvision/ds-2de7a425iwg-eb-sl.md
@@ -24,7 +24,6 @@
 - active deterrence: sound + strobe light to 100m
 - IR up to 200m (850nm)
 - 2 built-in speakers
-- auto-tracking
 - 300 presets
 - face capture
 - pan/tilt: pan 360 / tilt -15 to 90

--- a/cameras/hikvision/ds-2de7a432iw-aeb.json
+++ b/cameras/hikvision/ds-2de7a432iw-aeb.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "High PoE (802.3at) / AC 24V"
   },

--- a/cameras/hikvision/ds-2de7a632iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a632iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE (802.3bt) / 36 VDC"
   },
@@ -43,7 +46,6 @@
     "pan/tilt: pan 360 / tilt -15 to 90",
     "powered-by-DarkFighter + HIK AI-ISP",
     "AcuSense human/vehicle classification",
-    "auto-tracking (Smart Tracking)",
     "active deterrence: white-light flash + audible warning",
     "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
     "IR to 200m",

--- a/cameras/hikvision/ds-2de7a632iwg1-e.md
+++ b/cameras/hikvision/ds-2de7a632iwg1-e.md
@@ -22,7 +22,6 @@
 - pan/tilt: pan 360 / tilt -15 to 90
 - powered-by-DarkFighter + HIK AI-ISP
 - AcuSense human/vehicle classification
-- auto-tracking (Smart Tracking)
 - active deterrence: white-light flash + audible warning
 - built-in speaker (30m) + arrayed dual-mic (8m) two-way audio
 - IR to 200m

--- a/cameras/hikvision/ds-2de7a825iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a825iwg1-e.json
@@ -21,6 +21,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hi-PoE (802.3bt) / 36 VDC"
   },
@@ -43,7 +46,6 @@
     "pan/tilt: pan 360 / tilt -15 to 90",
     "powered-by-DarkFighter + HIK AI-ISP",
     "AcuSense human/vehicle classification",
-    "auto-tracking (Smart Tracking)",
     "active deterrence: white-light flash + audible warning",
     "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
     "IR to 200m",

--- a/cameras/hikvision/ds-2de7a825iwg1-e.md
+++ b/cameras/hikvision/ds-2de7a825iwg1-e.md
@@ -22,7 +22,6 @@
 - pan/tilt: pan 360 / tilt -15 to 90
 - powered-by-DarkFighter + HIK AI-ISP
 - AcuSense human/vehicle classification
-- auto-tracking (Smart Tracking)
 - active deterrence: white-light flash + audible warning
 - built-in speaker (30m) + arrayed dual-mic (8m) two-way audio
 - IR to 200m

--- a/cameras/hikvision/ds-2se4c425mwg-4g.json
+++ b/cameras/hikvision/ds-2se4c425mwg-4g.json
@@ -22,6 +22,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / 12 VDC"
   },

--- a/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
+++ b/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
@@ -33,6 +33,9 @@
     "type": "hybrid",
     "range_m": 400
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt Type 4, Class 8, 90W) / 36VDC",
     "consumption_w": 90,

--- a/cameras/hilook/ptz-n2c200m-de.json
+++ b/cameras/hilook/ptz-n2c200m-de.json
@@ -21,6 +21,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/hilook/ptz-n2c400m-de.json
+++ b/cameras/hilook/ptz-n2c400m-de.json
@@ -21,6 +21,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/hilook/ptz-n2d200m-de.json
+++ b/cameras/hilook/ptz-n2d200m-de.json
@@ -21,6 +21,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/hilook/ptz-n2d400m-de.json
+++ b/cameras/hilook/ptz-n2d400m-de.json
@@ -21,6 +21,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },

--- a/cameras/imou/aov-pt-5mp.json
+++ b/cameras/imou/aov-pt-5mp.json
@@ -39,6 +39,9 @@
     "type": "hybrid",
     "range_m": 20
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "10000mAh battery; DC 5V/2A or optional Imou 5W solar panel; <3.5W"
   },
@@ -60,7 +63,6 @@
   "features": [
     "Always-On-Video (AOV) low-power 24/7 recording",
     "AI human detection (>98%)",
-    "auto tracking",
     "siren & spotlight",
     "8x digital zoom",
     "PIR",

--- a/cameras/imou/aov-pt-5mp.md
+++ b/cameras/imou/aov-pt-5mp.md
@@ -23,7 +23,6 @@
 
 - Always-On-Video (AOV) low-power 24/7 recording
 - AI human detection (>98%)
-- auto tracking
 - siren & spotlight
 - 8x digital zoom
 - PIR

--- a/cameras/imou/aov-pt-pro.json
+++ b/cameras/imou/aov-pt-pro.json
@@ -39,6 +39,9 @@
     "type": "hybrid",
     "range_m": 25
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "10000mAh battery; DC 5V/2A; sold as a kit with a 5W solar panel"
   },
@@ -62,7 +65,6 @@
     "F1.0 large-aperture 'Aurora' lens",
     "AURORA full-color night vision (25m)",
     "AI human detection",
-    "auto tracking",
     "integrated siren",
     "4G LTE + Wi-Fi"
   ],

--- a/cameras/imou/aov-pt-pro.md
+++ b/cameras/imou/aov-pt-pro.md
@@ -25,7 +25,6 @@
 - F1.0 large-aperture 'Aurora' lens
 - AURORA full-color night vision (25m)
 - AI human detection
-- auto tracking
 - integrated siren
 - 4G LTE + Wi-Fi
 

--- a/cameras/imou/cell-pt.json
+++ b/cameras/imou/cell-pt.json
@@ -26,6 +26,9 @@
   "night_vision": {
     "type": "hybrid"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "5000mAh (base) up to 15000mAh battery (up to 280 days); USB-C fast charging; optional 3W/7W solar"
   },

--- a/cameras/imou/cruiser-2-5mp.json
+++ b/cameras/imou/cruiser-2-5mp.json
@@ -35,6 +35,9 @@
     "type": "color",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -57,7 +60,6 @@
   "features": [
     "5MP outdoor pan/tilt color night vision",
     "AI human/vehicle detection",
-    "auto-tracking",
     "smart siren + spotlight deterrence",
     "IP66",
     "H.265",

--- a/cameras/imou/cruiser-2-5mp.md
+++ b/cameras/imou/cruiser-2-5mp.md
@@ -24,7 +24,6 @@
 
 - 5MP outdoor pan/tilt color night vision
 - AI human/vehicle detection
-- auto-tracking
 - smart siren + spotlight deterrence
 - IP66
 - H.265

--- a/cameras/imou/cruiser-2c-5mp.json
+++ b/cameras/imou/cruiser-2c-5mp.json
@@ -37,6 +37,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A, <12W"
   },
@@ -59,7 +62,6 @@
   "features": [
     "outdoor pan/tilt",
     "8x digital zoom",
-    "auto-tracking",
     "human & vehicle detection",
     "full-color night vision",
     "110 dB siren",

--- a/cameras/imou/cruiser-2c-5mp.md
+++ b/cameras/imou/cruiser-2c-5mp.md
@@ -23,7 +23,6 @@
 
 - outdoor pan/tilt
 - 8x digital zoom
-- auto-tracking
 - human & vehicle detection
 - full-color night vision
 - 110 dB siren

--- a/cameras/imou/cruiser-dual-2.json
+++ b/cameras/imou/cruiser-dual-2.json
@@ -38,6 +38,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V, <12W"
   },
@@ -64,7 +67,6 @@
     "110 dB siren",
     "spotlight active deterrence",
     "IMOU SENSE human/vehicle detection",
-    "auto-tracking",
     "Wi-Fi 6",
     "two-way talk"
   ],

--- a/cameras/imou/cruiser-dual-2.md
+++ b/cameras/imou/cruiser-dual-2.md
@@ -27,7 +27,6 @@
 - 110 dB siren
 - spotlight active deterrence
 - IMOU SENSE human/vehicle detection
-- auto-tracking
 - Wi-Fi 6
 - two-way talk
 

--- a/cameras/imou/cruiser-dual.json
+++ b/cameras/imou/cruiser-dual.json
@@ -39,6 +39,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A, <12W"
   },
@@ -63,7 +66,6 @@
     "full-color night vision",
     "110 dB siren",
     "IMOU SENSE human/vehicle detection",
-    "auto-tracking",
     "Wi-Fi 6",
     "two-way talk"
   ],

--- a/cameras/imou/cruiser-dual.md
+++ b/cameras/imou/cruiser-dual.md
@@ -25,7 +25,6 @@
 - full-color night vision
 - 110 dB siren
 - IMOU SENSE human/vehicle detection
-- auto-tracking
 - Wi-Fi 6
 - two-way talk
 

--- a/cameras/imou/cruiser-pano-z.json
+++ b/cameras/imou/cruiser-pano-z.json
@@ -38,6 +38,9 @@
     "type": "hybrid",
     "range_m": 56
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1.5A or PoE 802.3at, <18W"
   },
@@ -62,7 +65,6 @@
     "smart color four-mode night vision",
     "warning lights + 120 dB alarm",
     "AI human/vehicle detection",
-    "auto-tracking",
     "AOR always-on-record",
     "dual microSD slots",
     "dual-band Wi-Fi 6",

--- a/cameras/imou/cruiser-pano-z.md
+++ b/cameras/imou/cruiser-pano-z.md
@@ -25,7 +25,6 @@
 - smart color four-mode night vision
 - warning lights + 120 dB alarm
 - AI human/vehicle detection
-- auto-tracking
 - AOR always-on-record
 - dual microSD slots
 - dual-band Wi-Fi 6

--- a/cameras/imou/cruiser-sc-4g-5mp.json
+++ b/cameras/imou/cruiser-sc-4g-5mp.json
@@ -38,6 +38,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A"
   },
@@ -60,7 +63,6 @@
   "features": [
     "4G LTE pan/tilt",
     "full-color night vision",
-    "auto-tracking",
     "spotlight + 110 dB siren",
     "red-blue warning lights",
     "AI human detection",

--- a/cameras/imou/cruiser-sc-4g-5mp.md
+++ b/cameras/imou/cruiser-sc-4g-5mp.md
@@ -23,7 +23,6 @@
 
 - 4G LTE pan/tilt
 - full-color night vision
-- auto-tracking
 - spotlight + 110 dB siren
 - red-blue warning lights
 - AI human detection

--- a/cameras/imou/cruiser-sc-8mp.json
+++ b/cameras/imou/cruiser-sc-8mp.json
@@ -37,6 +37,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A"
   },

--- a/cameras/imou/cruiser-z-5mp.json
+++ b/cameras/imou/cruiser-z-5mp.json
@@ -36,6 +36,9 @@
     "type": "hybrid",
     "range_m": 56
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -57,7 +60,6 @@
   },
   "features": [
     "dual-lens 12x mixed zoom (3x optical + 4x digital)",
-    "auto-tracking",
     "IMOU SENSE AI human & vehicle detection",
     "full-color night vision",
     "spotlight/siren active deterrence",

--- a/cameras/imou/cruiser-z-5mp.md
+++ b/cameras/imou/cruiser-z-5mp.md
@@ -22,7 +22,6 @@
 ## Features
 
 - dual-lens 12x mixed zoom (3x optical + 4x digital)
-- auto-tracking
 - IMOU SENSE AI human & vehicle detection
 - full-color night vision
 - spotlight/siren active deterrence

--- a/cameras/imou/indoor-2k.json
+++ b/cameras/imou/indoor-2k.json
@@ -18,6 +18,9 @@
     "type": "ir",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V USB"
   },

--- a/cameras/imou/ranger-2.json
+++ b/cameras/imou/ranger-2.json
@@ -34,6 +34,9 @@
     "type": "ir",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V (USB)"
   },

--- a/cameras/kedacom/ipc425-g223-n.json
+++ b/cameras/kedacom/ipc425-g223-n.json
@@ -3,28 +3,98 @@
   "brand": "Kedacom",
   "model": "IPC425-G223-N",
   "type": "ptz",
-  "connectivity": ["ethernet"],
-  "power_source": ["ac-mains"],
-  "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 60 },
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "ac-mains"
+  ],
+  "resolution": {
+    "megapixels": 2.0,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
   "sensor": "1/1.9\" progressive scan CMOS",
-  "lens": { "focal_length_mm": "6-138", "aperture": "F1.5 (W) / F3.4 (T)", "varifocal": true },
-  "night_vision": { "type": "ir", "range_m": 220 },
-  "power": { "method": "24V AC", "voltage": "24V AC / 3A", "consumption_w": 45 },
-  "storage": { "onboard": true, "nvr_compatible": true, "notes": "32GB built-in eMMC" },
-  "protocols": ["onvif", "rtsp", "http"],
-  "audio": { "two_way": true },
-  "features": ["23x optical zoom", "lens 6-138mm", "human auto-tracking", "face target capture", "360 endless pan", "-15 to 90 tilt (auto flip)", "256 presets", "8 patrols (32 presets each)", "Smart IR (9 LED array)", "120dB Ultra WDR", "32GB built-in eMMC storage", "motion detection", "tampering detection", "line crossing detection", "TVS 6000V lightning protection"],
+  "lens": {
+    "focal_length_mm": "6-138",
+    "aperture": "F1.5 (W) / F3.4 (T)",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 220
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "24V AC",
+    "voltage": "24V AC / 3A",
+    "consumption_w": 45
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "notes": "32GB built-in eMMC"
+  },
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
+  "audio": {
+    "two_way": true
+  },
+  "features": [
+    "23x optical zoom",
+    "lens 6-138mm",
+    "human auto-tracking",
+    "face target capture",
+    "360 endless pan",
+    "-15 to 90 tilt (auto flip)",
+    "256 presets",
+    "8 patrols (32 presets each)",
+    "Smart IR (9 LED array)",
+    "120dB Ultra WDR",
+    "32GB built-in eMMC storage",
+    "motion detection",
+    "tampering detection",
+    "line crossing detection",
+    "TVS 6000V lightning protection"
+  ],
   "operating_temp_c": "-40 to 70",
   "dimensions_mm": "Ø214 x 379",
-  "environment": ["outdoor"],
-  "markets": ["global"],
-  "sources": ["https://www.kedacom.com/en/ythwlsxj/4762.jhtml"],
+  "environment": [
+    "outdoor"
+  ],
+  "markets": [
+    "global"
+  ],
+  "sources": [
+    "https://www.kedacom.com/en/ythwlsxj/4762.jhtml"
+  ],
   "last_verified": "2026-07-04",
   "configs": {
-    "frigate": { "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/id=0", "best_substream": "rtsp://{user}:{pass}@{ip}:554/id=1", "verified": false },
-    "home_assistant": { "integration": "onvif" },
-    "blue_iris": { "profile": "ONVIF" }
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/id=0",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/id=1",
+      "verified": false
+    },
+    "home_assistant": {
+      "integration": "onvif"
+    },
+    "blue_iris": {
+      "profile": "ONVIF"
+    }
   },
   "status": "available"
 }

--- a/cameras/lorex/w462aqc-e-pantilt.json
+++ b/cameras/lorex/w462aqc-e-pantilt.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/0.62A (max 3.1W) via included power adapter"
   },
@@ -54,7 +57,6 @@
   "features": [
     "2K QHD indoor WiFi pan/tilt",
     "ONVIF Profile S confirmed on official datasheet",
-    "auto-tracking",
     "Lorex Home app",
     "Alexa / Google",
     "no monthly fees"

--- a/cameras/lorex/w462aqc-e-pantilt.md
+++ b/cameras/lorex/w462aqc-e-pantilt.md
@@ -23,7 +23,6 @@
 
 - 2K QHD indoor WiFi pan/tilt
 - ONVIF Profile S confirmed on official datasheet
-- auto-tracking
 - Lorex Home app
 - Alexa / Google
 - no monthly fees

--- a/cameras/lts/lts-lxptzip4c8wi-x25sdl.json
+++ b/cameras/lts/lts-lxptzip4c8wi-x25sdl.json
@@ -31,6 +31,9 @@
     "type": "hybrid",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12V DC or PoE+"
   },
@@ -52,7 +55,6 @@
   "features": [
     "25x optical zoom (5-125mm)",
     "active deterrence: built-in red/blue strobe lights + siren (X-Deterrence)",
-    "auto-tracking",
     "VCA: line crossing, intrusion detection, face detection",
     "MD 2.0 human/vehicle detection",
     "built-in heater for lens defogging",
@@ -61,7 +63,7 @@
   "environment": [
     "outdoor"
   ],
-  "release_notes": "Part of LTS's newer Pro-X line. Pro-X's underlying OEM/chipset origin was not confirmed in the sources reviewed (unlike Platinum, which is confirmed Hikvision OEM) \u2014 do not assume the same RTSP/ONVIF firmware conventions carry over without verification.",
+  "release_notes": "Part of LTS's newer Pro-X line. Pro-X's underlying OEM/chipset origin was not confirmed in the sources reviewed (unlike Platinum, which is confirmed Hikvision OEM) — do not assume the same RTSP/ONVIF firmware conventions carry over without verification.",
   "sources": [
     "https://ltsecurityinc.com/lxptzip4c8wi-x25sdl-8mp-4-inch-active-deterrence-ptz-camera-25x-optical-zoom.html",
     "https://www.amazon.com/LTS-LXPTZIP4C8WI-X25SDL-8MP-PTZ-Camera/dp/B0G455SC6V"
@@ -70,7 +72,7 @@
   "status": "available",
   "configs": {
     "frigate": {
-      "notes": "RTSP path and ONVIF profile not confirmed for the Pro-X line \u2014 needs direct verification before publishing. Do not assume the Platinum/Hikvision-style channel path applies.",
+      "notes": "RTSP path and ONVIF profile not confirmed for the Pro-X line — needs direct verification before publishing. Do not assume the Platinum/Hikvision-style channel path applies.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/lts/lts-lxptzip4c8wi-x25sdl.md
+++ b/cameras/lts/lts-lxptzip4c8wi-x25sdl.md
@@ -22,7 +22,6 @@
 
 - 25x optical zoom (5-125mm)
 - active deterrence: built-in red/blue strobe lights + siren (X-Deterrence)
-- auto-tracking
 - VCA: line crossing, intrusion detection, face detection
 - MD 2.0 human/vehicle detection
 - built-in heater for lens defogging

--- a/cameras/lts/lts-ptzip688x36.json
+++ b/cameras/lts/lts-ptzip688x36.json
@@ -37,6 +37,9 @@
   "night_vision": {
     "type": "ir"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "24V AC or High PoE, up to 50W"
   },
@@ -64,7 +67,7 @@
   "environment": [
     "outdoor"
   ],
-  "release_notes": "LTS (LT Security Inc.) is a US-based distributor selling Hikvision OEM hardware under its own model numbering. Hikvision-derived firmware ships with ONVIF disabled by default since v5.5.0 \u2014 must be manually enabled in the camera's web UI before use with third-party NVRs/Frigate/Home Assistant.",
+  "release_notes": "LTS (LT Security Inc.) is a US-based distributor selling Hikvision OEM hardware under its own model numbering. Hikvision-derived firmware ships with ONVIF disabled by default since v5.5.0 — must be manually enabled in the camera's web UI before use with third-party NVRs/Frigate/Home Assistant.",
   "sources": [
     "https://ltsecurityinc.com/ip-network-ptz-camera-ptzip688x36.html",
     "https://ltsecurityinc.com/default/products/product-lines/platinum/ip-camera/ip-ptz.html"

--- a/cameras/luma/lum-210-ptz.json
+++ b/cameras/luma/lum-210-ptz.json
@@ -17,6 +17,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (IEEE 802.3at)"
   },
@@ -38,7 +41,6 @@
   "features": [
     "25x optical zoom",
     "pan/tilt/zoom",
-    "auto-tracking",
     "Control4 integration",
     "preset patrol"
   ],

--- a/cameras/luma/lum-210-ptz.md
+++ b/cameras/luma/lum-210-ptz.md
@@ -20,7 +20,6 @@
 
 - 25x optical zoom
 - pan/tilt/zoom
-- auto-tracking
 - Control4 integration
 - preset patrol
 

--- a/cameras/pelco/spectra-enhanced-7-s7230l-ew1.json
+++ b/cameras/pelco/spectra-enhanced-7-s7230l-ew1.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) / 24VAC"
   },
@@ -46,7 +49,6 @@
     "360° continuous pan",
     "SureVision 4.0 WDR",
     "analytics-ready",
-    "autotracking",
     "preset tours"
   ],
   "release_year": 2022,

--- a/cameras/pelco/spectra-enhanced-7-s7230l-ew1.md
+++ b/cameras/pelco/spectra-enhanced-7-s7230l-ew1.md
@@ -24,7 +24,6 @@
 - 360° continuous pan
 - SureVision 4.0 WDR
 - analytics-ready
-- autotracking
 - preset tours
 
 ## Sources

--- a/cameras/pelco/spectra-enhanced-7-s7240l-ew1.json
+++ b/cameras/pelco/spectra-enhanced-7-s7240l-ew1.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 300
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) / 24VAC"
   },
@@ -46,7 +49,6 @@
     "360° continuous pan",
     "SureVision 4.0 WDR",
     "analytics-ready",
-    "autotracking",
     "preset tours"
   ],
   "release_year": 2022,

--- a/cameras/pelco/spectra-enhanced-7-s7240l-ew1.md
+++ b/cameras/pelco/spectra-enhanced-7-s7240l-ew1.md
@@ -24,7 +24,6 @@
 - 360° continuous pan
 - SureVision 4.0 WDR
 - analytics-ready
-- autotracking
 - preset tours
 
 ## Sources

--- a/cameras/pelco/spectra-professional-4k-s6230-fwl1.json
+++ b/cameras/pelco/spectra-professional-4k-s6230-fwl1.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 250
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) / 24VAC"
   },
@@ -46,7 +49,6 @@
     "360° continuous pan",
     "SureVision WDR",
     "analytics-ready",
-    "autotracking",
     "H.265 compression"
   ],
   "release_year": 2023,

--- a/cameras/pelco/spectra-professional-4k-s6230-fwl1.md
+++ b/cameras/pelco/spectra-professional-4k-s6230-fwl1.md
@@ -24,7 +24,6 @@
 - 360° continuous pan
 - SureVision WDR
 - analytics-ready
-- autotracking
 - H.265 compression
 
 ## Sources

--- a/cameras/reolink/altas-go-pt.json
+++ b/cameras/reolink/altas-go-pt.json
@@ -23,6 +23,9 @@
     "type": "hybrid",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (20000mAh) / solar panel"
   },
@@ -42,7 +45,6 @@
     "battery-powered (20000mAh) + solar option",
     "4G LTE",
     "355deg pan / 90deg tilt",
-    "auto-tracking",
     "ColorX hybrid night vision",
     "10-second pre-recording",
     "person/vehicle/animal detection",

--- a/cameras/reolink/altas-go-pt.md
+++ b/cameras/reolink/altas-go-pt.md
@@ -22,7 +22,6 @@
 - battery-powered (20000mAh) + solar option
 - 4G LTE
 - 355deg pan / 90deg tilt
-- auto-tracking
 - ColorX hybrid night vision
 - 10-second pre-recording
 - person/vehicle/animal detection

--- a/cameras/reolink/altas-pt-ultra.json
+++ b/cameras/reolink/altas-pt-ultra.json
@@ -17,6 +17,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"
   },

--- a/cameras/reolink/argus-pt-ultra.json
+++ b/cameras/reolink/argus-pt-ultra.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery / solar optional"
   },

--- a/cameras/reolink/e1-outdoor-cx.json
+++ b/cameras/reolink/e1-outdoor-cx.json
@@ -18,6 +18,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -41,7 +44,6 @@
     "2K ColorX WiFi outdoor F1.0 1/1.8\" sensor",
     "true color night vision no IR",
     "person/vehicle/animal AI",
-    "auto-tracking",
     "ONVIF/RTSP",
     "IP65",
     "Alexa/Google",

--- a/cameras/reolink/e1-outdoor-cx.md
+++ b/cameras/reolink/e1-outdoor-cx.md
@@ -24,7 +24,6 @@
 - 2K ColorX WiFi outdoor F1.0 1/1.8" sensor
 - true color night vision no IR
 - person/vehicle/animal AI
-- auto-tracking
 - ONVIF/RTSP
 - IP65
 - Alexa/Google

--- a/cameras/reolink/e1-outdoor-poe.json
+++ b/cameras/reolink/e1-outdoor-poe.json
@@ -24,6 +24,9 @@
     "type": "hybrid",
     "range_m": 12
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -46,7 +49,6 @@
   "features": [
     "355deg pan / 50deg tilt",
     "3x optical zoom",
-    "auto-tracking",
     "compact low-profile body",
     "person/vehicle/animal detection",
     "no subscription"

--- a/cameras/reolink/e1-outdoor-poe.md
+++ b/cameras/reolink/e1-outdoor-poe.md
@@ -23,7 +23,6 @@
 
 - 355deg pan / 50deg tilt
 - 3x optical zoom
-- auto-tracking
 - compact low-profile body
 - person/vehicle/animal detection
 - no subscription

--- a/cameras/reolink/e1-outdoor-pro.json
+++ b/cameras/reolink/e1-outdoor-pro.json
@@ -25,6 +25,9 @@
     "type": "hybrid",
     "range_m": 12
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/1A"
   },
@@ -48,7 +51,6 @@
     "3x optical zoom",
     "4K UHD",
     "person/vehicle/animal detection",
-    "auto-tracking",
     "355° pan / 50° tilt",
     "color night vision",
     "WiFi 6",

--- a/cameras/reolink/e1-outdoor-pro.md
+++ b/cameras/reolink/e1-outdoor-pro.md
@@ -24,7 +24,6 @@
 - 3x optical zoom
 - 4K UHD
 - person/vehicle/animal detection
-- auto-tracking
 - 355° pan / 50° tilt
 - color night vision
 - WiFi 6

--- a/cameras/reolink/e1-outdoor-se-poe.json
+++ b/cameras/reolink/e1-outdoor-se-poe.json
@@ -23,6 +23,9 @@
     "type": "hybrid",
     "range_m": 12
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -44,7 +47,6 @@
   },
   "features": [
     "355deg pan / 50deg tilt",
-    "auto-tracking",
     "spotlight color night vision",
     "person/vehicle/animal detection",
     "10x digital zoom",

--- a/cameras/reolink/e1-outdoor-se-poe.md
+++ b/cameras/reolink/e1-outdoor-se-poe.md
@@ -21,7 +21,6 @@
 ## Features
 
 - 355deg pan / 50deg tilt
-- auto-tracking
 - spotlight color night vision
 - person/vehicle/animal detection
 - 10x digital zoom

--- a/cameras/reolink/e1-outdoor-wifi.json
+++ b/cameras/reolink/e1-outdoor-wifi.json
@@ -19,6 +19,9 @@
     "type": "hybrid",
     "range_m": 12
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -45,7 +48,6 @@
     "5MP outdoor WiFi PTZ",
     "355° pan / 50° tilt (64 presets)",
     "3x optical zoom",
-    "auto-tracking",
     "12m IR",
     "person/vehicle/animal detection",
     "ONVIF/RTSP",

--- a/cameras/reolink/e1-outdoor-wifi.md
+++ b/cameras/reolink/e1-outdoor-wifi.md
@@ -24,7 +24,6 @@
 - 5MP outdoor WiFi PTZ
 - 355° pan / 50° tilt (64 presets)
 - 3x optical zoom
-- auto-tracking
 - 12m IR
 - person/vehicle/animal detection
 - ONVIF/RTSP

--- a/cameras/reolink/e1-pro.json
+++ b/cameras/reolink/e1-pro.json
@@ -25,6 +25,9 @@
     "type": "ir",
     "range_m": 12
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 5V/1A"
   },
@@ -48,7 +51,6 @@
     "64 presets",
     "human/pet detection",
     "crying detection",
-    "auto-tracking",
     "dual-band WiFi",
     "no subscription"
   ],

--- a/cameras/reolink/e1-pro.md
+++ b/cameras/reolink/e1-pro.md
@@ -24,7 +24,6 @@
 - 64 presets
 - human/pet detection
 - crying detection
-- auto-tracking
 - dual-band WiFi
 - no subscription
 

--- a/cameras/reolink/go-pt-s-lite.json
+++ b/cameras/reolink/go-pt-s-lite.json
@@ -23,6 +23,9 @@
     "type": "hybrid",
     "range_m": 10
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery / solar panel"
   },
@@ -42,7 +45,6 @@
     "battery-powered + solar option",
     "4G LTE (no WiFi needed)",
     "355deg pan / 140deg tilt",
-    "auto-tracking",
     "person/vehicle/animal detection",
     "PIR + siren",
     "app-only (no RTSP/ONVIF)",

--- a/cameras/reolink/go-pt-s-lite.md
+++ b/cameras/reolink/go-pt-s-lite.md
@@ -22,7 +22,6 @@
 - battery-powered + solar option
 - 4G LTE (no WiFi needed)
 - 355deg pan / 140deg tilt
-- auto-tracking
 - person/vehicle/animal detection
 - PIR + siren
 - app-only (no RTSP/ONVIF)

--- a/cameras/reolink/p830.json
+++ b/cameras/reolink/p830.json
@@ -23,6 +23,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (IEEE 802.3af) / DC 12V",
     "consumption_w": 12
@@ -45,7 +48,6 @@
   },
   "features": [
     "355° pan / 90° tilt",
-    "auto-tracking",
     "32 presets",
     "person/vehicle/animal detection",
     "spotlight + siren",

--- a/cameras/reolink/p830.md
+++ b/cameras/reolink/p830.md
@@ -21,7 +21,6 @@
 ## Features
 
 - 355° pan / 90° tilt
-- auto-tracking
 - 32 presets
 - person/vehicle/animal detection
 - spotlight + siren

--- a/cameras/reolink/rlc-523wa.json
+++ b/cameras/reolink/rlc-523wa.json
@@ -19,6 +19,9 @@
     "type": "hybrid",
     "range_m": 60
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V",
     "voltage": "12V",

--- a/cameras/reolink/rlc-81pa.json
+++ b/cameras/reolink/rlc-81pa.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -48,7 +51,6 @@
   },
   "features": [
     "180deg pan rotation",
-    "auto-tracking",
     "person/vehicle detection",
     "no subscription"
   ],

--- a/cameras/reolink/rlc-81pa.md
+++ b/cameras/reolink/rlc-81pa.md
@@ -24,7 +24,6 @@
 ## Features
 
 - 180deg pan rotation
-- auto-tracking
 - person/vehicle detection
 - no subscription
 

--- a/cameras/reolink/rlc-823a-16x.json
+++ b/cameras/reolink/rlc-823a-16x.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 80
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (IEEE 802.3at) / DC 12V",
     "voltage": "48V (PoE) / 12V (DC)",
@@ -50,7 +53,6 @@
   "features": [
     "16x optical zoom",
     "360° pan / 90° tilt",
-    "auto-tracking (person/vehicle/pet)",
     "person/vehicle/pet detection",
     "IR night vision up to 80m",
     "no subscription required"

--- a/cameras/reolink/rlc-823a-16x.md
+++ b/cameras/reolink/rlc-823a-16x.md
@@ -23,7 +23,6 @@
 
 - 16x optical zoom
 - 360° pan / 90° tilt
-- auto-tracking (person/vehicle/pet)
 - person/vehicle/pet detection
 - IR night vision up to 80m
 - no subscription required

--- a/cameras/reolink/rlc-823a.json
+++ b/cameras/reolink/rlc-823a.json
@@ -37,6 +37,9 @@
     "type": "hybrid",
     "range_m": 60
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (IEEE 802.3at) / DC 12V",
     "voltage": "48V (PoE) / 12V (DC)",
@@ -63,7 +66,6 @@
   "features": [
     "360° pan / 90° tilt",
     "5x optical zoom",
-    "auto-tracking (person/vehicle)",
     "spotlight color night vision",
     "active deterrence siren",
     "person/vehicle/animal detection",

--- a/cameras/reolink/rlc-823a.md
+++ b/cameras/reolink/rlc-823a.md
@@ -23,7 +23,6 @@
 
 - 360° pan / 90° tilt
 - 5x optical zoom
-- auto-tracking (person/vehicle)
 - spotlight color night vision
 - active deterrence siren
 - person/vehicle/animal detection

--- a/cameras/reolink/rlc-823s1.json
+++ b/cameras/reolink/rlc-823s1.json
@@ -27,6 +27,9 @@
     "type": "hybrid",
     "range_m": 60
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3at) / DC 12V",
     "consumption_w": 24
@@ -54,7 +57,6 @@
     "360deg pan / 90deg tilt",
     "5x optical zoom",
     "3D zoom",
-    "auto-tracking",
     "spotlight color night vision",
     "customizable patrol routes",
     "person/vehicle/animal detection",

--- a/cameras/reolink/rlc-823s1.md
+++ b/cameras/reolink/rlc-823s1.md
@@ -26,7 +26,6 @@
 - 360deg pan / 90deg tilt
 - 5x optical zoom
 - 3D zoom
-- auto-tracking
 - spotlight color night vision
 - customizable patrol routes
 - person/vehicle/animal detection

--- a/cameras/reolink/rlc-823s1w.json
+++ b/cameras/reolink/rlc-823s1w.json
@@ -28,6 +28,9 @@
     "type": "hybrid",
     "range_m": 60
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V",
     "consumption_w": 24
@@ -56,7 +59,6 @@
     "5x optical zoom",
     "3D zoom",
     "360deg pan / 90deg tilt",
-    "auto-tracking",
     "spotlight color night vision",
     "no subscription"
   ],

--- a/cameras/reolink/rlc-823s1w.md
+++ b/cameras/reolink/rlc-823s1w.md
@@ -27,7 +27,6 @@
 - 5x optical zoom
 - 3D zoom
 - 360deg pan / 90deg tilt
-- auto-tracking
 - spotlight color night vision
 - no subscription
 

--- a/cameras/reolink/rlc-830a.json
+++ b/cameras/reolink/rlc-830a.json
@@ -24,6 +24,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V",
     "consumption_w": 12
@@ -45,7 +48,6 @@
   },
   "features": [
     "355deg pan / 90deg tilt",
-    "auto-tracking",
     "spotlight color night vision",
     "person/vehicle/animal detection",
     "no subscription"

--- a/cameras/reolink/rlc-830a.md
+++ b/cameras/reolink/rlc-830a.md
@@ -22,7 +22,6 @@
 ## Features
 
 - 355deg pan / 90deg tilt
-- auto-tracking
 - spotlight color night vision
 - person/vehicle/animal detection
 - no subscription

--- a/cameras/reolink/trackflex-floodlight-wifi.json
+++ b/cameras/reolink/trackflex-floodlight-wifi.json
@@ -26,6 +26,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Hardwired (AC)"
   },

--- a/cameras/reolink/trackmix-lte-c.json
+++ b/cameras/reolink/trackmix-lte-c.json
@@ -23,6 +23,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery (5100mAh) / solar panel"
   },
@@ -43,7 +46,6 @@
     "4G LTE",
     "dual-lens 6x hybrid zoom",
     "355deg pan / 90deg tilt",
-    "auto-tracking",
     "person/vehicle/animal detection",
     "app-only (no RTSP/ONVIF)",
     "no subscription"

--- a/cameras/reolink/trackmix-lte-c.md
+++ b/cameras/reolink/trackmix-lte-c.md
@@ -23,7 +23,6 @@
 - 4G LTE
 - dual-lens 6x hybrid zoom
 - 355deg pan / 90deg tilt
-- auto-tracking
 - person/vehicle/animal detection
 - app-only (no RTSP/ONVIF)
 - no subscription

--- a/cameras/reolink/trackmix-lte-plus.json
+++ b/cameras/reolink/trackmix-lte-plus.json
@@ -24,6 +24,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"
   },
@@ -43,7 +46,6 @@
   "features": [
     "dual-lens",
     "6x hybrid zoom",
-    "auto-tracking",
     "355° pan / 90° tilt",
     "person/vehicle/animal detection",
     "4G LTE",

--- a/cameras/reolink/trackmix-lte-plus.md
+++ b/cameras/reolink/trackmix-lte-plus.md
@@ -22,7 +22,6 @@
 
 - dual-lens
 - 6x hybrid zoom
-- auto-tracking
 - 355° pan / 90° tilt
 - person/vehicle/animal detection
 - 4G LTE

--- a/cameras/reolink/trackmix-lte.json
+++ b/cameras/reolink/trackmix-lte.json
@@ -18,6 +18,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"
   },

--- a/cameras/reolink/trackmix-poe.json
+++ b/cameras/reolink/trackmix-poe.json
@@ -24,6 +24,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE (IEEE 802.3af, 48V active) / DC 12V/2A",
     "consumption_w": 12,
@@ -50,7 +53,6 @@
   },
   "features": [
     "dual-lens dual-view",
-    "auto-tracking",
     "6x hybrid zoom",
     "355° pan / 90° tilt",
     "person/vehicle/animal detection",

--- a/cameras/reolink/trackmix-poe.md
+++ b/cameras/reolink/trackmix-poe.md
@@ -22,7 +22,6 @@
 ## Features
 
 - dual-lens dual-view
-- auto-tracking
 - 6x hybrid zoom
 - 355° pan / 90° tilt
 - person/vehicle/animal detection

--- a/cameras/reolink/trackmix-wifi.json
+++ b/cameras/reolink/trackmix-wifi.json
@@ -25,6 +25,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V/2A"
   },
@@ -47,7 +50,6 @@
   },
   "features": [
     "dual-lens dual-view",
-    "auto-tracking",
     "6x hybrid zoom",
     "355° pan / 90° tilt",
     "Wi-Fi 6 dual-band",

--- a/cameras/reolink/trackmix-wifi.md
+++ b/cameras/reolink/trackmix-wifi.md
@@ -22,7 +22,6 @@
 ## Features
 
 - dual-lens dual-view
-- auto-tracking
 - 6x hybrid zoom
 - 355° pan / 90° tilt
 - Wi-Fi 6 dual-band

--- a/cameras/speco/speco-o4p25x2.json
+++ b/cameras/speco/speco-o4p25x2.json
@@ -37,6 +37,9 @@
     "type": "ir",
     "range_m": 120
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) or 24V AC/DC (power supply included)",
     "consumption_w": 34
@@ -58,7 +61,6 @@
   },
   "features": [
     "25x optical zoom, endless (360-degree continuous) panning, -3 to 90 degree tilt",
-    "Smart Tracking (auto-tracking)",
     "ONVIF Profile G, S, and T conformant",
     "line crossing, video blurring/tamper detection, human/vehicle detection",
     "face detection and recognition (requires a compatible Speco recorder)",
@@ -74,7 +76,7 @@
     "indoor",
     "outdoor"
   ],
-  "release_notes": "Discontinued (this generation superseded prior O4P25X/O4P30X models before itself being discontinued) \u2014 check specotech.com for the current-generation PTZ replacement before recommending for a new install.",
+  "release_notes": "Discontinued (this generation superseded prior O4P25X/O4P30X models before itself being discontinued) — check specotech.com for the current-generation PTZ replacement before recommending for a new install.",
   "sources": [
     "https://www.specotech.com/wp-content/uploads/2023/07/O4P25X2_spec.pdf",
     "https://www.bhphotovideo.com/c/product/1767729-REG/speco_technologies_o4p25x2_4mp_outdoor_ptz.html",
@@ -84,7 +86,7 @@
   "status": "discontinued",
   "configs": {
     "frigate": {
-      "notes": "ONVIF Profile G/S/T conformance confirmed via an official Speco spec sheet PDF. The official spec sheet explicitly notes 'Visit specotech.com for latest ONVIF support' \u2014 worth checking current firmware notes given ONVIF stacks are sometimes revised. Exact RTSP URL path not found; use ONVIF auto-discovery.",
+      "notes": "ONVIF Profile G/S/T conformance confirmed via an official Speco spec sheet PDF. The official spec sheet explicitly notes 'Visit specotech.com for latest ONVIF support' — worth checking current firmware notes given ONVIF stacks are sometimes revised. Exact RTSP URL path not found; use ONVIF auto-discovery.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/speco/speco-o4p25x2.md
+++ b/cameras/speco/speco-o4p25x2.md
@@ -23,7 +23,6 @@
 ## Features
 
 - 25x optical zoom, endless (360-degree continuous) panning, -3 to 90 degree tilt
-- Smart Tracking (auto-tracking)
 - ONVIF Profile G, S, and T conformant
 - line crossing, video blurring/tamper detection, human/vehicle detection
 - face detection and recognition (requires a compatible Speco recorder)

--- a/cameras/sv3c/c12.json
+++ b/cameras/sv3c/c12.json
@@ -22,6 +22,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V",
     "consumption_w": 12
@@ -43,7 +46,6 @@
   },
   "features": [
     "15x optical zoom",
-    "auto-tracking",
     "floodlight color night vision (12 IR LEDs)",
     "two-way audio",
     "metal dome shell",

--- a/cameras/sv3c/c12.md
+++ b/cameras/sv3c/c12.md
@@ -19,7 +19,6 @@
 ## Features
 
 - 15x optical zoom
-- auto-tracking
 - floodlight color night vision (12 IR LEDs)
 - two-way audio
 - metal dome shell

--- a/cameras/sv3c/c22-4k.json
+++ b/cameras/sv3c/c22-4k.json
@@ -34,6 +34,9 @@
     "type": "ir",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "12V DC (Wi-Fi data)"
   },

--- a/cameras/sv3c/c25.json
+++ b/cameras/sv3c/c25.json
@@ -16,6 +16,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -38,7 +41,6 @@
   "features": [
     "36x hybrid zoom (18x optical + 18x digital)",
     "350° pan / 93° tilt",
-    "auto-tracking",
     "people/vehicle/pet detection",
     "color night vision (9 IR LEDs)",
     "two-way audio",

--- a/cameras/sv3c/c25.md
+++ b/cameras/sv3c/c25.md
@@ -22,7 +22,6 @@
 
 - 36x hybrid zoom (18x optical + 18x digital)
 - 350° pan / 93° tilt
-- auto-tracking
 - people/vehicle/pet detection
 - color night vision (9 IR LEDs)
 - two-way audio

--- a/cameras/sv3c/ptz-4k-dual-network.json
+++ b/cameras/sv3c/ptz-4k-dual-network.json
@@ -14,6 +14,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE / DC 12V"
   },
@@ -35,7 +38,6 @@
     "pan/tilt/zoom",
     "4K 8MP",
     "dual network (PoE + WiFi)",
-    "auto-tracking",
     "human/vehicle detection",
     "color night vision",
     "RTSP",

--- a/cameras/sv3c/ptz-4k-dual-network.md
+++ b/cameras/sv3c/ptz-4k-dual-network.md
@@ -19,7 +19,6 @@
 - pan/tilt/zoom
 - 4K 8MP
 - dual network (PoE + WiFi)
-- auto-tracking
 - human/vehicle detection
 - color night vision
 - RTSP

--- a/cameras/sv3c/ptz-5mp-wifi-5x.json
+++ b/cameras/sv3c/ptz-5mp-wifi-5x.json
@@ -13,6 +13,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC 12V"
   },
@@ -34,7 +37,6 @@
   "features": [
     "5MP WiFi PTZ",
     "5x optical zoom",
-    "auto-tracking",
     "spotlight color night vision",
     "IP66",
     "RTSP"

--- a/cameras/sv3c/ptz-5mp-wifi-5x.md
+++ b/cameras/sv3c/ptz-5mp-wifi-5x.md
@@ -18,7 +18,6 @@
 
 - 5MP WiFi PTZ
 - 5x optical zoom
-- auto-tracking
 - spotlight color night vision
 - IP66
 - RTSP

--- a/cameras/sv3c/ptz-poe-15x.json
+++ b/cameras/sv3c/ptz-poe-15x.json
@@ -13,6 +13,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE / DC 12V"
   },
@@ -31,7 +34,6 @@
   },
   "features": [
     "15x optical zoom",
-    "auto-tracking",
     "floodlight color night vision",
     "RTSP",
     "FTP",

--- a/cameras/sv3c/ptz-poe-15x.md
+++ b/cameras/sv3c/ptz-poe-15x.md
@@ -16,7 +16,6 @@
 ## Features
 
 - 15x optical zoom
-- auto-tracking
 - floodlight color night vision
 - RTSP
 - FTP

--- a/cameras/sv3c/solar-dual-lens-2k.json
+++ b/cameras/sv3c/solar-dual-lens-2k.json
@@ -14,6 +14,9 @@
   "night_vision": {
     "type": "color"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "Solar panel / rechargeable battery"
   },
@@ -32,7 +35,6 @@
     "2K dual-lens",
     "solar powered",
     "360° pan/tilt",
-    "auto-tracking",
     "color night vision",
     "no subscription",
     "4-camera kit"

--- a/cameras/sv3c/solar-dual-lens-2k.md
+++ b/cameras/sv3c/solar-dual-lens-2k.md
@@ -19,7 +19,6 @@
 - 2K dual-lens
 - solar powered
 - 360° pan/tilt
-- auto-tracking
 - color night vision
 - no subscription
 - 4-camera kit

--- a/cameras/tiandy/tc-h326m.json
+++ b/cameras/tiandy/tc-h326m.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / DC 12V"
   },
@@ -46,7 +49,6 @@
     "25x optical zoom",
     "360° continuous pan",
     "Starlight sensor",
-    "autotracking",
     "H.265+ compression",
     "preset tours"
   ],

--- a/cameras/tiandy/tc-h326m.md
+++ b/cameras/tiandy/tc-h326m.md
@@ -23,7 +23,6 @@
 - 25x optical zoom
 - 360° continuous pan
 - Starlight sensor
-- autotracking
 - H.265+ compression
 - preset tours
 

--- a/cameras/tiandy/tc-h388m.json
+++ b/cameras/tiandy/tc-h388m.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 200
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++ (IEEE 802.3bt) / AC 24V"
   },
@@ -46,7 +49,6 @@
     "30x optical zoom",
     "360° continuous pan",
     "Starlight sensor",
-    "autotracking",
     "H.265+ compression",
     "smart IR"
   ],

--- a/cameras/tiandy/tc-h388m.md
+++ b/cameras/tiandy/tc-h388m.md
@@ -23,7 +23,6 @@
 - 30x optical zoom
 - 360° continuous pan
 - Starlight sensor
-- autotracking
 - H.265+ compression
 - smart IR
 

--- a/cameras/tvt/td-8423is-a.json
+++ b/cameras/tvt/td-8423is-a.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / DC 12V"
   },
@@ -46,7 +49,6 @@
     "360° pan / 90° tilt",
     "20x optical zoom",
     "smart IR",
-    "auto-tracking",
     "H.265 compression"
   ],
   "release_year": 2020,

--- a/cameras/tvt/td-8423is-a.md
+++ b/cameras/tvt/td-8423is-a.md
@@ -23,7 +23,6 @@
 - 360° pan / 90° tilt
 - 20x optical zoom
 - smart IR
-- auto-tracking
 - H.265 compression
 
 ## Sources

--- a/cameras/tvt/td-8443is-a.json
+++ b/cameras/tvt/td-8443is-a.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 100
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / DC 12V"
   },
@@ -46,7 +49,6 @@
     "360° pan / 90° tilt",
     "25x optical zoom",
     "smart IR",
-    "auto-tracking",
     "H.265 compression"
   ],
   "release_year": 2021,

--- a/cameras/tvt/td-8443is-a.md
+++ b/cameras/tvt/td-8443is-a.md
@@ -23,7 +23,6 @@
 - 360° pan / 90° tilt
 - 25x optical zoom
 - smart IR
-- auto-tracking
 - H.265 compression
 
 ## Sources

--- a/cameras/tvt/td-8483is-a.json
+++ b/cameras/tvt/td-8483is-a.json
@@ -23,6 +23,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / DC 24V"
   },
@@ -46,7 +49,6 @@
     "360° pan / 90° tilt",
     "25x optical zoom",
     "smart IR",
-    "auto-tracking",
     "face detection",
     "H.265 compression",
     "defog"

--- a/cameras/tvt/td-8483is-a.md
+++ b/cameras/tvt/td-8483is-a.md
@@ -23,7 +23,6 @@
 - 360° pan / 90° tilt
 - 25x optical zoom
 - smart IR
-- auto-tracking
 - face detection
 - H.265 compression
 - defog

--- a/cameras/ubiquiti/g4-ptz.json
+++ b/cameras/ubiquiti/g4-ptz.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 91
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE++, 42.5-57V DC; 42.9W max"
   },
@@ -51,8 +54,7 @@
     "IR night vision up to 91m (corrected from a rounded 100m)",
     "Ambarella S5L66 processor",
     "PoE++ powered",
-    "UniFi Protect ecosystem",
-    "auto-tracking"
+    "UniFi Protect ecosystem"
   ],
   "sources": [
     "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-ptz",

--- a/cameras/ubiquiti/g4-ptz.md
+++ b/cameras/ubiquiti/g4-ptz.md
@@ -28,7 +28,6 @@
 - Ambarella S5L66 processor
 - PoE++ powered
 - UniFi Protect ecosystem
-- auto-tracking
 
 ## Sources
 

--- a/cameras/ubiquiti/g6-ptz.json
+++ b/cameras/ubiquiti/g6-ptz.json
@@ -27,6 +27,9 @@
     "type": "ir",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE+, 42.5-57V DC; 24.5W max"
   },
@@ -51,7 +54,6 @@
     "dual-camera design: separate wide-angle and tele (zoom) sensors/lenses, 10x hybrid zoom -- corrected from a fabricated single-sensor 22x optical / 5-185mm spec and a fabricated 150m IR range",
     "pan 350 degrees, tilt 100 degrees (not full 360-degree endless pan)",
     "face recognition, license plate recognition",
-    "auto-tracking",
     "UniFi Protect ecosystem",
     "IK04 tamper resistance",
     "MicroSD card expansion slot",

--- a/cameras/ubiquiti/g6-ptz.md
+++ b/cameras/ubiquiti/g6-ptz.md
@@ -26,7 +26,6 @@
 - dual-camera design: separate wide-angle and tele (zoom) sensors/lenses, 10x hybrid zoom -- corrected from a fabricated single-sensor 22x optical / 5-185mm spec and a fabricated 150m IR range
 - pan 350 degrees, tilt 100 degrees (not full 360-degree endless pan)
 - face recognition, license plate recognition
-- auto-tracking
 - UniFi Protect ecosystem
 - IK04 tamper resistance
 - MicroSD card expansion slot

--- a/cameras/uniarch/uniarch-uho-p1a-m3f4d.json
+++ b/cameras/uniarch/uniarch-uho-p1a-m3f4d.json
@@ -33,6 +33,9 @@
     "type": "ir",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC power adapter"
   },
@@ -66,7 +69,7 @@
   "status": "available",
   "configs": {
     "frigate": {
-      "notes": "ONVIF support and exact RTSP path not confirmed for this specific model \u2014 not found on iSpyConnect's crowd-sourced Uniarch table. Needs direct verification before publishing.",
+      "notes": "ONVIF support and exact RTSP path not confirmed for this specific model — not found on iSpyConnect's crowd-sourced Uniarch table. Needs direct verification before publishing.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/uniarch/uniarch-uho-s2e.json
+++ b/cameras/uniarch/uniarch-uho-s2e.json
@@ -20,6 +20,9 @@
   "night_vision": {
     "type": "ir"
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "DC power adapter"
   },

--- a/cameras/vigi/c540v.json
+++ b/cameras/vigi/c540v.json
@@ -55,6 +55,9 @@
     "type": "hybrid",
     "range_m": 30
   },
+  "ptz": {
+    "autotracking": true
+  },
   "power": {
     "method": "PoE / DC",
     "consumption_w": 16,
@@ -83,7 +86,6 @@
     "pan-tilt",
     "3x mixed zoom",
     "instant zoom",
-    "auto-tracking",
     "customized patrol",
     "person detection",
     "vehicle detection",

--- a/cameras/vigi/c540v.md
+++ b/cameras/vigi/c540v.md
@@ -26,7 +26,6 @@
 - pan-tilt
 - 3x mixed zoom
 - instant zoom
-- auto-tracking
 - customized patrol
 - person detection
 - vehicle detection

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -15619,6 +15619,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "field_of_view_deg": "62 - 2.8 horizontal / 36.4 - 1.4 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP67, IK10",
     "weight_g": 2605,
     "operating_temp_c": "-52 to 60",
@@ -15870,6 +15873,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "field_of_view_deg": "62.4 - 3.5 horizontal / 37.6 - 2 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "dimensions_mm": "150 x 170",
     "weight_g": 1574,
     "operating_temp_c": "-20 to 50",
@@ -18110,6 +18116,9 @@
       "type": "ir",
       "range_m": 160
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "170 x 260",
     "weight_g": 3135,
@@ -18243,6 +18252,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 48V / AC 24V / High PoE 60W; 50 W (PoE, heater, fan and IR on), 62 W (AC, heater, fan and IR on)"
@@ -29420,6 +29432,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "166 x 295",
     "weight_g": 3200,
@@ -29469,6 +29484,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 250
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 24V / AC 24V / High PoE (IEEE 802.3bt); 61 W (PoE)"
@@ -29561,6 +29579,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "AC 24V / DC 24V / PoE Class 5 (IEEE 802.3bt); 58 W (PoE)"
@@ -29692,6 +29713,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "field_of_view_deg": "51.4 - 2.5 horizontal / 30.3 - 1.4 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "218 x 297",
     "weight_g": 4070,
@@ -29782,6 +29806,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "227 x 384.8",
     "weight_g": 5280,
@@ -29871,6 +29898,9 @@
       "type": "ir",
       "range_m": 120
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "162 x 293",
     "operating_temp_c": "-40 to 65",
@@ -29919,6 +29949,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 120
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V / High PoE (IEEE 802.3at); 23 W (PoE)"
@@ -34735,6 +34768,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V"
@@ -41740,6 +41776,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt)"
     },
@@ -42931,6 +42970,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt)"
     },
@@ -43032,6 +43074,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt) / 3-axis multi-connector cable"
     },
@@ -43058,7 +43103,6 @@
       "Zipstream H.265",
       "Axis Edge Vault TPM cybersecurity (FIPS 140-2 Level 2)",
       "sharpdome design (20deg above horizon)",
-      "auto-tracking",
       "used in NEOM/smart city Saudi Arabia & UAE critical infra"
     ],
     "sources": [
@@ -43117,6 +43161,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 300
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3bt)"
@@ -43206,6 +43253,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 300
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3bt)"
@@ -47686,6 +47736,9 @@
     "night_vision": {
       "type": "none"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (High PoE) via single Ethernet cable"
     },
@@ -47708,7 +47761,7 @@
       "Thermal frame rate 30 Hz",
       "Metadata fusion combining thermal and optical object detection in one view",
       "Bosch Intelligent Video Analytics (IVA)",
-      "Intelligent on-board video tracking / auto-tracking",
+      "Intelligent on-board video tracking",
       "360 degree endless pan, full PTZ",
       "Object detection up to ~4517 m (DRI criteria)",
       "Audio support",
@@ -65698,6 +65751,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -65722,7 +65778,6 @@
       "WizMind 4MP 25x Starlight PTZ",
       "face detection",
       "perimeter protection",
-      "auto-tracking",
       "H.265+",
       "IP66",
       "100m IR"
@@ -65788,6 +65843,9 @@
       "type": "ir",
       "range_m": 550
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (802.3bt) / AC 24V"
     },
@@ -65810,7 +65868,6 @@
     "features": [
       "45x optical zoom PTZ",
       "Starlight low-light sensor",
-      "AI auto-tracking",
       "face detection",
       "perimeter protection",
       "550m laser range",
@@ -65881,6 +65938,9 @@
       "type": "hybrid",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 36V/2.23A (±25%)",
       "consumption_w": 35,
@@ -65904,7 +65964,6 @@
       "dual-channel: 180° panoramic 4MP stitched + 4MP PTZ 25x zoom",
       "starlight 0.001 lux color @F1.0",
       "150m IR (PTZ) + 30m white light (panoramic)",
-      "auto-tracking (single-ball tracking)",
       "face detection with attributes (6 attributes, 8 expressions)",
       "9 IVS rules: tripwire, intrusion, loitering, parking, crowd",
       "human/vehicle classification",
@@ -78206,6 +78265,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -78295,6 +78357,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 21,
@@ -78320,7 +78385,6 @@
       "25x optical zoom",
       "Starlight",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78372,6 +78436,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at)"
     },
@@ -78395,7 +78462,6 @@
       "pan/tilt/zoom",
       "WizMind 4K 8MP 25x PTZ SMD 4.0",
       "face recognition",
-      "auto-tracking",
       "100m IR",
       "H.265+",
       "IP66"
@@ -78470,6 +78536,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78495,7 +78564,6 @@
       "25x optical zoom",
       "Smart Dual Light",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78559,6 +78627,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78584,7 +78655,6 @@
       "25x optical zoom",
       "Smart Dual Light",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78648,6 +78718,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78674,7 +78747,6 @@
       "Smart Dual Light",
       "WizSense",
       "4K PTZ",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78735,6 +78807,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V"
     },
@@ -78759,7 +78834,6 @@
       "WizSense AI",
       "Starlight low-light",
       "SMD Plus",
-      "auto-tracking",
       "IVS analytics",
       "H.265",
       "IK10"
@@ -78838,6 +78912,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 150
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "24VAC / PoE+ (802.3at)",
@@ -78933,6 +79010,9 @@
     "night_vision": {
       "type": "hybrid"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
     },
@@ -79018,6 +79098,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
@@ -79110,6 +79193,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 8
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "9400mAh battery + 5W solar panel"
@@ -79969,6 +80055,9 @@
       "type": "color",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Quick-swap 10000mAh battery + 5.5W SolarPlus 2.0 panel"
     },
@@ -80776,6 +80865,9 @@
       "type": "ir",
       "range_m": 8
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "5V/1A (USB, plug-in)"
     },
@@ -80847,6 +80939,9 @@
     "night_vision": {
       "type": "ir"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "micro-USB"
     },
@@ -80868,7 +80963,6 @@
       "person detection",
       "pet detection",
       "crying detection",
-      "auto-tracking",
       "privacy mode",
       "360 pan / 75 tilt (no HomeKit)"
     ],
@@ -81007,6 +81101,9 @@
       "type": "hybrid",
       "range_m": 5
     },
+    "ptz": {
+      "autotracking": true
+    },
     "storage": {
       "onboard": true,
       "max_microsd_gb": 128,
@@ -81144,6 +81241,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V (USB-C, hardwired)"
     },
@@ -81164,7 +81264,6 @@
     "features": [
       "4K dual-lens indoor pan/tilt",
       "8x hybrid zoom (3x optical tele)",
-      "AI auto-tracking",
       "on-device human/pet/crying detection",
       "color night vision + IR",
       "no subscription",
@@ -81548,6 +81647,9 @@
     "field_of_view_deg": "360 pan / 70 tilt",
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "storage": {
       "onboard": true,
@@ -81967,6 +82069,9 @@
     "field_of_view_deg": "135",
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Adjustable/removable 2.2W solar panel + built-in rechargeable battery"
@@ -83523,6 +83628,9 @@
       "type": "ir",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/1A (Micro USB)"
     },
@@ -83550,7 +83658,6 @@
     "features": [
       "340deg pan/55deg tilt indoor camera",
       "AI person detection",
-      "auto-tracking",
       "EZVIZ App",
       "Alexa / Google / Hikvision NVR compatible",
       "RTSP (manual app enable) / ONVIF (firmware >= V5.3.2 build 231228)",
@@ -83821,6 +83928,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A (max 6W, outdoor adapter)"
     },
@@ -83849,7 +83959,6 @@
       "AI person detection",
       "spotlight color night vision",
       "strobe light deterrence",
-      "auto-tracking",
       "Alexa / Google",
       "no officially confirmed RTSP/ONVIF -- official datasheet lists only 'EZVIZ Cloud Proprietary Protocol'"
     ],
@@ -84039,6 +84148,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V adapter (RJ45 Ethernet port is data-only, no PoE)"
     },
@@ -84065,7 +84177,6 @@
       "outdoor pan/tilt WiFi",
       "F1.6 color night vision 30m",
       "AI person/vehicle detection",
-      "auto-tracking",
       "dual spotlights",
       "sound + light deterrence",
       "no officially confirmed RTSP/ONVIF -- official docs list only 'EZVIZ Cloud Proprietary Protocol'",
@@ -84846,6 +84957,9 @@
       "type": "hybrid",
       "range_m": 15
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (EZVIZ Solar Panel, Type-C versions)"
     },
@@ -85050,6 +85164,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V/1A (Type-C)"
@@ -85675,6 +85792,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 15
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (8W IP65 solar panel, sold separately)"
@@ -87061,6 +87181,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A (outdoor adapter)"
     },
@@ -87089,7 +87212,6 @@
       "1080p outdoor pan/tilt",
       "dual spotlights color night vision",
       "AI person/vehicle detection",
-      "auto-tracking",
       "strobe deterrence",
       "RTSP / ONVIF (official ONVIF compatibility FAQ lists H8c firmware builds)",
       "Alexa / Google"
@@ -87158,6 +87280,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A"
@@ -87432,6 +87557,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A (max 12W)"
@@ -87774,6 +87902,9 @@
       "type": "hybrid",
       "range_m": 40
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1.5A (max 12W)"
     },
@@ -87908,6 +88039,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 15
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter; solar-compatible (EZVIZ Solar Panel, optional)"
@@ -88179,6 +88313,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 35
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); kit includes 8W solar panel (Type-C connection); DC 5V/2A adapter (sold separately)"
@@ -89980,6 +90117,9 @@
       "type": "hybrid",
       "range_m": 20
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC"
     },
@@ -90159,6 +90299,9 @@
       "type": "ir",
       "range_m": 8
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/2A",
       "consumption_w": 10,
@@ -90317,6 +90460,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/4A",
       "consumption_w": 30,
@@ -90411,6 +90557,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 50
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) or DC 12V/2A",
@@ -90507,6 +90656,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 50
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/2A",
@@ -91811,6 +91963,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / AC 24V"
     },
@@ -91833,7 +91988,6 @@
     "features": [
       "22x optical zoom",
       "360° continuous pan",
-      "autotracking",
       "H.265 compression",
       "preset tours"
     ],
@@ -91890,6 +92044,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / AC 24V"
     },
@@ -91912,7 +92069,6 @@
     "features": [
       "25x optical zoom",
       "360° continuous pan",
-      "autotracking",
       "H.265 compression",
       "preset tours",
       "WDR"
@@ -94151,6 +94307,9 @@
     "night_vision": {
       "type": "none"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "HPoE (IEEE 802.3bt, Class 8), injector included",
       "consumption_w": 65,
@@ -94378,6 +94537,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 4, Class 8)",
@@ -97511,6 +97673,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 3, Class 6)",
       "consumption_w": 42,
@@ -99668,6 +99833,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / AC 24V / DC 24V"
     },
@@ -99690,7 +99858,7 @@
       "200m Smart IR",
       "360 presets, 8 patrol patterns",
       "endless 360 pan",
-      "auto-tracking / object detection",
+      "object detection",
       "120dB WDR",
       "snow-removing (defog)",
       "ICR day/night"
@@ -100082,6 +100250,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC / PoE"
     },
@@ -100104,7 +100275,6 @@
       "150m Smart IR (850nm)",
       "1024 presets",
       "endless 360 pan",
-      "auto tracking",
       "line-crossing / intrusion / area analytics",
       "120dB optical WDR",
       "two-way audio",
@@ -135087,6 +135257,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V / PoE"
     },
@@ -135583,6 +135756,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -135868,6 +136044,9 @@
     "night_vision": {
       "type": "color",
       "range_m": 40
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136371,6 +136550,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
       "voltage": "12V (DC) / PoE+"
@@ -136466,6 +136648,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -136491,7 +136676,6 @@
       "AcuSense",
       "IP66",
       "H.265+",
-      "auto-tracking",
       "very popular commercial India PTZ",
       "₹25,000–35,000"
     ],
@@ -136649,6 +136833,9 @@
     },
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE / 12 VDC"
@@ -136926,6 +137113,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -136948,7 +137138,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking",
       "IR to 50m (850nm)",
       "120dB WDR",
       "3D positioning",
@@ -137014,6 +137203,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
     },
@@ -137036,7 +137228,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking",
       "IR to 50m (850nm, smart supplement)",
       "120dB WDR",
       "3D positioning",
@@ -137109,6 +137300,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
     },
@@ -137134,7 +137328,6 @@
       "50m IR",
       "H.265+",
       "IP66",
-      "auto-tracking",
       "most affordable Hikvision PoE mini PTZ"
     ],
     "sources": [
@@ -137283,6 +137476,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V"
     },
@@ -137363,6 +137559,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
     },
@@ -137385,7 +137584,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "powered-by-DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "face capture, regional people counting",
       "IR to 50m (850nm)",
       "120dB WDR",
@@ -137661,6 +137859,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V"
     },
@@ -137736,6 +137937,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at)"
     },
@@ -137760,10 +137964,8 @@
       "4MP 25x PTZ DeepinView",
       "100m IR",
       "AcuSense AI",
-      "auto-tracking",
       "H.265+",
-      "IP66",
-      "smart tracking"
+      "IP66"
     ],
     "sources": [
       "https://www.hikvision.com/en/products/"
@@ -137926,6 +138128,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -137949,7 +138154,6 @@
       "AcuSense human/vehicle classification",
       "active deterrence strobe + audible warning to 100m",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138014,6 +138218,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138037,7 +138244,6 @@
       "AcuSense human/vehicle classification",
       "arrayed dual-mic two-way audio",
       "white-light + audible audio-visual alarm",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138206,6 +138412,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138229,7 +138438,6 @@
       "AcuSense human/vehicle classification",
       "active deterrence strobe + audible warning to 100m",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138294,6 +138502,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt Type3) / 36 VDC"
     },
@@ -138318,7 +138529,6 @@
       "arrayed dual-mic (8m) + speaker (30m)",
       "audio-visual alarm (white-light flash + audible)",
       "IR up to 200m",
-      "auto-tracking",
       "300 presets",
       "regional people counting",
       "360 VR panoramic view",
@@ -138384,6 +138594,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138408,7 +138621,6 @@
       "active deterrence: sound + strobe light to 100m",
       "IR up to 200m (850nm)",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "face capture",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138478,6 +138690,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3at) / AC 24V"
@@ -138664,6 +138879,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 36 VDC"
     },
@@ -138686,7 +138904,6 @@
       "pan/tilt: pan 360 / tilt -15 to 90",
       "powered-by-DarkFighter + HIK AI-ISP",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "active deterrence: white-light flash + audible warning",
       "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
       "IR to 200m",
@@ -138753,6 +138970,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 36 VDC"
     },
@@ -138775,7 +138995,6 @@
       "pan/tilt: pan 360 / tilt -15 to 90",
       "powered-by-DarkFighter + HIK AI-ISP",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "active deterrence: white-light flash + audible warning",
       "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
       "IR to 200m",
@@ -139098,6 +139317,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
@@ -139446,6 +139668,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 400
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 4, Class 8, 90W) / 36VDC",
@@ -141637,6 +141862,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -141723,6 +141951,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -141812,6 +142043,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -141897,6 +142131,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -142923,6 +143160,9 @@
       "type": "hybrid",
       "range_m": 20
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "10000mAh battery; DC 5V/2A or optional Imou 5W solar panel; <3.5W"
     },
@@ -142944,7 +143184,6 @@
     "features": [
       "Always-On-Video (AOV) low-power 24/7 recording",
       "AI human detection (>98%)",
-      "auto tracking",
       "siren & spotlight",
       "8x digital zoom",
       "PIR",
@@ -143086,6 +143325,9 @@
       "type": "hybrid",
       "range_m": 25
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "10000mAh battery; DC 5V/2A; sold as a kit with a 5W solar panel"
     },
@@ -143109,7 +143351,6 @@
       "F1.0 large-aperture 'Aurora' lens",
       "AURORA full-color night vision (25m)",
       "AI human detection",
-      "auto tracking",
       "integrated siren",
       "4G LTE + Wi-Fi"
     ],
@@ -144364,6 +144605,9 @@
     "night_vision": {
       "type": "hybrid"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "5000mAh (base) up to 15000mAh battery (up to 280 days); USB-C fast charging; optional 3W/7W solar"
     },
@@ -144767,6 +145011,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -144789,7 +145036,6 @@
     "features": [
       "5MP outdoor pan/tilt color night vision",
       "AI human/vehicle detection",
-      "auto-tracking",
       "smart siren + spotlight deterrence",
       "IP66",
       "H.265",
@@ -144864,6 +145110,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A, <12W"
     },
@@ -144886,7 +145135,6 @@
     "features": [
       "outdoor pan/tilt",
       "8x digital zoom",
-      "auto-tracking",
       "human & vehicle detection",
       "full-color night vision",
       "110 dB siren",
@@ -145022,6 +145270,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A, <12W"
     },
@@ -145046,7 +145297,6 @@
       "full-color night vision",
       "110 dB siren",
       "IMOU SENSE human/vehicle detection",
-      "auto-tracking",
       "Wi-Fi 6",
       "two-way talk"
     ],
@@ -145115,6 +145365,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V, <12W"
     },
@@ -145141,7 +145394,6 @@
       "110 dB siren",
       "spotlight active deterrence",
       "IMOU SENSE human/vehicle detection",
-      "auto-tracking",
       "Wi-Fi 6",
       "two-way talk"
     ],
@@ -145305,6 +145557,9 @@
       "type": "hybrid",
       "range_m": 56
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1.5A or PoE 802.3at, <18W"
     },
@@ -145329,7 +145584,6 @@
       "smart color four-mode night vision",
       "warning lights + 120 dB alarm",
       "AI human/vehicle detection",
-      "auto-tracking",
       "AOR always-on-record",
       "dual microSD slots",
       "dual-band Wi-Fi 6",
@@ -145402,6 +145656,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A"
     },
@@ -145424,7 +145681,6 @@
     "features": [
       "4G LTE pan/tilt",
       "full-color night vision",
-      "auto-tracking",
       "spotlight + 110 dB siren",
       "red-blue warning lights",
       "AI human detection",
@@ -145494,6 +145750,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A"
@@ -145768,6 +146027,9 @@
       "type": "hybrid",
       "range_m": 56
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -145789,7 +146051,6 @@
     },
     "features": [
       "dual-lens 12x mixed zoom (3x optical + 4x digital)",
-      "auto-tracking",
       "IMOU SENSE AI human & vehicle detection",
       "full-color night vision",
       "spotlight/siren active deterrence",
@@ -146021,6 +146282,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V USB"
@@ -146748,6 +147012,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V (USB)"
@@ -154398,6 +154665,9 @@
       "type": "ir",
       "range_m": 220
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "24V AC",
       "voltage": "24V AC / 3A",
@@ -157822,6 +158092,9 @@
       "type": "ir",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/0.62A (max 3.1W) via included power adapter"
     },
@@ -157849,7 +158122,6 @@
     "features": [
       "2K QHD indoor WiFi pan/tilt",
       "ONVIF Profile S confirmed on official datasheet",
-      "auto-tracking",
       "Lorex Home app",
       "Alexa / Google",
       "no monthly fees"
@@ -159000,6 +159272,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12V DC or PoE+"
     },
@@ -159021,7 +159296,6 @@
     "features": [
       "25x optical zoom (5-125mm)",
       "active deterrence: built-in red/blue strobe lights + siren (X-Deterrence)",
-      "auto-tracking",
       "VCA: line crossing, intrusion detection, face detection",
       "MD 2.0 human/vehicle detection",
       "built-in heater for lens defogging",
@@ -159092,6 +159366,9 @@
     },
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "24V AC or High PoE, up to 50W"
@@ -159346,6 +159623,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at)"
     },
@@ -159367,7 +159647,6 @@
     "features": [
       "25x optical zoom",
       "pan/tilt/zoom",
-      "auto-tracking",
       "Control4 integration",
       "preset patrol"
     ],
@@ -163716,6 +163995,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163739,7 +164021,6 @@
       "360° continuous pan",
       "SureVision 4.0 WDR",
       "analytics-ready",
-      "autotracking",
       "preset tours"
     ],
     "release_year": 2022,
@@ -163795,6 +164076,9 @@
       "type": "ir",
       "range_m": 300
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163818,7 +164102,6 @@
       "360° continuous pan",
       "SureVision 4.0 WDR",
       "analytics-ready",
-      "autotracking",
       "preset tours"
     ],
     "release_year": 2022,
@@ -163874,6 +164157,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163897,7 +164183,6 @@
       "360° continuous pan",
       "SureVision WDR",
       "analytics-ready",
-      "autotracking",
       "H.265 compression"
     ],
     "release_year": 2023,
@@ -164310,6 +164595,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (20000mAh) / solar panel"
     },
@@ -164329,7 +164617,6 @@
       "battery-powered (20000mAh) + solar option",
       "4G LTE",
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "ColorX hybrid night vision",
       "10-second pre-recording",
       "person/vehicle/animal detection",
@@ -164383,6 +164670,9 @@
     "field_of_view_deg": "355 pan/90 tilt",
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"
@@ -165759,6 +166049,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery / solar optional"
@@ -168372,6 +168665,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -168395,7 +168691,6 @@
       "2K ColorX WiFi outdoor F1.0 1/1.8\" sensor",
       "true color night vision no IR",
       "person/vehicle/animal AI",
-      "auto-tracking",
       "ONVIF/RTSP",
       "IP65",
       "Alexa/Google",
@@ -168483,6 +168778,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -168505,7 +168803,6 @@
     "features": [
       "355deg pan / 50deg tilt",
       "3x optical zoom",
-      "auto-tracking",
       "compact low-profile body",
       "person/vehicle/animal detection",
       "no subscription"
@@ -168588,6 +168885,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A"
     },
@@ -168611,7 +168911,6 @@
       "3x optical zoom",
       "4K UHD",
       "person/vehicle/animal detection",
-      "auto-tracking",
       "355° pan / 50° tilt",
       "color night vision",
       "WiFi 6",
@@ -168691,6 +168990,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -168712,7 +169014,6 @@
     },
     "features": [
       "355deg pan / 50deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "person/vehicle/animal detection",
       "10x digital zoom",
@@ -168787,6 +169088,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -168813,7 +169117,6 @@
       "5MP outdoor WiFi PTZ",
       "355° pan / 50° tilt (64 presets)",
       "3x optical zoom",
-      "auto-tracking",
       "12m IR",
       "person/vehicle/animal detection",
       "ONVIF/RTSP",
@@ -168903,6 +169206,9 @@
       "type": "ir",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/1A"
     },
@@ -168926,7 +169232,6 @@
       "64 presets",
       "human/pet detection",
       "crying detection",
-      "auto-tracking",
       "dual-band WiFi",
       "no subscription"
     ],
@@ -169882,6 +170187,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery / solar panel"
     },
@@ -169901,7 +170209,6 @@
       "battery-powered + solar option",
       "4G LTE (no WiFi needed)",
       "355deg pan / 140deg tilt",
-      "auto-tracking",
       "person/vehicle/animal detection",
       "PIR + siren",
       "app-only (no RTSP/ONVIF)",
@@ -171030,6 +171337,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3af) / DC 12V",
       "consumption_w": 12
@@ -171052,7 +171362,6 @@
     },
     "features": [
       "355° pan / 90° tilt",
-      "auto-tracking",
       "32 presets",
       "person/vehicle/animal detection",
       "spotlight + siren",
@@ -173218,6 +173527,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "voltage": "12V",
@@ -174206,6 +174518,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -174227,7 +174542,6 @@
     },
     "features": [
       "180deg pan rotation",
-      "auto-tracking",
       "person/vehicle detection",
       "no subscription"
     ],
@@ -174548,6 +174862,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
       "voltage": "48V (PoE) / 12V (DC)",
@@ -174574,7 +174891,6 @@
     "features": [
       "360° pan / 90° tilt",
       "5x optical zoom",
-      "auto-tracking (person/vehicle)",
       "spotlight color night vision",
       "active deterrence siren",
       "person/vehicle/animal detection",
@@ -174657,6 +174973,9 @@
       "type": "ir",
       "range_m": 80
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
       "voltage": "48V (PoE) / 12V (DC)",
@@ -174684,7 +175003,6 @@
     "features": [
       "16x optical zoom",
       "360° pan / 90° tilt",
-      "auto-tracking (person/vehicle/pet)",
       "person/vehicle/pet detection",
       "IR night vision up to 80m",
       "no subscription required"
@@ -174769,6 +175087,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
       "consumption_w": 24
@@ -174796,7 +175117,6 @@
       "360deg pan / 90deg tilt",
       "5x optical zoom",
       "3D zoom",
-      "auto-tracking",
       "spotlight color night vision",
       "customizable patrol routes",
       "person/vehicle/animal detection",
@@ -174883,6 +175203,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "consumption_w": 24
@@ -174911,7 +175234,6 @@
       "5x optical zoom",
       "3D zoom",
       "360deg pan / 90deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "no subscription"
     ],
@@ -175202,6 +175524,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
       "consumption_w": 12
@@ -175223,7 +175548,6 @@
     },
     "features": [
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "person/vehicle/animal detection",
       "no subscription"
@@ -176125,6 +176449,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hardwired (AC)"
     },
@@ -176229,6 +176556,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"
     },
@@ -176319,6 +176649,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (5100mAh) / solar panel"
     },
@@ -176339,7 +176672,6 @@
       "4G LTE",
       "dual-lens 6x hybrid zoom",
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "person/vehicle/animal detection",
       "app-only (no RTSP/ONVIF)",
       "no subscription"
@@ -176399,6 +176731,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"
     },
@@ -176418,7 +176753,6 @@
     "features": [
       "dual-lens",
       "6x hybrid zoom",
-      "auto-tracking",
       "355° pan / 90° tilt",
       "person/vehicle/animal detection",
       "4G LTE",
@@ -176484,6 +176818,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3af, 48V active) / DC 12V/2A",
       "consumption_w": 12,
@@ -176510,7 +176847,6 @@
     },
     "features": [
       "dual-lens dual-view",
-      "auto-tracking",
       "6x hybrid zoom",
       "355° pan / 90° tilt",
       "person/vehicle/animal detection",
@@ -176600,6 +176936,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/2A"
     },
@@ -176622,7 +176961,6 @@
     },
     "features": [
       "dual-lens dual-view",
-      "auto-tracking",
       "6x hybrid zoom",
       "355° pan / 90° tilt",
       "Wi-Fi 6 dual-band",
@@ -179665,6 +180003,9 @@
       "type": "ir",
       "range_m": 120
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) or 24V AC/DC (power supply included)",
       "consumption_w": 34
@@ -179686,7 +180027,6 @@
     },
     "features": [
       "25x optical zoom, endless (360-degree continuous) panning, -3 to 90 degree tilt",
-      "Smart Tracking (auto-tracking)",
       "ONVIF Profile G, S, and T conformant",
       "line crossing, video blurring/tamper detection, human/vehicle detection",
       "face detection and recognition (requires a compatible Speco recorder)",
@@ -182176,6 +182516,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "consumption_w": 12
@@ -182197,7 +182540,6 @@
     },
     "features": [
       "15x optical zoom",
-      "auto-tracking",
       "floodlight color night vision (12 IR LEDs)",
       "two-way audio",
       "metal dome shell",
@@ -182270,6 +182612,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "12V DC (Wi-Fi data)"
@@ -182348,6 +182693,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -182370,7 +182718,6 @@
     "features": [
       "36x hybrid zoom (18x optical + 18x digital)",
       "350° pan / 93° tilt",
-      "auto-tracking",
       "people/vehicle/pet detection",
       "color night vision (9 IR LEDs)",
       "two-way audio",
@@ -182692,6 +183039,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC 12V"
     },
@@ -182713,7 +183063,6 @@
       "pan/tilt/zoom",
       "4K 8MP",
       "dual network (PoE + WiFi)",
-      "auto-tracking",
       "human/vehicle detection",
       "color night vision",
       "RTSP",
@@ -182766,6 +183115,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -182787,7 +183139,6 @@
     "features": [
       "5MP WiFi PTZ",
       "5x optical zoom",
-      "auto-tracking",
       "spotlight color night vision",
       "IP66",
       "RTSP"
@@ -182837,6 +183188,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC 12V"
     },
@@ -182855,7 +183209,6 @@
     },
     "features": [
       "15x optical zoom",
-      "auto-tracking",
       "floodlight color night vision",
       "RTSP",
       "FTP",
@@ -183079,6 +183432,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Solar panel / rechargeable battery"
     },
@@ -183097,7 +183453,6 @@
       "2K dual-lens",
       "solar powered",
       "360° pan/tilt",
-      "auto-tracking",
       "color night vision",
       "no subscription",
       "4-camera kit"
@@ -189532,6 +189887,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189555,7 +189913,6 @@
       "25x optical zoom",
       "360° continuous pan",
       "Starlight sensor",
-      "autotracking",
       "H.265+ compression",
       "preset tours"
     ],
@@ -189614,6 +189971,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / AC 24V"
     },
@@ -189637,7 +189997,6 @@
       "30x optical zoom",
       "360° continuous pan",
       "Starlight sensor",
-      "autotracking",
       "H.265+ compression",
       "smart IR"
     ],
@@ -189695,6 +190054,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189718,7 +190080,6 @@
       "360° pan / 90° tilt",
       "20x optical zoom",
       "smart IR",
-      "auto-tracking",
       "H.265 compression"
     ],
     "release_year": 2020,
@@ -189776,6 +190137,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189799,7 +190163,6 @@
       "360° pan / 90° tilt",
       "25x optical zoom",
       "smart IR",
-      "auto-tracking",
       "H.265 compression"
     ],
     "release_year": 2021,
@@ -189857,6 +190220,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 24V"
     },
@@ -189880,7 +190246,6 @@
       "360° pan / 90° tilt",
       "25x optical zoom",
       "smart IR",
-      "auto-tracking",
       "face detection",
       "H.265 compression",
       "defog"
@@ -191864,6 +192229,9 @@
       "type": "ir",
       "range_m": 91
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++, 42.5-57V DC; 42.9W max"
     },
@@ -191888,8 +192256,7 @@
       "IR night vision up to 91m (corrected from a rounded 100m)",
       "Ambarella S5L66 processor",
       "PoE++ powered",
-      "UniFi Protect ecosystem",
-      "auto-tracking"
+      "UniFi Protect ecosystem"
     ],
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-ptz",
@@ -192446,6 +192813,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+, 42.5-57V DC; 24.5W max"
     },
@@ -192470,7 +192840,6 @@
       "dual-camera design: separate wide-angle and tele (zoom) sensors/lenses, 10x hybrid zoom -- corrected from a fabricated single-sensor 22x optical / 5-185mm spec and a fabricated 150m IR range",
       "pan 350 degrees, tilt 100 degrees (not full 360-degree endless pan)",
       "face recognition, license plate recognition",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "IK04 tamper resistance",
       "MicroSD card expansion slot",
@@ -192879,6 +193248,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC power adapter"
     },
@@ -192948,6 +193320,9 @@
     "field_of_view_deg": "360 pan range (pan/tilt)",
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC power adapter"
@@ -194495,6 +194870,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC",
       "consumption_w": 16,
@@ -194523,7 +194901,6 @@
       "pan-tilt",
       "3x mixed zoom",
       "instant zoom",
-      "auto-tracking",
       "customized patrol",
       "person detection",
       "vehicle detection",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -15619,6 +15619,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "field_of_view_deg": "62 - 2.8 horizontal / 36.4 - 1.4 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP67, IK10",
     "weight_g": 2605,
     "operating_temp_c": "-52 to 60",
@@ -15870,6 +15873,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "field_of_view_deg": "62.4 - 3.5 horizontal / 37.6 - 2 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "dimensions_mm": "150 x 170",
     "weight_g": 1574,
     "operating_temp_c": "-20 to 50",
@@ -18110,6 +18116,9 @@
       "type": "ir",
       "range_m": 160
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "170 x 260",
     "weight_g": 3135,
@@ -18243,6 +18252,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 48V / AC 24V / High PoE 60W; 50 W (PoE, heater, fan and IR on), 62 W (AC, heater, fan and IR on)"
@@ -29420,6 +29432,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "166 x 295",
     "weight_g": 3200,
@@ -29469,6 +29484,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 250
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 24V / AC 24V / High PoE (IEEE 802.3bt); 61 W (PoE)"
@@ -29561,6 +29579,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "AC 24V / DC 24V / PoE Class 5 (IEEE 802.3bt); 58 W (PoE)"
@@ -29692,6 +29713,9 @@
     "last_verified": "2026-07-11",
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "field_of_view_deg": "51.4 - 2.5 horizontal / 30.3 - 1.4 vertical",
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP68, IK10",
     "dimensions_mm": "218 x 297",
     "weight_g": 4070,
@@ -29782,6 +29806,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "227 x 384.8",
     "weight_g": 5280,
@@ -29871,6 +29898,9 @@
       "type": "ir",
       "range_m": 120
     },
+    "ptz": {
+      "autotracking": true
+    },
     "ip_rating": "IP66, IK10",
     "dimensions_mm": "162 x 293",
     "operating_temp_c": "-40 to 65",
@@ -29919,6 +29949,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 120
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V / High PoE (IEEE 802.3at); 23 W (PoE)"
@@ -34735,6 +34768,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V"
@@ -41740,6 +41776,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt)"
     },
@@ -42931,6 +42970,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt)"
     },
@@ -43032,6 +43074,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "High PoE (802.3bt) / 3-axis multi-connector cable"
     },
@@ -43058,7 +43103,6 @@
       "Zipstream H.265",
       "Axis Edge Vault TPM cybersecurity (FIPS 140-2 Level 2)",
       "sharpdome design (20deg above horizon)",
-      "auto-tracking",
       "used in NEOM/smart city Saudi Arabia & UAE critical infra"
     ],
     "sources": [
@@ -43117,6 +43161,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 300
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3bt)"
@@ -43206,6 +43253,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 300
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3bt)"
@@ -47686,6 +47736,9 @@
     "night_vision": {
       "type": "none"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (High PoE) via single Ethernet cable"
     },
@@ -47708,7 +47761,7 @@
       "Thermal frame rate 30 Hz",
       "Metadata fusion combining thermal and optical object detection in one view",
       "Bosch Intelligent Video Analytics (IVA)",
-      "Intelligent on-board video tracking / auto-tracking",
+      "Intelligent on-board video tracking",
       "360 degree endless pan, full PTZ",
       "Object detection up to ~4517 m (DRI criteria)",
       "Audio support",
@@ -65698,6 +65751,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -65722,7 +65778,6 @@
       "WizMind 4MP 25x Starlight PTZ",
       "face detection",
       "perimeter protection",
-      "auto-tracking",
       "H.265+",
       "IP66",
       "100m IR"
@@ -65788,6 +65843,9 @@
       "type": "ir",
       "range_m": 550
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (802.3bt) / AC 24V"
     },
@@ -65810,7 +65868,6 @@
     "features": [
       "45x optical zoom PTZ",
       "Starlight low-light sensor",
-      "AI auto-tracking",
       "face detection",
       "perimeter protection",
       "550m laser range",
@@ -65881,6 +65938,9 @@
       "type": "hybrid",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 36V/2.23A (±25%)",
       "consumption_w": 35,
@@ -65904,7 +65964,6 @@
       "dual-channel: 180° panoramic 4MP stitched + 4MP PTZ 25x zoom",
       "starlight 0.001 lux color @F1.0",
       "150m IR (PTZ) + 30m white light (panoramic)",
-      "auto-tracking (single-ball tracking)",
       "face detection with attributes (6 attributes, 8 expressions)",
       "9 IVS rules: tripwire, intrusion, loitering, parking, crowd",
       "human/vehicle classification",
@@ -78206,6 +78265,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -78295,6 +78357,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 21,
@@ -78320,7 +78385,6 @@
       "25x optical zoom",
       "Starlight",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78372,6 +78436,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at)"
     },
@@ -78395,7 +78462,6 @@
       "pan/tilt/zoom",
       "WizMind 4K 8MP 25x PTZ SMD 4.0",
       "face recognition",
-      "auto-tracking",
       "100m IR",
       "H.265+",
       "IP66"
@@ -78470,6 +78536,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78495,7 +78564,6 @@
       "25x optical zoom",
       "Smart Dual Light",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78559,6 +78627,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78584,7 +78655,6 @@
       "25x optical zoom",
       "Smart Dual Light",
       "WizSense",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78648,6 +78718,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12VDC/PoE+",
       "consumption_w": 23,
@@ -78674,7 +78747,6 @@
       "Smart Dual Light",
       "WizSense",
       "4K PTZ",
-      "auto-tracking",
       "pan 240 deg/s",
       "H.265+"
     ],
@@ -78735,6 +78807,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V"
     },
@@ -78759,7 +78834,6 @@
       "WizSense AI",
       "Starlight low-light",
       "SMD Plus",
-      "auto-tracking",
       "IVS analytics",
       "H.265",
       "IK10"
@@ -78838,6 +78912,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 150
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "24VAC / PoE+ (802.3at)",
@@ -78933,6 +79010,9 @@
     "night_vision": {
       "type": "hybrid"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
     },
@@ -79018,6 +79098,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
@@ -79110,6 +79193,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 8
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "9400mAh battery + 5W solar panel"
@@ -79969,6 +80055,9 @@
       "type": "color",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Quick-swap 10000mAh battery + 5.5W SolarPlus 2.0 panel"
     },
@@ -80776,6 +80865,9 @@
       "type": "ir",
       "range_m": 8
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "5V/1A (USB, plug-in)"
     },
@@ -80847,6 +80939,9 @@
     "night_vision": {
       "type": "ir"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "micro-USB"
     },
@@ -80868,7 +80963,6 @@
       "person detection",
       "pet detection",
       "crying detection",
-      "auto-tracking",
       "privacy mode",
       "360 pan / 75 tilt (no HomeKit)"
     ],
@@ -81007,6 +81101,9 @@
       "type": "hybrid",
       "range_m": 5
     },
+    "ptz": {
+      "autotracking": true
+    },
     "storage": {
       "onboard": true,
       "max_microsd_gb": 128,
@@ -81144,6 +81241,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V (USB-C, hardwired)"
     },
@@ -81164,7 +81264,6 @@
     "features": [
       "4K dual-lens indoor pan/tilt",
       "8x hybrid zoom (3x optical tele)",
-      "AI auto-tracking",
       "on-device human/pet/crying detection",
       "color night vision + IR",
       "no subscription",
@@ -81548,6 +81647,9 @@
     "field_of_view_deg": "360 pan / 70 tilt",
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "storage": {
       "onboard": true,
@@ -81967,6 +82069,9 @@
     "field_of_view_deg": "135",
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Adjustable/removable 2.2W solar panel + built-in rechargeable battery"
@@ -83523,6 +83628,9 @@
       "type": "ir",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/1A (Micro USB)"
     },
@@ -83550,7 +83658,6 @@
     "features": [
       "340deg pan/55deg tilt indoor camera",
       "AI person detection",
-      "auto-tracking",
       "EZVIZ App",
       "Alexa / Google / Hikvision NVR compatible",
       "RTSP (manual app enable) / ONVIF (firmware >= V5.3.2 build 231228)",
@@ -83821,6 +83928,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A (max 6W, outdoor adapter)"
     },
@@ -83849,7 +83959,6 @@
       "AI person detection",
       "spotlight color night vision",
       "strobe light deterrence",
-      "auto-tracking",
       "Alexa / Google",
       "no officially confirmed RTSP/ONVIF -- official datasheet lists only 'EZVIZ Cloud Proprietary Protocol'"
     ],
@@ -84039,6 +84148,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V adapter (RJ45 Ethernet port is data-only, no PoE)"
     },
@@ -84065,7 +84177,6 @@
       "outdoor pan/tilt WiFi",
       "F1.6 color night vision 30m",
       "AI person/vehicle detection",
-      "auto-tracking",
       "dual spotlights",
       "sound + light deterrence",
       "no officially confirmed RTSP/ONVIF -- official docs list only 'EZVIZ Cloud Proprietary Protocol'",
@@ -84846,6 +84957,9 @@
       "type": "hybrid",
       "range_m": 15
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (EZVIZ Solar Panel, Type-C versions)"
     },
@@ -85050,6 +85164,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V/1A (Type-C)"
@@ -85675,6 +85792,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 15
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter (sold separately); solar-compatible (8W IP65 solar panel, sold separately)"
@@ -87061,6 +87181,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A (outdoor adapter)"
     },
@@ -87089,7 +87212,6 @@
       "1080p outdoor pan/tilt",
       "dual spotlights color night vision",
       "AI person/vehicle detection",
-      "auto-tracking",
       "strobe deterrence",
       "RTSP / ONVIF (official ONVIF compatibility FAQ lists H8c firmware builds)",
       "Alexa / Google"
@@ -87158,6 +87280,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A"
@@ -87432,6 +87557,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A (max 12W)"
@@ -87774,6 +87902,9 @@
       "type": "hybrid",
       "range_m": 40
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1.5A (max 12W)"
     },
@@ -87908,6 +88039,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 15
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); DC 5V/2A adapter; solar-compatible (EZVIZ Solar Panel, optional)"
@@ -88179,6 +88313,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 35
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); kit includes 8W solar panel (Type-C connection); DC 5V/2A adapter (sold separately)"
@@ -89980,6 +90117,9 @@
       "type": "hybrid",
       "range_m": 20
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC"
     },
@@ -90159,6 +90299,9 @@
       "type": "ir",
       "range_m": 8
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/2A",
       "consumption_w": 10,
@@ -90317,6 +90460,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/4A",
       "consumption_w": 30,
@@ -90411,6 +90557,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 50
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) or DC 12V/2A",
@@ -90507,6 +90656,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 50
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/2A",
@@ -91811,6 +91963,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / AC 24V"
     },
@@ -91833,7 +91988,6 @@
     "features": [
       "22x optical zoom",
       "360° continuous pan",
-      "autotracking",
       "H.265 compression",
       "preset tours"
     ],
@@ -91890,6 +92044,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / AC 24V"
     },
@@ -91912,7 +92069,6 @@
     "features": [
       "25x optical zoom",
       "360° continuous pan",
-      "autotracking",
       "H.265 compression",
       "preset tours",
       "WDR"
@@ -94151,6 +94307,9 @@
     "night_vision": {
       "type": "none"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "HPoE (IEEE 802.3bt, Class 8), injector included",
       "consumption_w": 65,
@@ -94378,6 +94537,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 4, Class 8)",
@@ -97511,6 +97673,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 3, Class 6)",
       "consumption_w": 42,
@@ -99668,6 +99833,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / AC 24V / DC 24V"
     },
@@ -99690,7 +99858,7 @@
       "200m Smart IR",
       "360 presets, 8 patrol patterns",
       "endless 360 pan",
-      "auto-tracking / object detection",
+      "object detection",
       "120dB WDR",
       "snow-removing (defog)",
       "ICR day/night"
@@ -100082,6 +100250,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC / PoE"
     },
@@ -100104,7 +100275,6 @@
       "150m Smart IR (850nm)",
       "1024 presets",
       "endless 360 pan",
-      "auto tracking",
       "line-crossing / intrusion / area analytics",
       "120dB optical WDR",
       "two-way audio",
@@ -135087,6 +135257,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V / PoE"
     },
@@ -135583,6 +135756,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -135868,6 +136044,9 @@
     "night_vision": {
       "type": "color",
       "range_m": 40
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136371,6 +136550,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
       "voltage": "12V (DC) / PoE+"
@@ -136466,6 +136648,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
     },
@@ -136491,7 +136676,6 @@
       "AcuSense",
       "IP66",
       "H.265+",
-      "auto-tracking",
       "very popular commercial India PTZ",
       "₹25,000–35,000"
     ],
@@ -136649,6 +136833,9 @@
     },
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE / 12 VDC"
@@ -136926,6 +137113,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -136948,7 +137138,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking",
       "IR to 50m (850nm)",
       "120dB WDR",
       "3D positioning",
@@ -137014,6 +137203,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
     },
@@ -137036,7 +137228,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking",
       "IR to 50m (850nm, smart supplement)",
       "120dB WDR",
       "3D positioning",
@@ -137109,6 +137300,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
     },
@@ -137134,7 +137328,6 @@
       "50m IR",
       "H.265+",
       "IP66",
-      "auto-tracking",
       "most affordable Hikvision PoE mini PTZ"
     ],
     "sources": [
@@ -137283,6 +137476,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V"
     },
@@ -137363,6 +137559,9 @@
       "type": "ir",
       "range_m": 50
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
     },
@@ -137385,7 +137584,6 @@
       "pan/tilt: pan 360 / tilt -5 to 90",
       "powered-by-DarkFighter low-light",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "face capture, regional people counting",
       "IR to 50m (850nm)",
       "120dB WDR",
@@ -137661,6 +137859,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V"
     },
@@ -137736,6 +137937,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at)"
     },
@@ -137760,10 +137964,8 @@
       "4MP 25x PTZ DeepinView",
       "100m IR",
       "AcuSense AI",
-      "auto-tracking",
       "H.265+",
-      "IP66",
-      "smart tracking"
+      "IP66"
     ],
     "sources": [
       "https://www.hikvision.com/en/products/"
@@ -137926,6 +138128,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -137949,7 +138154,6 @@
       "AcuSense human/vehicle classification",
       "active deterrence strobe + audible warning to 100m",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138014,6 +138218,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138037,7 +138244,6 @@
       "AcuSense human/vehicle classification",
       "arrayed dual-mic two-way audio",
       "white-light + audible audio-visual alarm",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138206,6 +138412,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138229,7 +138438,6 @@
       "AcuSense human/vehicle classification",
       "active deterrence strobe + audible warning to 100m",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "IR up to 200m",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138294,6 +138502,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt Type3) / 36 VDC"
     },
@@ -138318,7 +138529,6 @@
       "arrayed dual-mic (8m) + speaker (30m)",
       "audio-visual alarm (white-light flash + audible)",
       "IR up to 200m",
-      "auto-tracking",
       "300 presets",
       "regional people counting",
       "360 VR panoramic view",
@@ -138384,6 +138594,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE / 36 VDC"
     },
@@ -138408,7 +138621,6 @@
       "active deterrence: sound + strobe light to 100m",
       "IR up to 200m (850nm)",
       "2 built-in speakers",
-      "auto-tracking",
       "300 presets",
       "face capture",
       "pan/tilt: pan 360 / tilt -15 to 90",
@@ -138478,6 +138690,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 200
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "High PoE (802.3at) / AC 24V"
@@ -138664,6 +138879,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 36 VDC"
     },
@@ -138686,7 +138904,6 @@
       "pan/tilt: pan 360 / tilt -15 to 90",
       "powered-by-DarkFighter + HIK AI-ISP",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "active deterrence: white-light flash + audible warning",
       "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
       "IR to 200m",
@@ -138753,6 +138970,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hi-PoE (802.3bt) / 36 VDC"
     },
@@ -138775,7 +138995,6 @@
       "pan/tilt: pan 360 / tilt -15 to 90",
       "powered-by-DarkFighter + HIK AI-ISP",
       "AcuSense human/vehicle classification",
-      "auto-tracking (Smart Tracking)",
       "active deterrence: white-light flash + audible warning",
       "built-in speaker (30m) + arrayed dual-mic (8m) two-way audio",
       "IR to 200m",
@@ -139098,6 +139317,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 100
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC"
@@ -139446,6 +139668,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 400
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE++ (IEEE 802.3bt Type 4, Class 8, 90W) / 36VDC",
@@ -141637,6 +141862,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -141723,6 +141951,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -141812,6 +142043,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -141897,6 +142131,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -142923,6 +143160,9 @@
       "type": "hybrid",
       "range_m": 20
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "10000mAh battery; DC 5V/2A or optional Imou 5W solar panel; <3.5W"
     },
@@ -142944,7 +143184,6 @@
     "features": [
       "Always-On-Video (AOV) low-power 24/7 recording",
       "AI human detection (>98%)",
-      "auto tracking",
       "siren & spotlight",
       "8x digital zoom",
       "PIR",
@@ -143086,6 +143325,9 @@
       "type": "hybrid",
       "range_m": 25
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "10000mAh battery; DC 5V/2A; sold as a kit with a 5W solar panel"
     },
@@ -143109,7 +143351,6 @@
       "F1.0 large-aperture 'Aurora' lens",
       "AURORA full-color night vision (25m)",
       "AI human detection",
-      "auto tracking",
       "integrated siren",
       "4G LTE + Wi-Fi"
     ],
@@ -144364,6 +144605,9 @@
     "night_vision": {
       "type": "hybrid"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "5000mAh (base) up to 15000mAh battery (up to 280 days); USB-C fast charging; optional 3W/7W solar"
     },
@@ -144767,6 +145011,9 @@
       "type": "color",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -144789,7 +145036,6 @@
     "features": [
       "5MP outdoor pan/tilt color night vision",
       "AI human/vehicle detection",
-      "auto-tracking",
       "smart siren + spotlight deterrence",
       "IP66",
       "H.265",
@@ -144864,6 +145110,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A, <12W"
     },
@@ -144886,7 +145135,6 @@
     "features": [
       "outdoor pan/tilt",
       "8x digital zoom",
-      "auto-tracking",
       "human & vehicle detection",
       "full-color night vision",
       "110 dB siren",
@@ -145022,6 +145270,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A, <12W"
     },
@@ -145046,7 +145297,6 @@
       "full-color night vision",
       "110 dB siren",
       "IMOU SENSE human/vehicle detection",
-      "auto-tracking",
       "Wi-Fi 6",
       "two-way talk"
     ],
@@ -145115,6 +145365,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V, <12W"
     },
@@ -145141,7 +145394,6 @@
       "110 dB siren",
       "spotlight active deterrence",
       "IMOU SENSE human/vehicle detection",
-      "auto-tracking",
       "Wi-Fi 6",
       "two-way talk"
     ],
@@ -145305,6 +145557,9 @@
       "type": "hybrid",
       "range_m": 56
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1.5A or PoE 802.3at, <18W"
     },
@@ -145329,7 +145584,6 @@
       "smart color four-mode night vision",
       "warning lights + 120 dB alarm",
       "AI human/vehicle detection",
-      "auto-tracking",
       "AOR always-on-record",
       "dual microSD slots",
       "dual-band Wi-Fi 6",
@@ -145402,6 +145656,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A"
     },
@@ -145424,7 +145681,6 @@
     "features": [
       "4G LTE pan/tilt",
       "full-color night vision",
-      "auto-tracking",
       "spotlight + 110 dB siren",
       "red-blue warning lights",
       "AI human detection",
@@ -145494,6 +145750,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 12V/1A"
@@ -145768,6 +146027,9 @@
       "type": "hybrid",
       "range_m": 56
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -145789,7 +146051,6 @@
     },
     "features": [
       "dual-lens 12x mixed zoom (3x optical + 4x digital)",
-      "auto-tracking",
       "IMOU SENSE AI human & vehicle detection",
       "full-color night vision",
       "spotlight/siren active deterrence",
@@ -146021,6 +146282,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V USB"
@@ -146748,6 +147012,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC 5V (USB)"
@@ -154398,6 +154665,9 @@
       "type": "ir",
       "range_m": 220
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "24V AC",
       "voltage": "24V AC / 3A",
@@ -157822,6 +158092,9 @@
       "type": "ir",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/0.62A (max 3.1W) via included power adapter"
     },
@@ -157849,7 +158122,6 @@
     "features": [
       "2K QHD indoor WiFi pan/tilt",
       "ONVIF Profile S confirmed on official datasheet",
-      "auto-tracking",
       "Lorex Home app",
       "Alexa / Google",
       "no monthly fees"
@@ -159000,6 +159272,9 @@
       "type": "hybrid",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "12V DC or PoE+"
     },
@@ -159021,7 +159296,6 @@
     "features": [
       "25x optical zoom (5-125mm)",
       "active deterrence: built-in red/blue strobe lights + siren (X-Deterrence)",
-      "auto-tracking",
       "VCA: line crossing, intrusion detection, face detection",
       "MD 2.0 human/vehicle detection",
       "built-in heater for lens defogging",
@@ -159092,6 +159366,9 @@
     },
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "24V AC or High PoE, up to 50W"
@@ -159346,6 +159623,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at)"
     },
@@ -159367,7 +159647,6 @@
     "features": [
       "25x optical zoom",
       "pan/tilt/zoom",
-      "auto-tracking",
       "Control4 integration",
       "preset patrol"
     ],
@@ -163716,6 +163995,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163739,7 +164021,6 @@
       "360° continuous pan",
       "SureVision 4.0 WDR",
       "analytics-ready",
-      "autotracking",
       "preset tours"
     ],
     "release_year": 2022,
@@ -163795,6 +164076,9 @@
       "type": "ir",
       "range_m": 300
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163818,7 +164102,6 @@
       "360° continuous pan",
       "SureVision 4.0 WDR",
       "analytics-ready",
-      "autotracking",
       "preset tours"
     ],
     "release_year": 2022,
@@ -163874,6 +164157,9 @@
       "type": "ir",
       "range_m": 250
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / 24VAC"
     },
@@ -163897,7 +164183,6 @@
       "360° continuous pan",
       "SureVision WDR",
       "analytics-ready",
-      "autotracking",
       "H.265 compression"
     ],
     "release_year": 2023,
@@ -164310,6 +164595,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (20000mAh) / solar panel"
     },
@@ -164329,7 +164617,6 @@
       "battery-powered (20000mAh) + solar option",
       "4G LTE",
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "ColorX hybrid night vision",
       "10-second pre-recording",
       "person/vehicle/animal detection",
@@ -164383,6 +164670,9 @@
     "field_of_view_deg": "355 pan/90 tilt",
     "night_vision": {
       "type": "color"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"
@@ -165759,6 +166049,9 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "Rechargeable battery / solar optional"
@@ -168372,6 +168665,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -168395,7 +168691,6 @@
       "2K ColorX WiFi outdoor F1.0 1/1.8\" sensor",
       "true color night vision no IR",
       "person/vehicle/animal AI",
-      "auto-tracking",
       "ONVIF/RTSP",
       "IP65",
       "Alexa/Google",
@@ -168483,6 +168778,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -168505,7 +168803,6 @@
     "features": [
       "355deg pan / 50deg tilt",
       "3x optical zoom",
-      "auto-tracking",
       "compact low-profile body",
       "person/vehicle/animal detection",
       "no subscription"
@@ -168588,6 +168885,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/1A"
     },
@@ -168611,7 +168911,6 @@
       "3x optical zoom",
       "4K UHD",
       "person/vehicle/animal detection",
-      "auto-tracking",
       "355° pan / 50° tilt",
       "color night vision",
       "WiFi 6",
@@ -168691,6 +168990,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -168712,7 +169014,6 @@
     },
     "features": [
       "355deg pan / 50deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "person/vehicle/animal detection",
       "10x digital zoom",
@@ -168787,6 +169088,9 @@
       "type": "hybrid",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -168813,7 +169117,6 @@
       "5MP outdoor WiFi PTZ",
       "355° pan / 50° tilt (64 presets)",
       "3x optical zoom",
-      "auto-tracking",
       "12m IR",
       "person/vehicle/animal detection",
       "ONVIF/RTSP",
@@ -168903,6 +169206,9 @@
       "type": "ir",
       "range_m": 12
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 5V/1A"
     },
@@ -168926,7 +169232,6 @@
       "64 presets",
       "human/pet detection",
       "crying detection",
-      "auto-tracking",
       "dual-band WiFi",
       "no subscription"
     ],
@@ -169882,6 +170187,9 @@
       "type": "hybrid",
       "range_m": 10
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery / solar panel"
     },
@@ -169901,7 +170209,6 @@
       "battery-powered + solar option",
       "4G LTE (no WiFi needed)",
       "355deg pan / 140deg tilt",
-      "auto-tracking",
       "person/vehicle/animal detection",
       "PIR + siren",
       "app-only (no RTSP/ONVIF)",
@@ -171030,6 +171337,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3af) / DC 12V",
       "consumption_w": 12
@@ -171052,7 +171362,6 @@
     },
     "features": [
       "355° pan / 90° tilt",
-      "auto-tracking",
       "32 presets",
       "person/vehicle/animal detection",
       "spotlight + siren",
@@ -173218,6 +173527,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "voltage": "12V",
@@ -174206,6 +174518,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -174227,7 +174542,6 @@
     },
     "features": [
       "180deg pan rotation",
-      "auto-tracking",
       "person/vehicle detection",
       "no subscription"
     ],
@@ -174548,6 +174862,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
       "voltage": "48V (PoE) / 12V (DC)",
@@ -174574,7 +174891,6 @@
     "features": [
       "360° pan / 90° tilt",
       "5x optical zoom",
-      "auto-tracking (person/vehicle)",
       "spotlight color night vision",
       "active deterrence siren",
       "person/vehicle/animal detection",
@@ -174657,6 +174973,9 @@
       "type": "ir",
       "range_m": 80
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
       "voltage": "48V (PoE) / 12V (DC)",
@@ -174684,7 +175003,6 @@
     "features": [
       "16x optical zoom",
       "360° pan / 90° tilt",
-      "auto-tracking (person/vehicle/pet)",
       "person/vehicle/pet detection",
       "IR night vision up to 80m",
       "no subscription required"
@@ -174769,6 +175087,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
       "consumption_w": 24
@@ -174796,7 +175117,6 @@
       "360deg pan / 90deg tilt",
       "5x optical zoom",
       "3D zoom",
-      "auto-tracking",
       "spotlight color night vision",
       "customizable patrol routes",
       "person/vehicle/animal detection",
@@ -174883,6 +175203,9 @@
       "type": "hybrid",
       "range_m": 60
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "consumption_w": 24
@@ -174911,7 +175234,6 @@
       "5x optical zoom",
       "3D zoom",
       "360deg pan / 90deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "no subscription"
     ],
@@ -175202,6 +175524,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
       "consumption_w": 12
@@ -175223,7 +175548,6 @@
     },
     "features": [
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "spotlight color night vision",
       "person/vehicle/animal detection",
       "no subscription"
@@ -176125,6 +176449,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Hardwired (AC)"
     },
@@ -176229,6 +176556,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"
     },
@@ -176319,6 +176649,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery (5100mAh) / solar panel"
     },
@@ -176339,7 +176672,6 @@
       "4G LTE",
       "dual-lens 6x hybrid zoom",
       "355deg pan / 90deg tilt",
-      "auto-tracking",
       "person/vehicle/animal detection",
       "app-only (no RTSP/ONVIF)",
       "no subscription"
@@ -176399,6 +176731,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"
     },
@@ -176418,7 +176753,6 @@
     "features": [
       "dual-lens",
       "6x hybrid zoom",
-      "auto-tracking",
       "355° pan / 90° tilt",
       "person/vehicle/animal detection",
       "4G LTE",
@@ -176484,6 +176818,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE (IEEE 802.3af, 48V active) / DC 12V/2A",
       "consumption_w": 12,
@@ -176510,7 +176847,6 @@
     },
     "features": [
       "dual-lens dual-view",
-      "auto-tracking",
       "6x hybrid zoom",
       "355° pan / 90° tilt",
       "person/vehicle/animal detection",
@@ -176600,6 +176936,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V/2A"
     },
@@ -176622,7 +176961,6 @@
     },
     "features": [
       "dual-lens dual-view",
-      "auto-tracking",
       "6x hybrid zoom",
       "355° pan / 90° tilt",
       "Wi-Fi 6 dual-band",
@@ -179665,6 +180003,9 @@
       "type": "ir",
       "range_m": 120
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) or 24V AC/DC (power supply included)",
       "consumption_w": 34
@@ -179686,7 +180027,6 @@
     },
     "features": [
       "25x optical zoom, endless (360-degree continuous) panning, -3 to 90 degree tilt",
-      "Smart Tracking (auto-tracking)",
       "ONVIF Profile G, S, and T conformant",
       "line crossing, video blurring/tamper detection, human/vehicle detection",
       "face detection and recognition (requires a compatible Speco recorder)",
@@ -182176,6 +182516,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V",
       "consumption_w": 12
@@ -182197,7 +182540,6 @@
     },
     "features": [
       "15x optical zoom",
-      "auto-tracking",
       "floodlight color night vision (12 IR LEDs)",
       "two-way audio",
       "metal dome shell",
@@ -182270,6 +182612,9 @@
     "night_vision": {
       "type": "ir",
       "range_m": 30
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "12V DC (Wi-Fi data)"
@@ -182348,6 +182693,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -182370,7 +182718,6 @@
     "features": [
       "36x hybrid zoom (18x optical + 18x digital)",
       "350° pan / 93° tilt",
-      "auto-tracking",
       "people/vehicle/pet detection",
       "color night vision (9 IR LEDs)",
       "two-way audio",
@@ -182692,6 +183039,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC 12V"
     },
@@ -182713,7 +183063,6 @@
       "pan/tilt/zoom",
       "4K 8MP",
       "dual network (PoE + WiFi)",
-      "auto-tracking",
       "human/vehicle detection",
       "color night vision",
       "RTSP",
@@ -182766,6 +183115,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC 12V"
     },
@@ -182787,7 +183139,6 @@
     "features": [
       "5MP WiFi PTZ",
       "5x optical zoom",
-      "auto-tracking",
       "spotlight color night vision",
       "IP66",
       "RTSP"
@@ -182837,6 +183188,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC 12V"
     },
@@ -182855,7 +183209,6 @@
     },
     "features": [
       "15x optical zoom",
-      "auto-tracking",
       "floodlight color night vision",
       "RTSP",
       "FTP",
@@ -183079,6 +183432,9 @@
     "night_vision": {
       "type": "color"
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "Solar panel / rechargeable battery"
     },
@@ -183097,7 +183453,6 @@
       "2K dual-lens",
       "solar powered",
       "360° pan/tilt",
-      "auto-tracking",
       "color night vision",
       "no subscription",
       "4-camera kit"
@@ -189532,6 +189887,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189555,7 +189913,6 @@
       "25x optical zoom",
       "360° continuous pan",
       "Starlight sensor",
-      "autotracking",
       "H.265+ compression",
       "preset tours"
     ],
@@ -189614,6 +189971,9 @@
       "type": "ir",
       "range_m": 200
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++ (IEEE 802.3bt) / AC 24V"
     },
@@ -189637,7 +189997,6 @@
       "30x optical zoom",
       "360° continuous pan",
       "Starlight sensor",
-      "autotracking",
       "H.265+ compression",
       "smart IR"
     ],
@@ -189695,6 +190054,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189718,7 +190080,6 @@
       "360° pan / 90° tilt",
       "20x optical zoom",
       "smart IR",
-      "auto-tracking",
       "H.265 compression"
     ],
     "release_year": 2020,
@@ -189776,6 +190137,9 @@
       "type": "ir",
       "range_m": 100
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 12V"
     },
@@ -189799,7 +190163,6 @@
       "360° pan / 90° tilt",
       "25x optical zoom",
       "smart IR",
-      "auto-tracking",
       "H.265 compression"
     ],
     "release_year": 2021,
@@ -189857,6 +190220,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+ (IEEE 802.3at) / DC 24V"
     },
@@ -189880,7 +190246,6 @@
       "360° pan / 90° tilt",
       "25x optical zoom",
       "smart IR",
-      "auto-tracking",
       "face detection",
       "H.265 compression",
       "defog"
@@ -191864,6 +192229,9 @@
       "type": "ir",
       "range_m": 91
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE++, 42.5-57V DC; 42.9W max"
     },
@@ -191888,8 +192256,7 @@
       "IR night vision up to 91m (corrected from a rounded 100m)",
       "Ambarella S5L66 processor",
       "PoE++ powered",
-      "UniFi Protect ecosystem",
-      "auto-tracking"
+      "UniFi Protect ecosystem"
     ],
     "sources": [
       "https://techspecs.ui.com/unifi/cameras-nvrs/uvc-g4-ptz",
@@ -192446,6 +192813,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE+, 42.5-57V DC; 24.5W max"
     },
@@ -192470,7 +192840,6 @@
       "dual-camera design: separate wide-angle and tele (zoom) sensors/lenses, 10x hybrid zoom -- corrected from a fabricated single-sensor 22x optical / 5-185mm spec and a fabricated 150m IR range",
       "pan 350 degrees, tilt 100 degrees (not full 360-degree endless pan)",
       "face recognition, license plate recognition",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "IK04 tamper resistance",
       "MicroSD card expansion slot",
@@ -192879,6 +193248,9 @@
       "type": "ir",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "DC power adapter"
     },
@@ -192948,6 +193320,9 @@
     "field_of_view_deg": "360 pan range (pan/tilt)",
     "night_vision": {
       "type": "ir"
+    },
+    "ptz": {
+      "autotracking": true
     },
     "power": {
       "method": "DC power adapter"
@@ -194495,6 +194870,9 @@
       "type": "hybrid",
       "range_m": 30
     },
+    "ptz": {
+      "autotracking": true
+    },
     "power": {
       "method": "PoE / DC",
       "consumption_w": 16,
@@ -194523,7 +194901,6 @@
       "pan-tilt",
       "3x mixed zoom",
       "instant zoom",
-      "auto-tracking",
       "customized patrol",
       "person detection",
       "vehicle detection",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -181,6 +181,27 @@
         }
       }
     },
+    "ptz": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "PTZ capabilities (pan/tilt/zoom cameras). Camera-side autotracking is distinct from Frigate autotracking (configs.frigate.autotracking), which additionally requires ONVIF relative movement.",
+      "properties": {
+        "autotracking": {
+          "type": "boolean",
+          "description": "Camera-side (onboard) subject autotracking — the camera moves itself to follow a subject."
+        },
+        "onvif_ptz": {
+          "type": "string",
+          "description": "ONVIF PTZ movement model the camera exposes. Frigate autotracking requires 'relative'; e.g. Reolink is 'absolute' only.",
+          "enum": [
+            "relative",
+            "absolute",
+            "continuous",
+            "none"
+          ]
+        }
+      }
+    },
     "power": {
       "type": "object",
       "additionalProperties": false,
@@ -373,6 +394,10 @@
               "type": "string",
               "enum": ["go2rtc", "ffmpeg", "rtsp"],
               "description": "Recommended stream input type (e.g. go2rtc for WebRTC/audio, ffmpeg for scaling, native rtsp)."
+            },
+            "autotracking": {
+              "type": "boolean",
+              "description": "Whether Frigate can drive PTZ autotracking on this camera. Requires ONVIF relative movement (ptz.onvif_ptz: relative); false for absolute-only cameras like Reolink. Distinct from camera-side ptz.autotracking."
             }
           }
         },


### PR DESCRIPTION
**Part 1 of #124.**

Splits the previously-conflated free-text "autotracking" into two structured, honest facts.

## Schema
- New **`ptz`** object: `autotracking` (camera-side onboard tracking) + `onvif_ptz` (`relative`/`absolute`/`continuous`/`none` — the ONVIF movement model Frigate depends on).
- New **`configs.frigate.autotracking`**: whether Frigate can drive PTZ autotracking (requires ONVIF relative move).

## Migration
- **153** PTZ/dual-lens cameras → `ptz.autotracking: true`; **84** now-redundant pure-autotracking feature strings removed. Versioned/combined descriptors ("Autotracking 2", "355 pan / 90 tilt with auto-tracking") intentionally kept.
- Round-trip byte-identical formatting → clean diffs; AJV passes on all 2,230.

## Deliberately deferred to part 2 (community-sourced)
- `onvif_ptz` + `configs.frigate.autotracking` left **unset** — this data is empirical, not in datasheets. Reolink (camera-side ✓, Frigate ✗) is the canonical case.
- **16 non-PTZ** cameras mentioning autotracking (Hanwha/ACTi *digital* tracking, Hikvision *e-PTZ*, fixed-cam tags) were **not** migrated — forcing a mechanical-PTZ `ptz` object onto digital tracking would be wrong. Listed for manual review.

Checks part-1 boxes on #124.