### PR TITLE
Annke: disambiguate C800/C1200 by exact model number + expand catalogue (+27, v1.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.38.0] — 2026-07-20
+
+**Annke catalogue expansion + C800/C1200 model-number disambiguation** (issue #129). Replaced the generic "C800 (Turret)/(Bullet)" umbrella entries with exact `I91xx` model numbers, corrected the 12MP line to the **C1200** family (removing a duplicate of the existing C1200 turret), and added the current Annke line-ups. Net: **2,230 -> 2,257 cameras** (+27; brand count unchanged). Thanks to @fvdpol (#129) for the report.
+
+### Added -- Annke (27)
+- **C800** (8MP): I91DB, I91DM, I91DL, I91DF (dome).
+- **C1200** (12MP): I91DD (bullet), C1200D I91DG (dome).
+- **NightChroma**: NC500 (I81HE turret / I81HD bullet), NCBR800 (I91DJ bullet / I91DU turret), NCT425 I81EL (2-in-1 dual-lens PTZ).
+- **Dual-lens panoramic**: FCD600 I51FS, FCD800 (I91ET turret / I91EV bullet), I91BH, I91BI, I51DX.
+- **Zoom PTZ / speed dome**: CZ804 (I91DQ dome / I91DE bullet), CZ825X I91BW (25x), CZ425X I81HB (25x), I91BK, I81EM, I51EX.
+- **Other**: C500D I51DN, I91BV (full-color turret), SLPR400 I81HY (ANPR/LPR).
+
+### Changed
+- `C800 (Turret)` -> `C800 I91BM`, `C800 (Bullet)` -> `C800 I91BD` (legacy 2020 revision; id/URL preserved).
+- `C1200` -> `C1200 I91DN` (enriched with its model number; identified as the 12MP turret).
+- Retail order SKUs (AN-/AU-/AP-...) captured as aliases across the family.
+
 ## [1.37.0] — 2026-07-15
 
 Reolink autotracking: separate the camera-side capability from Frigate compatibility (#124 part 2, Reolink slice).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCTV Camera Database
 
-An open, structured database of 2,230 CCTV / IP camera models and their technical specifications, covering 71 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,257 CCTV / IP camera models and their technical specifications, covering 71 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
 [![cameras](https://img.shields.io/badge/cameras-1%2C896-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-71-green)](cameras/)
@@ -31,7 +31,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,230 cameras, 25 per page
+- **Pagination** — page through all 2,257 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -63,7 +63,7 @@ cctv-camera-database/
 │   ├── tapo/             #  62 cameras
 │   └── …60 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,230 cameras as one array
+│   ├── cameras.json      # all 2,257 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -121,7 +121,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,230** |
+| Total cameras | **2,257** |
 | Brands | **71** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,279 |

--- a/cameras/annke/c1200-i91dd.json
+++ b/cameras/annke/c1200-i91dd.json
@@ -1,47 +1,45 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c1200-i91dd",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C1200 I91DD",
   "aliases": [
     "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "I91DD",
+    "C1200 Bullet",
+    "12MP Smart Dual Light Bullet"
   ],
-  "type": "turret",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
     "megapixels": 12,
     "max_width": 4096,
     "max_height": 3072,
-    "label": "12MP UHD"
+    "label": "12MP"
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 10
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +52,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "12MP (4096x3072) PoE bullet",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "Color Night Vision (0.01 lux)",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91dd"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c1200-i91dd.md
+++ b/cameras/annke/c1200-i91dd.md
@@ -1,0 +1,35 @@
+# Annke C1200 I91DD
+
+*Also known as: C1200, I91DD, C1200 Bullet, 12MP Smart Dual Light Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C1200 I91DD |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 12MP (12MP, 4096×3072) |
+| Sensor | 1/2.7" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- 12MP (4096x3072) PoE bullet
+- Smart Dual-Light (IR + white light up to 30m)
+- Color Night Vision (0.01 lux)
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://www.annkecctv.com/products/i91dd
+
+---
+*Auto-generated from annke-c1200-i91dd.json — do not edit by hand.*

--- a/cameras/annke/c1200.md
+++ b/cameras/annke/c1200.md
@@ -1,11 +1,11 @@
-# Annke C1200
+# Annke C1200 I91DN
 
-*Also known as: 12MP PoE AI Turret*
+*Also known as: C1200, I91DN, C1200 Turret, 12MP PoE AI Turret*
 
 | Field | Spec |
 |-------|------|
 | Brand | Annke |
-| Model | C1200 |
+| Model | C1200 I91DN |
 | Type | turret |
 | Connectivity | ethernet |
 | Resolution | 12MP UHD (12MP, 4096×3072) |

--- a/cameras/annke/c1200d-i91dg.json
+++ b/cameras/annke/c1200d-i91dg.json
@@ -1,23 +1,23 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c1200d-i91dg",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C1200D I91DG",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "C1200D",
+    "I91DG",
+    "AN-I91DG0102",
+    "AN-I91DG",
+    "12MP Smart Dual Light Dome"
   ],
-  "type": "turret",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
     "megapixels": 12,
     "max_width": 4096,
     "max_height": 3072,
-    "label": "12MP UHD"
+    "label": "12MP"
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "lens": {
@@ -26,22 +26,22 @@
     "aperture": "F1.6",
     "varifocal": false
   },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
-  },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 10
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -53,33 +53,28 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP67, IK08",
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "12MP (4096x3072) PoE dome",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "Color Night Vision (0.01 lux @ F2.0)",
+    "IK08 vandal-resistant",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/c1200d"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c1200d-i91dg.md
+++ b/cameras/annke/c1200d-i91dg.md
@@ -1,0 +1,36 @@
+# Annke C1200D I91DG
+
+*Also known as: C1200D, I91DG, AN-I91DG0102, AN-I91DG, 12MP Smart Dual Light Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C1200D I91DG |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 12MP (12MP, 4096×3072) |
+| Sensor | 1/2.7" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67, IK08 |
+| Two-way audio | No |
+
+## Features
+
+- 12MP (4096x3072) PoE dome
+- Smart Dual-Light (IR + white light up to 30m)
+- Color Night Vision (0.01 lux @ F2.0)
+- IK08 vandal-resistant
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF
+
+## Sources
+
+- https://ca-en.annke.com/products/c1200d
+
+---
+*Auto-generated from annke-c1200d-i91dg.json — do not edit by hand.*

--- a/cameras/annke/c500d-i51dn.json
+++ b/cameras/annke/c500d-i51dn.json
@@ -1,51 +1,50 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c500d-i51dn",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C500D I51DN",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "C500D",
+    "I51DN",
+    "AN-I51DN0102-V5",
+    "AN-I51DN",
+    "3K PoE Dome"
   ],
-  "type": "turret",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 2592,
+    "max_height": 1944,
+    "label": "3K (2592x1944)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/3\" OmniVision Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +53,25 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "3K (2592x1944) PoE dome",
+    "EXIR 2.0 IR night vision up to 30m",
+    "noise-cancelling built-in microphone",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/c500d"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c500d-i51dn.md
+++ b/cameras/annke/c500d-i51dn.md
@@ -1,0 +1,34 @@
+# Annke C500D I51DN
+
+*Also known as: C500D, I51DN, AN-I51DN0102-V5, AN-I51DN, 3K PoE Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C500D I51DN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 3K (2592x1944) (5MP, 2592×1944) |
+| Sensor | 1/3" OmniVision Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm |
+| Night vision | ir (30m) |
+| Power | PoE (802.3af) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- 3K (2592x1944) PoE dome
+- EXIR 2.0 IR night vision up to 30m
+- noise-cancelling built-in microphone
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://ca-en.annke.com/products/c500d
+
+---
+*Auto-generated from annke-c500d-i51dn.json — do not edit by hand.*

--- a/cameras/annke/c800-bullet.md
+++ b/cameras/annke/c800-bullet.md
@@ -1,11 +1,11 @@
-# Annke C800 (Bullet)
+# Annke C800 I91BD
 
-*Also known as: 4K 8MP PoE Bullet*
+*Also known as: I91BD, C800 Bullet, C800 (Bullet), 4K 8MP PoE Bullet*
 
 | Field | Spec |
 |-------|------|
 | Brand | Annke |
-| Model | C800 (Bullet) |
+| Model | C800 I91BD |
 | Type | bullet |
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP, 3840×2160) |

--- a/cameras/annke/c800-i91db.json
+++ b/cameras/annke/c800-i91db.json
@@ -1,35 +1,29 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c800-i91db",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C800 I91DB",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "I91DB",
+    "C800 Turret",
+    "4K Fixed Turret",
+    "4K Color Night Vision PoE Turret"
   ],
   "type": "turret",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F2.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
@@ -37,15 +31,19 @@
       "H.265",
       "H.264+",
       "H.264"
-    ]
+    ],
+    "max_fps": 25
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +52,28 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP PoE turret",
+    "1/1.8\" large sensor",
+    "Color Night Vision",
+    "active deterrence (strobe light + siren)",
+    "two-way audio (built-in mic + speaker)",
+    "Smart IR up to 30m",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91db"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c800-i91db.md
+++ b/cameras/annke/c800-i91db.md
@@ -1,0 +1,37 @@
+# Annke C800 I91DB
+
+*Also known as: I91DB, C800 Turret, 4K Fixed Turret, 4K Color Night Vision PoE Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C800 I91DB |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F2.0 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP PoE turret
+- 1/1.8" large sensor
+- Color Night Vision
+- active deterrence (strobe light + siren)
+- two-way audio (built-in mic + speaker)
+- Smart IR up to 30m
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i91db
+
+---
+*Auto-generated from annke-c800-i91db.json — do not edit by hand.*

--- a/cameras/annke/c800-i91df.json
+++ b/cameras/annke/c800-i91df.json
@@ -1,47 +1,48 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c800-i91df",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C800 I91DF",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "I91DF",
+    "AN-I91DF0104-V2",
+    "AN-I91DF",
+    "C800D",
+    "C800 Dome",
+    "4K 8MP Smart Dual Light Dome"
   ],
-  "type": "turret",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.4\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "4 (fixed)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -53,33 +54,28 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP67, IK08",
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP PoE dome",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "Color Night Vision (0.005 lux @ F1.6)",
+    "IK08 vandal-resistant",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91df"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c800-i91df.md
+++ b/cameras/annke/c800-i91df.md
@@ -1,0 +1,36 @@
+# Annke C800 I91DF
+
+*Also known as: I91DF, AN-I91DF0104-V2, AN-I91DF, C800D, C800 Dome, 4K 8MP Smart Dual Light Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C800 I91DF |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/2.4" Progressive Scan CMOS |
+| Lens | 1× 4 (fixed)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67, IK08 |
+| Two-way audio | No |
+
+## Features
+
+- 4K 8MP PoE dome
+- Smart Dual-Light (IR + white light up to 30m)
+- Color Night Vision (0.005 lux @ F1.6)
+- IK08 vandal-resistant
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://www.annkecctv.com/products/i91df
+
+---
+*Auto-generated from annke-c800-i91df.json — do not edit by hand.*

--- a/cameras/annke/c800-i91dl.json
+++ b/cameras/annke/c800-i91dl.json
@@ -1,47 +1,48 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c800-i91dl",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C800 I91DL",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "I91DL",
+    "AN-I91DL0104-V3",
+    "AN-I91DL",
+    "C800 Bullet",
+    "4K Smart Dual Light Bullet",
+    "4K 8MP PoE Bullet"
   ],
-  "type": "turret",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.4\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "4 (fixed)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +55,27 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP PoE bullet",
+    "Smart Dual-Light (IR + white light)",
+    "Color Night Vision (0.005 lux @ F1.6)",
+    "supplement light up to 30m",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91dl"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c800-i91dl.md
+++ b/cameras/annke/c800-i91dl.md
@@ -1,0 +1,36 @@
+# Annke C800 I91DL
+
+*Also known as: I91DL, AN-I91DL0104-V3, AN-I91DL, C800 Bullet, 4K Smart Dual Light Bullet, 4K 8MP PoE Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C800 I91DL |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/2.4" Progressive Scan CMOS |
+| Lens | 1× 4 (fixed)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- 4K 8MP PoE bullet
+- Smart Dual-Light (IR + white light)
+- Color Night Vision (0.005 lux @ F1.6)
+- supplement light up to 30m
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://www.annkecctv.com/products/i91dl
+
+---
+*Auto-generated from annke-c800-i91dl.json — do not edit by hand.*

--- a/cameras/annke/c800-i91dm.json
+++ b/cameras/annke/c800-i91dm.json
@@ -1,47 +1,47 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-c800-i91dm",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "C800 I91DM",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "I91DM",
+    "AN-I91DM0104-V2",
+    "AN-I91DM",
+    "C800 Turret",
+    "4K 8MP Smart Dual Light Turret"
   ],
   "type": "turret",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.4\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "4 (fixed)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +54,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP PoE turret",
+    "Smart Dual-Light (IR up to 30m + white light up to 20m)",
+    "Color Night Vision",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91dm"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/c800-i91dm.md
+++ b/cameras/annke/c800-i91dm.md
@@ -1,0 +1,35 @@
+# Annke C800 I91DM
+
+*Also known as: I91DM, AN-I91DM0104-V2, AN-I91DM, C800 Turret, 4K 8MP Smart Dual Light Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | C800 I91DM |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/2.4" Progressive Scan CMOS |
+| Lens | 1× 4 (fixed)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- 4K 8MP PoE turret
+- Smart Dual-Light (IR up to 30m + white light up to 20m)
+- Color Night Vision
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://www.annkecctv.com/products/i91dm
+
+---
+*Auto-generated from annke-c800-i91dm.json — do not edit by hand.*

--- a/cameras/annke/c800-turret.json
+++ b/cameras/annke/c800-turret.json
@@ -1,9 +1,12 @@
 {
   "id": "annke-c800-turret",
   "brand": "Annke",
-  "model": "C800 (Turret)",
+  "model": "C800 I91BM",
   "aliases": [
-    "4K 8MP PoE Turret I91BM"
+    "I91BM",
+    "C800 Turret",
+    "C800 (Turret)",
+    "4K 8MP PoE Turret"
   ],
   "type": "turret",
   "connectivity": [

--- a/cameras/annke/c800-turret.md
+++ b/cameras/annke/c800-turret.md
@@ -1,11 +1,11 @@
-# Annke C800 (Turret)
+# Annke C800 I91BM
 
-*Also known as: 4K 8MP PoE Turret I91BM*
+*Also known as: I91BM, C800 Turret, C800 (Turret), 4K 8MP PoE Turret*
 
 | Field | Spec |
 |-------|------|
 | Brand | Annke |
-| Model | C800 (Turret) |
+| Model | C800 I91BM |
 | Type | turret |
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP, 3840×2160) |

--- a/cameras/annke/cz425x-i81hb.json
+++ b/cameras/annke/cz425x-i81hb.json
@@ -1,51 +1,51 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-cz425x-i81hb",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "CZ425X I81HB",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "CZ425X",
+    "I81HB",
+    "AU-I81HB0102-V2",
+    "AU-I81HB",
+    "4MP 25X Zoom PTZ Speed Dome"
   ],
-  "type": "turret",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 4,
+    "max_width": 2560,
+    "max_height": 1440,
+    "label": "4MP (2560x1440)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "4.8-120 (25x optical zoom, 16x digital)",
     "aperture": "F1.6",
-    "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
+    "varifocal": true
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 50
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE+ (802.3at) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -53,33 +53,28 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP66, IK10",
   "audio": {
-    "microphone": true,
+    "microphone": false,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4MP PTZ speed dome",
+    "25x optical zoom (4.8-120mm), 16x digital",
+    "full-color night vision + IR up to 50m",
+    "IK10 vandal-resistant, 4000V lightning protection",
+    "1-ch audio in / 1-ch audio out (external mic/speaker)",
     "H.265+",
-    "IP67"
+    "PoE+ (802.3at)"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/cz425x"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/cz425x-i81hb.md
+++ b/cameras/annke/cz425x-i81hb.md
@@ -1,0 +1,36 @@
+# Annke CZ425X I81HB
+
+*Also known as: CZ425X, I81HB, AU-I81HB0102-V2, AU-I81HB, 4MP 25X Zoom PTZ Speed Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | CZ425X I81HB |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4.8-120 (25x optical zoom, 16x digital)mm F1.6 |
+| Night vision | hybrid (50m) |
+| Power | PoE+ (802.3at) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66, IK10 |
+| Two-way audio | No |
+
+## Features
+
+- 4MP PTZ speed dome
+- 25x optical zoom (4.8-120mm), 16x digital
+- full-color night vision + IR up to 50m
+- IK10 vandal-resistant, 4000V lightning protection
+- 1-ch audio in / 1-ch audio out (external mic/speaker)
+- H.265+
+- PoE+ (802.3at)
+
+## Sources
+
+- https://ca-en.annke.com/products/cz425x
+
+---
+*Auto-generated from annke-cz425x-i81hb.json — do not edit by hand.*

--- a/cameras/annke/cz804-i91de.json
+++ b/cameras/annke/cz804-i91de.json
@@ -1,47 +1,46 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-cz804-i91de",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "CZ804 I91DE",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "CZ804",
+    "I91DE",
+    "AN-I91DE0102",
+    "4K 4X Optical Zoom Bullet"
   ],
-  "type": "turret",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.4\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "2.8-12 (4x optical zoom)",
     "aperture": "F1.6",
-    "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
+    "varifocal": true
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 50
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +53,28 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP bullet, 4x optical zoom (2.8-12mm motorized varifocal)",
+    "Smart Dual-Light (IR up to 50m + white light)",
+    "active deterrence (spotlight + strobe alarm)",
+    "Motion Detection 2.0 (human/vehicle)",
+    "Color Night Vision (0.005 lux @ F1.6)",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/T/G), ISAPI"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/cz804?variant=50076426240275"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/cz804-i91de.md
+++ b/cameras/annke/cz804-i91de.md
@@ -1,0 +1,37 @@
+# Annke CZ804 I91DE
+
+*Also known as: CZ804, I91DE, AN-I91DE0102, 4K 4X Optical Zoom Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | CZ804 I91DE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/2.4" Progressive Scan CMOS |
+| Lens | 1× 2.8-12 (4x optical zoom)mm F1.6 |
+| Night vision | hybrid (50m) |
+| Power | PoE (802.3af, Class 3, max 12.9W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP bullet, 4x optical zoom (2.8-12mm motorized varifocal)
+- Smart Dual-Light (IR up to 50m + white light)
+- active deterrence (spotlight + strobe alarm)
+- Motion Detection 2.0 (human/vehicle)
+- Color Night Vision (0.005 lux @ F1.6)
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF (Profile S/T/G), ISAPI
+
+## Sources
+
+- https://ca-en.annke.com/products/cz804?variant=50076426240275
+
+---
+*Auto-generated from annke-cz804-i91de.json — do not edit by hand.*

--- a/cameras/annke/cz804-i91dq.json
+++ b/cameras/annke/cz804-i91dq.json
@@ -1,47 +1,45 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-cz804-i91dq",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "CZ804 I91DQ",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "CZ804",
+    "I91DQ",
+    "AN-I91DQ0102",
+    "4K 4X Optical Zoom Dome"
   ],
-  "type": "turret",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.4\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
-    "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
+    "focal_length_mm": "2.8-12 (4x optical zoom)",
+    "varifocal": true
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, Class 3, max 12W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -53,33 +51,29 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP67, IK08",
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP dome, 4x optical zoom (2.8-12mm motorized varifocal)",
+    "Smart Dual-Light (IR up to 30m + white light)",
+    "active deterrence (spotlight + strobe alarm)",
+    "Motion Detection 2.0 (human/vehicle)",
+    "IK08 vandal-resistant",
     "H.265+",
-    "IP67"
+    "built-in microphone (no two-way)",
+    "RTSP/ONVIF (Profile S/T/G), ISAPI"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/cz804"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/cz804-i91dq.md
+++ b/cameras/annke/cz804-i91dq.md
@@ -1,0 +1,37 @@
+# Annke CZ804 I91DQ
+
+*Also known as: CZ804, I91DQ, AN-I91DQ0102, 4K 4X Optical Zoom Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | CZ804 I91DQ |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/2.4" Progressive Scan CMOS |
+| Lens | 1× 2.8-12 (4x optical zoom)mm |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, Class 3, max 12W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67, IK08 |
+| Two-way audio | No |
+
+## Features
+
+- 4K 8MP dome, 4x optical zoom (2.8-12mm motorized varifocal)
+- Smart Dual-Light (IR up to 30m + white light)
+- active deterrence (spotlight + strobe alarm)
+- Motion Detection 2.0 (human/vehicle)
+- IK08 vandal-resistant
+- H.265+
+- built-in microphone (no two-way)
+- RTSP/ONVIF (Profile S/T/G), ISAPI
+
+## Sources
+
+- https://ca-en.annke.com/products/cz804
+
+---
+*Auto-generated from annke-cz804-i91dq.json — do not edit by hand.*

--- a/cameras/annke/cz825x-i91bw.json
+++ b/cameras/annke/cz825x-i91bw.json
@@ -1,86 +1,80 @@
 {
-  "id": "annke-c800-bullet",
+  "id": "annke-cz825x-i91bw",
   "brand": "Annke",
-  "model": "C800 I91BD",
+  "model": "CZ825X I91BW",
   "aliases": [
-    "I91BD",
-    "C800 Bullet",
-    "C800 (Bullet)",
-    "4K 8MP PoE Bullet"
+    "CZ825X",
+    "I91BW",
+    "25X Optical Zoom PTZ Speed Dome"
   ],
-  "type": "bullet",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2020,
   "resolution": {
     "megapixels": 8,
     "max_width": 3840,
     "max_height": 2160,
     "label": "4K UHD"
   },
-  "sensor": "1/2.4\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 / 4 (fixed)",
-    "aperture": "F1.6",
-    "varifocal": false
+    "focal_length_mm": "5.9-147.5 (25x optical zoom, 16x digital)",
+    "aperture": "F1.5",
+    "varifocal": true
   },
-  "field_of_view_deg": "78 horizontal / 96 diagonal (4mm)",
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
-      "H.264+",
-      "H.264",
-      "MJPEG"
-    ]
+      "H.264"
+    ],
+    "max_fps": 25
   },
   "night_vision": {
-    "type": "ir",
-    "range_m": 30
+    "type": "hybrid",
+    "range_m": 200
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V"
+    "method": "Hi-PoE / 24VAC (max 42W)"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
-  "operating_temp_c": "-30 to 60",
   "protocols": [
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
+  "ip_rating": "IP66, IK10",
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "4K 8MP PoE bullet",
-    "EXIR 2.0 night vision",
-    "120 dB WDR",
-    "3D DNR",
+    "4K PTZ speed dome",
+    "25x optical zoom (5.9-147.5mm), 16x digital",
+    "IR night vision up to 200m",
+    "color night vision (0.001 lux @ F1.5)",
+    "IK10 vandal-resistant",
+    "two-way audio (speaker range up to 30m)",
     "H.265+",
-    "AI human/vehicle detection",
-    "IP67",
-    "IK08",
-    "RTSP/ONVIF"
+    "Hi-PoE / 24VAC"
   ],
   "sources": [
-    "https://www.annke.com/products/c800"
+    "https://ca-en.annke.com/products/cz825x"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
-    "dc"
+    "ac-mains"
   ],
   "configs": {
     "frigate": {

--- a/cameras/annke/cz825x-i91bw.md
+++ b/cameras/annke/cz825x-i91bw.md
@@ -1,0 +1,37 @@
+# Annke CZ825X I91BW
+
+*Also known as: CZ825X, I91BW, 25X Optical Zoom PTZ Speed Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | CZ825X I91BW |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 5.9-147.5 (25x optical zoom, 16x digital)mm F1.5 |
+| Night vision | hybrid (200m) |
+| Power | Hi-PoE / 24VAC (max 42W) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66, IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K PTZ speed dome
+- 25x optical zoom (5.9-147.5mm), 16x digital
+- IR night vision up to 200m
+- color night vision (0.001 lux @ F1.5)
+- IK10 vandal-resistant
+- two-way audio (speaker range up to 30m)
+- H.265+
+- Hi-PoE / 24VAC
+
+## Sources
+
+- https://ca-en.annke.com/products/cz825x
+
+---
+*Auto-generated from annke-cz825x-i91bw.json — do not edit by hand.*

--- a/cameras/annke/fcd600-i51fs.json
+++ b/cameras/annke/fcd600-i51fs.json
@@ -1,47 +1,46 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-fcd600-i51fs",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "FCD600 I51FS",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "FCD600",
+    "I51FS",
+    "AN-I51FS0102",
+    "6MP Dual-Lens Bullet"
   ],
-  "type": "turret",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 6,
+    "max_width": 3632,
+    "max_height": 1632,
+    "label": "6MP panoramic (3632x1632)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "2x 1/2.5\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "count": 2,
+    "focal_length_mm": "2.8 (fixed, dual lens)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 11.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +53,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "6MP dual-lens panoramic bullet (2x 1/2.5\" sensors)",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "Color Night Vision (0.005 lux)",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/fcd600"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/fcd600-i51fs.md
+++ b/cameras/annke/fcd600-i51fs.md
@@ -1,0 +1,35 @@
+# Annke FCD600 I51FS
+
+*Also known as: FCD600, I51FS, AN-I51FS0102, 6MP Dual-Lens Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | FCD600 I51FS |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 6MP panoramic (3632x1632) (6MP, 3632×1632) |
+| Sensor | 2x 1/2.5" Progressive Scan CMOS |
+| Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 11.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 6MP dual-lens panoramic bullet (2x 1/2.5" sensors)
+- Smart Dual-Light (IR + white light up to 30m)
+- Color Night Vision (0.005 lux)
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://ca-en.annke.com/products/fcd600
+
+---
+*Auto-generated from annke-fcd600-i51fs.json — do not edit by hand.*

--- a/cameras/annke/fcd800-i91et.json
+++ b/cameras/annke/fcd800-i91et.json
@@ -1,47 +1,46 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-fcd800-i91et",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "FCD800 I91ET",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "FCD800",
+    "I91ET",
+    "AN-I91ET0102",
+    "4K Seamless Dual-Lens Turret"
   ],
-  "type": "turret",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
+    "megapixels": 8,
     "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "max_height": 1860,
+    "label": "4096x1860 panoramic"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "2x 1/2.4\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "count": 2,
+    "focal_length_mm": "2.8 (fixed, dual lens)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 11.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +53,27 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP seamless dual-lens panoramic turret (2x 1/2.4\" sensors)",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "active sound + light deterrence",
+    "Color Night Vision (0.005 lux)",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/fcd800"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/fcd800-i91et.md
+++ b/cameras/annke/fcd800-i91et.md
@@ -1,0 +1,36 @@
+# Annke FCD800 I91ET
+
+*Also known as: FCD800, I91ET, AN-I91ET0102, 4K Seamless Dual-Lens Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | FCD800 I91ET |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 4096x1860 panoramic (8MP, 4096×1860) |
+| Sensor | 2x 1/2.4" Progressive Scan CMOS |
+| Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 11.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP seamless dual-lens panoramic turret (2x 1/2.4" sensors)
+- Smart Dual-Light (IR + white light up to 30m)
+- active sound + light deterrence
+- Color Night Vision (0.005 lux)
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://ca-en.annke.com/products/fcd800
+
+---
+*Auto-generated from annke-fcd800-i91et.json — do not edit by hand.*

--- a/cameras/annke/fcd800-i91ev.json
+++ b/cameras/annke/fcd800-i91ev.json
@@ -1,47 +1,46 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-fcd800-i91ev",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "FCD800 I91EV",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "FCD800",
+    "I91EV",
+    "AN-I91EV0102",
+    "4K Seamless Dual-Lens Bullet"
   ],
-  "type": "turret",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
+    "megapixels": 8,
     "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "max_height": 1860,
+    "label": "4096x1860 panoramic"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "2x 1/2.4\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "count": 2,
+    "focal_length_mm": "2.8 (fixed, dual lens)",
     "aperture": "F1.6",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 11.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +53,27 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP seamless dual-lens panoramic bullet (2x 1/2.4\" sensors)",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "sound + light active deterrence (siren + spotlight)",
+    "Color Night Vision (0.005 lux)",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/fcd800?variant=51933939400979"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/fcd800-i91ev.md
+++ b/cameras/annke/fcd800-i91ev.md
@@ -1,0 +1,36 @@
+# Annke FCD800 I91EV
+
+*Also known as: FCD800, I91EV, AN-I91EV0102, 4K Seamless Dual-Lens Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | FCD800 I91EV |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 4096x1860 panoramic (8MP, 4096×1860) |
+| Sensor | 2x 1/2.4" Progressive Scan CMOS |
+| Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 11.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP seamless dual-lens panoramic bullet (2x 1/2.4" sensors)
+- Smart Dual-Light (IR + white light up to 30m)
+- sound + light active deterrence (siren + spotlight)
+- Color Night Vision (0.005 lux)
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://ca-en.annke.com/products/fcd800?variant=51933939400979
+
+---
+*Auto-generated from annke-fcd800-i91ev.json — do not edit by hand.*

--- a/cameras/annke/i51dx.json
+++ b/cameras/annke/i51dx.json
@@ -1,43 +1,38 @@
 {
-  "id": "annke-c800-bullet",
+  "id": "annke-i51dx",
   "brand": "Annke",
-  "model": "C800 I91BD",
+  "model": "I51DX",
   "aliases": [
-    "I91BD",
-    "C800 Bullet",
-    "C800 (Bullet)",
-    "4K 8MP PoE Bullet"
+    "6MP 180 Panoramic Turret",
+    "Dual-Lens Panoramic Turret"
   ],
-  "type": "bullet",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2020,
   "resolution": {
-    "megapixels": 8,
-    "max_width": 3840,
-    "max_height": 2160,
-    "label": "4K UHD"
+    "megapixels": 6,
+    "max_width": 3632,
+    "max_height": 1632,
+    "label": "6MP panoramic (3632x1632)"
   },
-  "sensor": "1/2.4\" Progressive Scan CMOS",
+  "sensor": "2x 1/2.5\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 / 4 (fixed)",
-    "aperture": "F1.6",
+    "count": 2,
+    "focal_length_mm": "2.8 (fixed, dual lens)",
+    "aperture": "F1.2",
     "varifocal": false
   },
-  "field_of_view_deg": "78 horizontal / 96 diagonal (4mm)",
   "video": {
     "codecs": [
-      "H.265+",
       "H.265",
-      "H.264+",
       "H.264",
       "MJPEG"
-    ]
+    ],
+    "max_fps": 20
   },
   "night_vision": {
-    "type": "ir",
+    "type": "hybrid",
     "range_m": 30
   },
   "power": {
@@ -45,39 +40,34 @@
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
-  "operating_temp_c": "-30 to 60",
   "protocols": [
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
+  "ip_rating": "IP66",
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "4K 8MP PoE bullet",
-    "EXIR 2.0 night vision",
-    "120 dB WDR",
-    "3D DNR",
-    "H.265+",
-    "AI human/vehicle detection",
-    "IP67",
-    "IK08",
+    "6MP 180-degree panoramic dual-lens turret (2x 1/2.5\" sensors)",
+    "Smart Dual-Light (white light up to 20m + IR up to 30m)",
+    "Color Night Vision (0.005 lux @ F1.2)",
+    "two-way audio (built-in mic + speaker)",
     "RTSP/ONVIF"
   ],
   "sources": [
-    "https://www.annke.com/products/c800"
+    "https://www.annkecctv.com/products/i51dx"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i51dx.md
+++ b/cameras/annke/i51dx.md
@@ -1,0 +1,34 @@
+# Annke I51DX
+
+*Also known as: 6MP 180 Panoramic Turret, Dual-Lens Panoramic Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I51DX |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 6MP panoramic (3632x1632) (6MP, 3632×1632) |
+| Sensor | 2x 1/2.5" Progressive Scan CMOS |
+| Lens | 2× 2.8 (fixed, dual lens)mm F1.2 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- 6MP 180-degree panoramic dual-lens turret (2x 1/2.5" sensors)
+- Smart Dual-Light (white light up to 20m + IR up to 30m)
+- Color Night Vision (0.005 lux @ F1.2)
+- two-way audio (built-in mic + speaker)
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i51dx
+
+---
+*Auto-generated from annke-i51dx.json — do not edit by hand.*

--- a/cameras/annke/i51ex.json
+++ b/cameras/annke/i51ex.json
@@ -1,47 +1,44 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i51ex",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I51EX",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "3K Mini PT Speed Dome",
+    "Mini PTZ Dome"
   ],
-  "type": "turret",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "3K (3072x1728)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
     "aperture": "F1.6",
     "varifocal": false
   },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
-  },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 10.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -53,33 +50,28 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP66",
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "mini PT speed dome (pan-tilt)",
+    "Smart Dual-Light (IR + white light up to 30m)",
+    "Color Night Vision (0.01 lux color, 0.005 lux B/W)",
+    "two-way audio (built-in mic + speaker)",
+    "3K (3072x1728) @ 20fps",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i51ex"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i51ex.md
+++ b/cameras/annke/i51ex.md
@@ -1,0 +1,36 @@
+# Annke I51EX
+
+*Also known as: 3K Mini PT Speed Dome, Mini PTZ Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I51EX |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 3K (3072x1728) (5MP, 3072×1728) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.6 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 10.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- mini PT speed dome (pan-tilt)
+- Smart Dual-Light (IR + white light up to 30m)
+- Color Night Vision (0.01 lux color, 0.005 lux B/W)
+- two-way audio (built-in mic + speaker)
+- 3K (3072x1728) @ 20fps
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i51ex
+
+---
+*Auto-generated from annke-i51ex.json — do not edit by hand.*

--- a/cameras/annke/i81em.json
+++ b/cameras/annke/i81em.json
@@ -1,51 +1,48 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i81em",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I81EM",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "3K Outdoor PT Camera",
+    "Fixed PT Network Camera"
   ],
-  "type": "turret",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "3K (3072x1728)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F1.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 10W) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -53,33 +50,28 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP66",
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "pan-tilt (PT) network camera",
+    "1/1.8\" large sensor, F1.0 lens",
+    "Smart white light up to 30m (full-color night vision)",
+    "two-way audio (built-in mic + speaker)",
+    "3K (3072x1728) @ 20fps",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i81em"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i81em.md
+++ b/cameras/annke/i81em.md
@@ -1,0 +1,36 @@
+# Annke I81EM
+
+*Also known as: 3K Outdoor PT Camera, Fixed PT Network Camera*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I81EM |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 3K (3072x1728) (5MP, 3072×1728) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.0 |
+| Night vision | color (30m) |
+| Power | PoE (802.3af, max 10W) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- pan-tilt (PT) network camera
+- 1/1.8" large sensor, F1.0 lens
+- Smart white light up to 30m (full-color night vision)
+- two-way audio (built-in mic + speaker)
+- 3K (3072x1728) @ 20fps
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i81em
+
+---
+*Auto-generated from annke-i81em.json — do not edit by hand.*

--- a/cameras/annke/i91bh.json
+++ b/cameras/annke/i91bh.json
@@ -1,35 +1,26 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i91bh",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I91BH",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "4K Panoramic Turret",
+    "Dual-Lens Panoramic Turret"
   ],
-  "type": "turret",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 5120,
+    "max_height": 1440,
+    "label": "5120x1440 panoramic"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "2x 1/1.8\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "count": 2,
+    "focal_length_mm": "4 (fixed, dual lens)",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
@@ -37,15 +28,19 @@
       "H.265",
       "H.264+",
       "H.264"
-    ]
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 40
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +49,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K dual-lens panoramic turret (2x 1/1.8\" sensors)",
+    "180-degree panoramic 5120x1440",
+    "24/7 full-color imaging (warm light up to 40m)",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF/ISAPI"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91bh"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i91bh.md
+++ b/cameras/annke/i91bh.md
@@ -1,0 +1,35 @@
+# Annke I91BH
+
+*Also known as: 4K Panoramic Turret, Dual-Lens Panoramic Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I91BH |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 5120x1440 panoramic (8MP, 5120×1440) |
+| Sensor | 2x 1/1.8" Progressive Scan CMOS |
+| Lens | 2× 4 (fixed, dual lens)mm |
+| Night vision | color (40m) |
+| Power | PoE (802.3af) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K dual-lens panoramic turret (2x 1/1.8" sensors)
+- 180-degree panoramic 5120x1440
+- 24/7 full-color imaging (warm light up to 40m)
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF/ISAPI
+
+## Sources
+
+- https://www.annkecctv.com/products/i91bh
+
+---
+*Auto-generated from annke-i91bh.json — do not edit by hand.*

--- a/cameras/annke/i91bi.json
+++ b/cameras/annke/i91bi.json
@@ -1,35 +1,26 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i91bi",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I91BI",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "8MP Panoramic Camera",
+    "Dual-Lens Panoramic"
   ],
-  "type": "turret",
+  "type": "panoramic",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 5120,
+    "max_height": 1440,
+    "label": "5120x1440 panoramic"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "2x 1/1.8\" Progressive Scan CMOS",
   "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "count": 2,
+    "focal_length_mm": "4 (fixed, dual lens)",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
@@ -37,15 +28,19 @@
       "H.265",
       "H.264+",
       "H.264"
-    ]
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 40
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +49,27 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "8MP dual-lens panoramic (2x 1/1.8\" sensors)",
+    "5120x1440 panoramic",
+    "24/7 full-color imaging (warm light up to 40m)",
+    "AI detection",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91bi"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i91bi.md
+++ b/cameras/annke/i91bi.md
@@ -1,0 +1,36 @@
+# Annke I91BI
+
+*Also known as: 8MP Panoramic Camera, Dual-Lens Panoramic*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I91BI |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 5120x1440 panoramic (8MP, 5120×1440) |
+| Sensor | 2x 1/1.8" Progressive Scan CMOS |
+| Lens | 2× 4 (fixed, dual lens)mm |
+| Night vision | color (40m) |
+| Power | PoE (802.3af) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 8MP dual-lens panoramic (2x 1/1.8" sensors)
+- 5120x1440 panoramic
+- 24/7 full-color imaging (warm light up to 40m)
+- AI detection
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i91bi
+
+---
+*Auto-generated from annke-i91bi.json — do not edit by hand.*

--- a/cameras/annke/i91bk.json
+++ b/cameras/annke/i91bk.json
@@ -1,51 +1,47 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i91bk",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I91BK",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "Mini Dome PTZ",
+    "4X Optical Zoom Mini PTZ"
   ],
-  "type": "turret",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "3K (3072x1728)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
-    "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
+    "focal_length_mm": "2.8-12 (4x optical zoom, 16x digital)",
+    "varifocal": true
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 15
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af) / DC 12V (max 9.2W)"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -53,33 +49,29 @@
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
+  "ip_rating": "IP66, IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "Mini dome PTZ",
+    "4x optical zoom (2.8-12mm), 16x digital zoom",
+    "IR night vision up to 20m",
+    "IK10 vandal-resistant",
+    "TVS 4000V lightning/surge protection",
+    "built-in mic + 1-ch audio in/out",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/G/T)"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91bk"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i91bk.md
+++ b/cameras/annke/i91bk.md
@@ -1,0 +1,37 @@
+# Annke I91BK
+
+*Also known as: Mini Dome PTZ, 4X Optical Zoom Mini PTZ*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I91BK |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 3K (3072x1728) (5MP, 3072×1728) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8-12 (4x optical zoom, 16x digital)mm |
+| Night vision | ir (20m) |
+| Power | PoE (802.3af) / DC 12V (max 9.2W) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66, IK10 |
+| Two-way audio | No |
+
+## Features
+
+- Mini dome PTZ
+- 4x optical zoom (2.8-12mm), 16x digital zoom
+- IR night vision up to 20m
+- IK10 vandal-resistant
+- TVS 4000V lightning/surge protection
+- built-in mic + 1-ch audio in/out
+- H.265+
+- RTSP/ONVIF (Profile S/G/T)
+
+## Sources
+
+- https://www.annkecctv.com/products/i91bk
+
+---
+*Auto-generated from annke-i91bk.json — do not edit by hand.*

--- a/cameras/annke/i91bv.json
+++ b/cameras/annke/i91bv.json
@@ -1,51 +1,42 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-i91bv",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "I91BV",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "4K Full-Color Turret",
+    "Acme Color Night Vision Turret"
   ],
   "type": "turret",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
-  "lens": {
-    "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
-    "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
-  },
+  "sensor": "1/1.2\" Progressive Scan CMOS",
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 25
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 40
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, Class 3) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +45,27 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP PoE turret",
+    "1/1.2\" large sensor",
+    "Acme full-color night vision (24/7 color imaging)",
+    "IR up to 40m",
     "H.265+",
-    "IP67"
+    "built-in microphone (audio recording)",
+    "RTSP/ONVIF"
+  ],
+  "sources": [
+    "https://www.annkecctv.com/products/i91bv"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/i91bv.md
+++ b/cameras/annke/i91bv.md
@@ -1,0 +1,35 @@
+# Annke I91BV
+
+*Also known as: 4K Full-Color Turret, Acme Color Night Vision Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | I91BV |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.2" Progressive Scan CMOS |
+| Night vision | hybrid (40m) |
+| Power | PoE (802.3af, Class 3) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- 4K 8MP PoE turret
+- 1/1.2" large sensor
+- Acme full-color night vision (24/7 color imaging)
+- IR up to 40m
+- H.265+
+- built-in microphone (audio recording)
+- RTSP/ONVIF
+
+## Sources
+
+- https://www.annkecctv.com/products/i91bv
+
+---
+*Auto-generated from annke-i91bv.json — do not edit by hand.*

--- a/cameras/annke/nc500-i81hd.json
+++ b/cameras/annke/nc500-i81hd.json
@@ -1,51 +1,52 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-nc500-i81hd",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "NC500 I81HD",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "NC500",
+    "NightChroma NC500",
+    "I81HD",
+    "AN-I81HD0102-V2",
+    "AN-I81HD",
+    "3K Full-Color Bullet"
   ],
-  "type": "turret",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "3K (3072x1728)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F1.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +55,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "NightChroma full-color night vision (0.001 lux @ F1.0)",
+    "3K (3072x1728) bullet",
+    "white light supplement up to 30m",
+    "built-in microphone (audio recording)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/T/G), ISAPI"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/nc500?variant=50076619899155"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/nc500-i81hd.md
+++ b/cameras/annke/nc500-i81hd.md
@@ -1,0 +1,35 @@
+# Annke NC500 I81HD
+
+*Also known as: NC500, NightChroma NC500, I81HD, AN-I81HD0102-V2, AN-I81HD, 3K Full-Color Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | NC500 I81HD |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 3K (3072x1728) (5MP, 3072×1728) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.0 |
+| Night vision | color (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- NightChroma full-color night vision (0.001 lux @ F1.0)
+- 3K (3072x1728) bullet
+- white light supplement up to 30m
+- built-in microphone (audio recording)
+- H.265+
+- RTSP/ONVIF (Profile S/T/G), ISAPI
+
+## Sources
+
+- https://ca-en.annke.com/products/nc500?variant=50076619899155
+
+---
+*Auto-generated from annke-nc500-i81hd.json — do not edit by hand.*

--- a/cameras/annke/nc500-i81he.json
+++ b/cameras/annke/nc500-i81he.json
@@ -1,51 +1,52 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-nc500-i81he",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "NC500 I81HE",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "NC500",
+    "NightChroma NC500",
+    "I81HE",
+    "AN-I81HE0102-V2",
+    "AN-I81HE",
+    "3K Full-Color Turret"
   ],
   "type": "turret",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "3K (3072x1728)"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F1.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 6.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
+    "max_microsd_gb": 256,
     "nvr_compatible": true,
     "cloud": false
   },
@@ -54,32 +55,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "NightChroma full-color night vision (0.001 lux @ F1.0)",
+    "3K (3072x1728) turret",
+    "white light supplement up to 30m",
+    "built-in microphone (audio recording)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/T/G), ISAPI"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/nc500"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/nc500-i81he.md
+++ b/cameras/annke/nc500-i81he.md
@@ -1,0 +1,35 @@
+# Annke NC500 I81HE
+
+*Also known as: NC500, NightChroma NC500, I81HE, AN-I81HE0102-V2, AN-I81HE, 3K Full-Color Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | NC500 I81HE |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 3K (3072x1728) (5MP, 3072×1728) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.0 |
+| Night vision | color (30m) |
+| Power | PoE (802.3af, max 6.5W) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | No |
+
+## Features
+
+- NightChroma full-color night vision (0.001 lux @ F1.0)
+- 3K (3072x1728) turret
+- white light supplement up to 30m
+- built-in microphone (audio recording)
+- H.265+
+- RTSP/ONVIF (Profile S/T/G), ISAPI
+
+## Sources
+
+- https://ca-en.annke.com/products/nc500
+
+---
+*Auto-generated from annke-nc500-i81he.json — do not edit by hand.*

--- a/cameras/annke/ncbr800-i91dj.json
+++ b/cameras/annke/ncbr800-i91dj.json
@@ -1,47 +1,48 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-ncbr800-i91dj",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "NCBR800 I91DJ",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "NCBR800",
+    "NightChroma NCBR800",
+    "I91DJ",
+    "AP-I91DJ0102",
+    "AP-I91DJ",
+    "4K Full-Color Bullet"
   ],
-  "type": "turret",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F1.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 25
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 10.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +55,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP NightChroma full-color bullet (1/1.8\" sensor, F1.0)",
+    "switchable white light / smart dual-light / IR (up to 30m)",
+    "full-color 0.0008 lux",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/ncbr800"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/ncbr800-i91dj.md
+++ b/cameras/annke/ncbr800-i91dj.md
@@ -1,0 +1,35 @@
+# Annke NCBR800 I91DJ
+
+*Also known as: NCBR800, NightChroma NCBR800, I91DJ, AP-I91DJ0102, AP-I91DJ, 4K Full-Color Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | NCBR800 I91DJ |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.0 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 10.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP NightChroma full-color bullet (1/1.8" sensor, F1.0)
+- switchable white light / smart dual-light / IR (up to 30m)
+- full-color 0.0008 lux
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://ca-en.annke.com/products/ncbr800
+
+---
+*Auto-generated from annke-ncbr800-i91dj.json — do not edit by hand.*

--- a/cameras/annke/ncbr800-i91du.json
+++ b/cameras/annke/ncbr800-i91du.json
@@ -1,47 +1,48 @@
 {
-  "id": "annke-c1200",
+  "id": "annke-ncbr800-i91du",
   "brand": "Annke",
-  "model": "C1200 I91DN",
+  "model": "NCBR800 I91DU",
   "aliases": [
-    "C1200",
-    "I91DN",
-    "C1200 Turret",
-    "12MP PoE AI Turret"
+    "NCBR800",
+    "NightChroma NCBR800",
+    "I91DU",
+    "AN-I91DU0103",
+    "AN-I91DU",
+    "4K Full-Color Turret"
   ],
   "type": "turret",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2024,
   "resolution": {
-    "megapixels": 12,
-    "max_width": 4096,
-    "max_height": 3072,
-    "label": "12MP UHD"
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.8 (fixed)",
-    "aperture": "F1.6",
+    "aperture": "F1.0",
     "varifocal": false
-  },
-  "field_of_view_deg": "113 horizontal (134 diagonal)",
-  "night_vision": {
-    "type": "hybrid",
-    "range_m": 30
   },
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
       "H.264+",
-      "H.264"
-    ]
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 25
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 6.5
+    "method": "PoE (802.3af, max 10.5W) / DC 12V"
   },
   "storage": {
     "onboard": true,
@@ -54,32 +55,26 @@
     "onvif"
   ],
   "ip_rating": "IP67",
-  "operating_temp_c": "-30 to 60",
-  "environment": [
-    "outdoor"
-  ],
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
-    "12MP (4096x3072) ultra-high resolution",
-    "available in turret or bullet form",
-    "AI human/vehicle detection (Motion Detection 2.0)",
-    "smart dual-light (IR + white light) color night vision",
-    "30m supplement light range",
-    "120 dB WDR",
+    "4K 8MP NightChroma full-color turret (1/1.8\" sensor, F1.0)",
+    "switchable white light / smart dual-light / IR (up to 30m)",
+    "full-color 0.0008 lux",
+    "two-way audio (built-in mic + speaker)",
     "H.265+",
-    "IP67"
+    "RTSP/ONVIF (Profile S/T/G)"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/ncbr800?variant=50144218579219"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
-  "sources": [
-    "https://www.annke.com/products/c1200"
-  ],
+  "last_verified": "2026-07-19",
   "power_source": [
     "poe",
     "dc"

--- a/cameras/annke/ncbr800-i91du.md
+++ b/cameras/annke/ncbr800-i91du.md
@@ -1,0 +1,35 @@
+# Annke NCBR800 I91DU
+
+*Also known as: NCBR800, NightChroma NCBR800, I91DU, AN-I91DU0103, AN-I91DU, 4K Full-Color Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | NCBR800 I91DU |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 (fixed)mm F1.0 |
+| Night vision | hybrid (30m) |
+| Power | PoE (802.3af, max 10.5W) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP NightChroma full-color turret (1/1.8" sensor, F1.0)
+- switchable white light / smart dual-light / IR (up to 30m)
+- full-color 0.0008 lux
+- two-way audio (built-in mic + speaker)
+- H.265+
+- RTSP/ONVIF (Profile S/T/G)
+
+## Sources
+
+- https://ca-en.annke.com/products/ncbr800?variant=50144218579219
+
+---
+*Auto-generated from annke-ncbr800-i91du.json — do not edit by hand.*

--- a/cameras/annke/nct425-i81el.json
+++ b/cameras/annke/nct425-i81el.json
@@ -1,0 +1,100 @@
+{
+  "id": "annke-nct425-i81el",
+  "brand": "Annke",
+  "model": "NCT425 I81EL",
+  "aliases": [
+    "NCT425",
+    "NightChroma NCT425",
+    "I81EL",
+    "AU-I81EL0102",
+    "2-in-1 Dual-Lens PTZ"
+  ],
+  "type": "dual-lens",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 4,
+    "max_width": 2560,
+    "max_height": 1440,
+    "label": "4MP per channel (2560x1440)"
+  },
+  "sensor": "1/3\" (fixed bullet) + 1/2.8\" (PTZ) Progressive Scan CMOS",
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "bullet 2.8 (F1.0) + PTZ 4.8-120 (25x optical zoom)",
+    "varifocal": true
+  },
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE+ (802.3at, max 24W) / DC 12V"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "2-in-1 dual-lens: fixed bullet (2.8mm F1.0) + 25x optical zoom PTZ (4.8-120mm)",
+    "NightChroma full-color on bullet (0.0005 lux) + IR up to 100m on PTZ",
+    "4MP per channel @ 30fps",
+    "1-ch audio in / 1-ch audio out (external mic/speaker)",
+    "6000V lightning protection, IP66",
+    "H.265+",
+    "PoE+ (802.3at, 24W)"
+  ],
+  "sources": [
+    "https://ca-en.annke.com/products/nct425"
+  ],
+  "markets": [
+    "global"
+  ],
+  "last_verified": "2026-07-19",
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "notes": "Uses Hikvision protocol. ONVIF integration works. Dual-channel: bullet + PTZ on separate channels."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+    }
+  }
+}

--- a/cameras/annke/nct425-i81el.md
+++ b/cameras/annke/nct425-i81el.md
@@ -1,0 +1,36 @@
+# Annke NCT425 I81EL
+
+*Also known as: NCT425, NightChroma NCT425, I81EL, AU-I81EL0102, 2-in-1 Dual-Lens PTZ*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | NCT425 I81EL |
+| Type | dual-lens |
+| Connectivity | ethernet |
+| Resolution | 4MP per channel (2560x1440) (4MP, 2560×1440) |
+| Sensor | 1/3" (fixed bullet) + 1/2.8" (PTZ) Progressive Scan CMOS |
+| Lens | 2× bullet 2.8 (F1.0) + PTZ 4.8-120 (25x optical zoom)mm |
+| Night vision | hybrid (100m) |
+| Power | PoE+ (802.3at, max 24W) / DC 12V |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP66 |
+| Two-way audio | No |
+
+## Features
+
+- 2-in-1 dual-lens: fixed bullet (2.8mm F1.0) + 25x optical zoom PTZ (4.8-120mm)
+- NightChroma full-color on bullet (0.0005 lux) + IR up to 100m on PTZ
+- 4MP per channel @ 30fps
+- 1-ch audio in / 1-ch audio out (external mic/speaker)
+- 6000V lightning protection, IP66
+- H.265+
+- PoE+ (802.3at, 24W)
+
+## Sources
+
+- https://ca-en.annke.com/products/nct425
+
+---
+*Auto-generated from annke-nct425-i81el.json — do not edit by hand.*

--- a/cameras/annke/slpr400-i81hy.json
+++ b/cameras/annke/slpr400-i81hy.json
@@ -1,86 +1,80 @@
 {
-  "id": "annke-c800-bullet",
+  "id": "annke-slpr400-i81hy",
   "brand": "Annke",
-  "model": "C800 I91BD",
+  "model": "SLPR400 I81HY",
   "aliases": [
-    "I91BD",
-    "C800 Bullet",
-    "C800 (Bullet)",
-    "4K 8MP PoE Bullet"
+    "SLPR400",
+    "I81HY",
+    "AU-I81HY0102",
+    "4MP ANPR LPR Bullet",
+    "License Plate Recognition Camera"
   ],
   "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
-  "release_year": 2020,
   "resolution": {
-    "megapixels": 8,
-    "max_width": 3840,
-    "max_height": 2160,
-    "label": "4K UHD"
+    "megapixels": 4,
+    "max_width": 2560,
+    "max_height": 1440,
+    "label": "4MP"
   },
-  "sensor": "1/2.4\" Progressive Scan CMOS",
+  "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 / 4 (fixed)",
-    "aperture": "F1.6",
-    "varifocal": false
+    "focal_length_mm": "2.7-13.5 (5x optical zoom)",
+    "aperture": "F1.4",
+    "varifocal": true
   },
-  "field_of_view_deg": "78 horizontal / 96 diagonal (4mm)",
   "video": {
     "codecs": [
       "H.265+",
       "H.265",
-      "H.264+",
-      "H.264",
-      "MJPEG"
-    ]
+      "H.264"
+    ],
+    "max_fps": 30
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 60
   },
   "power": {
-    "method": "PoE (802.3af) / DC 12V"
+    "method": "PoE"
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 512,
     "nvr_compatible": true,
     "cloud": false
   },
-  "operating_temp_c": "-30 to 60",
   "protocols": [
     "rtsp",
     "onvif"
   ],
-  "ip_rating": "IP67",
+  "ip_rating": "IP67, IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
     "two_way": false
   },
   "features": [
-    "4K 8MP PoE bullet",
-    "EXIR 2.0 night vision",
-    "120 dB WDR",
-    "3D DNR",
-    "H.265+",
-    "AI human/vehicle detection",
-    "IP67",
-    "IK08",
-    "RTSP/ONVIF"
+    "ANPR / LPR license plate recognition (deep-learning)",
+    "vehicle detection + block/allow list management",
+    "recognizes motorcycle plates",
+    "4MP motorized varifocal (2.7-13.5mm, 5x optical zoom, autofocus)",
+    "IR up to 60m (0.003 lux)",
+    "IK10 vandal-resistant, IP67",
+    "for traffic checkpoints / access control",
+    "H.265+"
   ],
   "sources": [
-    "https://www.annke.com/products/c800"
+    "https://ca-en.annke.com/products/slpr400"
   ],
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-07-19",
   "power_source": [
-    "poe",
-    "dc"
+    "poe"
   ],
   "configs": {
     "frigate": {

--- a/cameras/annke/slpr400-i81hy.md
+++ b/cameras/annke/slpr400-i81hy.md
@@ -1,0 +1,37 @@
+# Annke SLPR400 I81HY
+
+*Also known as: SLPR400, I81HY, AU-I81HY0102, 4MP ANPR LPR Bullet, License Plate Recognition Camera*
+
+| Field | Spec |
+|-------|------|
+| Brand | Annke |
+| Model | SLPR400 I81HY |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2560×1440) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 2.7-13.5 (5x optical zoom)mm F1.4 |
+| Night vision | ir (60m) |
+| Power | PoE |
+| Storage | NVR |
+| Protocols | rtsp, onvif |
+| IP rating | IP67, IK10 |
+| Two-way audio | No |
+
+## Features
+
+- ANPR / LPR license plate recognition (deep-learning)
+- vehicle detection + block/allow list management
+- recognizes motorcycle plates
+- 4MP motorized varifocal (2.7-13.5mm, 5x optical zoom, autofocus)
+- IR up to 60m (0.003 lux)
+- IK10 vandal-resistant, IP67
+- for traffic checkpoints / access control
+- H.265+
+
+## Sources
+
+- https://ca-en.annke.com/products/slpr400
+
+---
+*Auto-generated from annke-slpr400-i81hy.json — do not edit by hand.*

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -376,14 +376,41 @@ amcrest-ip8m-vt2879ew-ai,Amcrest,IP8M-VT2879EW-AI,turret,4K,8,"1/2.8"" CMOS",31-
 annke-ac400,Annke,AC400,dome,4MP,4,"1/3"" Progressive Scan CMOS",104 horizontal (123 diagonal),ir,IP67,false,2023
 annke-ac500,Annke,AC500,turret,5MP 3K,5,"1/3"" BSI CMOS",105 horizontal,hybrid,IP67,true,2023
 annke-ac800,Annke,AC800,bullet,4K UHD,8,"1/1.8"" BSI CMOS",102 horizontal (134 diagonal),hybrid,IP67,true,2022
-annke-c1200,Annke,C1200,turret,12MP UHD,12,"1/2.7"" Progressive Scan CMOS",113 horizontal (134 diagonal),hybrid,IP67,false,2024
+annke-c1200,Annke,C1200 I91DN,turret,12MP UHD,12,"1/2.7"" Progressive Scan CMOS",113 horizontal (134 diagonal),hybrid,IP67,false,2024
+annke-c1200-i91dd,Annke,C1200 I91DD,bullet,12MP,12,"1/2.7"" Progressive Scan CMOS",,hybrid,IP67,false,
+annke-c1200d-i91dg,Annke,C1200D I91DG,dome,12MP,12,"1/2.7"" Progressive Scan CMOS",,hybrid,"IP67, IK08",false,
 annke-c500,Annke,C500,bullet,5MP 3K,5,"OmniVision 1/2.7"" CMOS",100 horizontal (2.8mm),ir,IP67,false,2021
-annke-c800-bullet,Annke,C800 (Bullet),bullet,4K UHD,8,"1/2.4"" Progressive Scan CMOS",78 horizontal / 96 diagonal (4mm),ir,IP67,false,2020
-annke-c800-turret,Annke,C800 (Turret),turret,4K UHD,8,"1/2.4"" Progressive Scan CMOS",78 horizontal / 96 diagonal (4mm),ir,IP67,false,2020
+annke-c500d-i51dn,Annke,C500D I51DN,dome,3K (2592x1944),5,"1/3"" OmniVision Progressive Scan CMOS",,ir,IP67,false,
+annke-c800-bullet,Annke,C800 I91BD,bullet,4K UHD,8,"1/2.4"" Progressive Scan CMOS",78 horizontal / 96 diagonal (4mm),ir,IP67,false,2020
+annke-c800-i91db,Annke,C800 I91DB,turret,4K UHD,8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-c800-i91df,Annke,C800 I91DF,dome,4K UHD,8,"1/2.4"" Progressive Scan CMOS",,hybrid,"IP67, IK08",false,
+annke-c800-i91dl,Annke,C800 I91DL,bullet,4K UHD,8,"1/2.4"" Progressive Scan CMOS",,hybrid,IP67,false,
+annke-c800-i91dm,Annke,C800 I91DM,turret,4K UHD,8,"1/2.4"" Progressive Scan CMOS",,hybrid,IP67,false,
+annke-c800-turret,Annke,C800 I91BM,turret,4K UHD,8,"1/2.4"" Progressive Scan CMOS",78 horizontal / 96 diagonal (4mm),ir,IP67,false,2020
 annke-c800x,Annke,C800X,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS (BSI)",111 horizontal / 134 diagonal,hybrid,IP67,true,2023
+annke-cz425x-i81hb,Annke,CZ425X I81HB,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",,hybrid,"IP66, IK10",false,
+annke-cz804-i91de,Annke,CZ804 I91DE,bullet,4K UHD,8,"1/2.4"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-cz804-i91dq,Annke,CZ804 I91DQ,dome,4K UHD,8,"1/2.4"" Progressive Scan CMOS",,hybrid,"IP67, IK08",false,
+annke-cz825x-i91bw,Annke,CZ825X I91BW,ptz,4K UHD,8,"1/1.8"" Progressive Scan CMOS",,hybrid,"IP66, IK10",true,
+annke-fcd600-i51fs,Annke,FCD600 I51FS,panoramic,6MP panoramic (3632x1632),6,"2x 1/2.5"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-fcd800-i91et,Annke,FCD800 I91ET,panoramic,4096x1860 panoramic,8,"2x 1/2.4"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-fcd800-i91ev,Annke,FCD800 I91EV,panoramic,4096x1860 panoramic,8,"2x 1/2.4"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-i51dx,Annke,I51DX,panoramic,6MP panoramic (3632x1632),6,"2x 1/2.5"" Progressive Scan CMOS",,hybrid,IP66,true,
+annke-i51ex,Annke,I51EX,ptz,3K (3072x1728),5,"1/3"" Progressive Scan CMOS",,hybrid,IP66,true,
 annke-i61dq,Annke,I61DQ,dual-lens,6MP (dual-lens 180°),6,,180 horizontal,hybrid,IP67,true,2024
+annke-i81em,Annke,I81EM,ptz,3K (3072x1728),5,"1/1.8"" Progressive Scan CMOS",,color,IP66,true,
+annke-i91bh,Annke,I91BH,panoramic,5120x1440 panoramic,8,"2x 1/1.8"" Progressive Scan CMOS",,color,IP67,true,
+annke-i91bi,Annke,I91BI,panoramic,5120x1440 panoramic,8,"2x 1/1.8"" Progressive Scan CMOS",,color,IP67,true,
+annke-i91bk,Annke,I91BK,ptz,3K (3072x1728),5,"1/2.8"" Progressive Scan CMOS",,ir,"IP66, IK10",false,
+annke-i91bv,Annke,I91BV,turret,4K UHD,8,"1/1.2"" Progressive Scan CMOS",,hybrid,IP67,false,
 annke-nc400,Annke,NC400,bullet,4MP,4,"1/2.7"" CMOS",107h,color,IP67,false,2021
+annke-nc500-i81hd,Annke,NC500 I81HD,bullet,3K (3072x1728),5,"1/3"" Progressive Scan CMOS",,color,IP67,false,
+annke-nc500-i81he,Annke,NC500 I81HE,turret,3K (3072x1728),5,"1/3"" Progressive Scan CMOS",,color,IP67,false,
 annke-nc800,Annke,NightChroma NC800,turret,4K UHD,8,"1/1.2"" BSI CMOS",102h,color,IP67,false,2023
+annke-ncbr800-i91dj,Annke,NCBR800 I91DJ,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-ncbr800-i91du,Annke,NCBR800 I91DU,turret,4K UHD,8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,true,
+annke-nct425-i81el,Annke,NCT425 I81EL,dual-lens,4MP per channel (2560x1440),4,"1/3"" (fixed bullet) + 1/2.8"" (PTZ) Progressive Scan CMOS",,hybrid,IP66,false,
+annke-slpr400-i81hy,Annke,SLPR400 I81HY,bullet,4MP,4,"1/3"" Progressive Scan CMOS",,ir,"IP67, IK10",false,
 annke-video-doorbell,Annke,Video Doorbell HD,doorbell,1080p HD,2,,130h,ir,IP44,true,2023
 annke-wz500,Annke,WZ500,ptz,5MP,5,"1/2.8"" Sony CMOS",,hybrid,IP66,true,2023
 aqara-camera-hub-g3,Aqara,Camera Hub G3,ptz,3MP,3,CMOS,360 pan / 90 tilt,ir,IP20,true,2021

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -33989,8 +33989,11 @@
   {
     "id": "annke-c1200",
     "brand": "Annke",
-    "model": "C1200",
+    "model": "C1200 I91DN",
     "aliases": [
+      "C1200",
+      "I91DN",
+      "C1200 Turret",
       "12MP PoE AI Turret"
     ],
     "type": "turret",
@@ -34091,6 +34094,207 @@
     "added": "2026-06-09"
   },
   {
+    "id": "annke-c1200-i91dd",
+    "brand": "Annke",
+    "model": "C1200 I91DD",
+    "aliases": [
+      "C1200",
+      "I91DD",
+      "C1200 Bullet",
+      "12MP Smart Dual Light Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 4096,
+      "max_height": 3072,
+      "label": "12MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 10
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "12MP (4096x3072) PoE bullet",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux)",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dd"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c1200d-i91dg",
+    "brand": "Annke",
+    "model": "C1200D I91DG",
+    "aliases": [
+      "C1200D",
+      "I91DG",
+      "AN-I91DG0102",
+      "AN-I91DG",
+      "12MP Smart Dual Light Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 4096,
+      "max_height": 3072,
+      "label": "12MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 10
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "12MP (4096x3072) PoE dome",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux @ F2.0)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/c1200d"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c500",
     "brand": "Annke",
     "model": "C500",
@@ -34185,10 +34389,112 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-c500d-i51dn",
+    "brand": "Annke",
+    "model": "C500D I51DN",
+    "aliases": [
+      "C500D",
+      "I51DN",
+      "AN-I51DN0102-V5",
+      "AN-I51DN",
+      "3K PoE Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 2592,
+      "max_height": 1944,
+      "label": "3K (2592x1944)"
+    },
+    "sensor": "1/3\" OmniVision Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "3K (2592x1944) PoE dome",
+      "EXIR 2.0 IR night vision up to 30m",
+      "noise-cancelling built-in microphone",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/c500d"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c800-bullet",
     "brand": "Annke",
-    "model": "C800 (Bullet)",
+    "model": "C800 I91BD",
     "aliases": [
+      "I91BD",
+      "C800 Bullet",
+      "C800 (Bullet)",
       "4K 8MP PoE Bullet"
     ],
     "type": "bullet",
@@ -34287,11 +34593,422 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-c800-i91db",
+    "brand": "Annke",
+    "model": "C800 I91DB",
+    "aliases": [
+      "I91DB",
+      "C800 Turret",
+      "4K Fixed Turret",
+      "4K Color Night Vision PoE Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "1/1.8\" large sensor",
+      "Color Night Vision",
+      "active deterrence (strobe light + siren)",
+      "two-way audio (built-in mic + speaker)",
+      "Smart IR up to 30m",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91db"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91df",
+    "brand": "Annke",
+    "model": "C800 I91DF",
+    "aliases": [
+      "I91DF",
+      "AN-I91DF0104-V2",
+      "AN-I91DF",
+      "C800D",
+      "C800 Dome",
+      "4K 8MP Smart Dual Light Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE dome",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91df"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91dl",
+    "brand": "Annke",
+    "model": "C800 I91DL",
+    "aliases": [
+      "I91DL",
+      "AN-I91DL0104-V3",
+      "AN-I91DL",
+      "C800 Bullet",
+      "4K Smart Dual Light Bullet",
+      "4K 8MP PoE Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE bullet",
+      "Smart Dual-Light (IR + white light)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "supplement light up to 30m",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dl"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91dm",
+    "brand": "Annke",
+    "model": "C800 I91DM",
+    "aliases": [
+      "I91DM",
+      "AN-I91DM0104-V2",
+      "AN-I91DM",
+      "C800 Turret",
+      "4K 8MP Smart Dual Light Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "Smart Dual-Light (IR up to 30m + white light up to 20m)",
+      "Color Night Vision",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dm"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c800-turret",
     "brand": "Annke",
-    "model": "C800 (Turret)",
+    "model": "C800 I91BM",
     "aliases": [
-      "4K 8MP PoE Turret I91BM"
+      "I91BM",
+      "C800 Turret",
+      "C800 (Turret)",
+      "4K 8MP PoE Turret"
     ],
     "type": "turret",
     "connectivity": [
@@ -34488,6 +35205,906 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-cz425x-i81hb",
+    "brand": "Annke",
+    "model": "CZ425X I81HB",
+    "aliases": [
+      "CZ425X",
+      "I81HB",
+      "AU-I81HB0102-V2",
+      "AU-I81HB",
+      "4MP 25X Zoom PTZ Speed Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP (2560x1440)"
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8-120 (25x optical zoom, 16x digital)",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE+ (802.3at) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4MP PTZ speed dome",
+      "25x optical zoom (4.8-120mm), 16x digital",
+      "full-color night vision + IR up to 50m",
+      "IK10 vandal-resistant, 4000V lightning protection",
+      "1-ch audio in / 1-ch audio out (external mic/speaker)",
+      "H.265+",
+      "PoE+ (802.3at)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz425x"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz804-i91de",
+    "brand": "Annke",
+    "model": "CZ804 I91DE",
+    "aliases": [
+      "CZ804",
+      "I91DE",
+      "AN-I91DE0102",
+      "4K 4X Optical Zoom Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom)",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP bullet, 4x optical zoom (2.8-12mm motorized varifocal)",
+      "Smart Dual-Light (IR up to 50m + white light)",
+      "active deterrence (spotlight + strobe alarm)",
+      "Motion Detection 2.0 (human/vehicle)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz804?variant=50076426240275"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz804-i91dq",
+    "brand": "Annke",
+    "model": "CZ804 I91DQ",
+    "aliases": [
+      "CZ804",
+      "I91DQ",
+      "AN-I91DQ0102",
+      "4K 4X Optical Zoom Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3, max 12W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP dome, 4x optical zoom (2.8-12mm motorized varifocal)",
+      "Smart Dual-Light (IR up to 30m + white light)",
+      "active deterrence (spotlight + strobe alarm)",
+      "Motion Detection 2.0 (human/vehicle)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (no two-way)",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz804"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz825x-i91bw",
+    "brand": "Annke",
+    "model": "CZ825X I91BW",
+    "aliases": [
+      "CZ825X",
+      "I91BW",
+      "25X Optical Zoom PTZ Speed Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-147.5 (25x optical zoom, 16x digital)",
+      "aperture": "F1.5",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 200
+    },
+    "power": {
+      "method": "Hi-PoE / 24VAC (max 42W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K PTZ speed dome",
+      "25x optical zoom (5.9-147.5mm), 16x digital",
+      "IR night vision up to 200m",
+      "color night vision (0.001 lux @ F1.5)",
+      "IK10 vandal-resistant",
+      "two-way audio (speaker range up to 30m)",
+      "H.265+",
+      "Hi-PoE / 24VAC"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz825x"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd600-i51fs",
+    "brand": "Annke",
+    "model": "FCD600 I51FS",
+    "aliases": [
+      "FCD600",
+      "I51FS",
+      "AN-I51FS0102",
+      "6MP Dual-Lens Bullet"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3632,
+      "max_height": 1632,
+      "label": "6MP panoramic (3632x1632)"
+    },
+    "sensor": "2x 1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "6MP dual-lens panoramic bullet (2x 1/2.5\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd600"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd800-i91et",
+    "brand": "Annke",
+    "model": "FCD800 I91ET",
+    "aliases": [
+      "FCD800",
+      "I91ET",
+      "AN-I91ET0102",
+      "4K Seamless Dual-Lens Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 4096,
+      "max_height": 1860,
+      "label": "4096x1860 panoramic"
+    },
+    "sensor": "2x 1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP seamless dual-lens panoramic turret (2x 1/2.4\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "active sound + light deterrence",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd800"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd800-i91ev",
+    "brand": "Annke",
+    "model": "FCD800 I91EV",
+    "aliases": [
+      "FCD800",
+      "I91EV",
+      "AN-I91EV0102",
+      "4K Seamless Dual-Lens Bullet"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 4096,
+      "max_height": 1860,
+      "label": "4096x1860 panoramic"
+    },
+    "sensor": "2x 1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP seamless dual-lens panoramic bullet (2x 1/2.4\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "sound + light active deterrence (siren + spotlight)",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd800?variant=51933939400979"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i51dx",
+    "brand": "Annke",
+    "model": "I51DX",
+    "aliases": [
+      "6MP 180 Panoramic Turret",
+      "Dual-Lens Panoramic Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3632,
+      "max_height": 1632,
+      "label": "6MP panoramic (3632x1632)"
+    },
+    "sensor": "2x 1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.2",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "6MP 180-degree panoramic dual-lens turret (2x 1/2.5\" sensors)",
+      "Smart Dual-Light (white light up to 20m + IR up to 30m)",
+      "Color Night Vision (0.005 lux @ F1.2)",
+      "two-way audio (built-in mic + speaker)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i51dx"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i51ex",
+    "brand": "Annke",
+    "model": "I51EX",
+    "aliases": [
+      "3K Mini PT Speed Dome",
+      "Mini PTZ Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "mini PT speed dome (pan-tilt)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux color, 0.005 lux B/W)",
+      "two-way audio (built-in mic + speaker)",
+      "3K (3072x1728) @ 20fps",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i51ex"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-i61dq",
     "brand": "Annke",
     "model": "I61DQ",
@@ -34576,6 +36193,490 @@
       }
     },
     "added": "2026-06-09"
+  },
+  {
+    "id": "annke-i81em",
+    "brand": "Annke",
+    "model": "I81EM",
+    "aliases": [
+      "3K Outdoor PT Camera",
+      "Fixed PT Network Camera"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "pan-tilt (PT) network camera",
+      "1/1.8\" large sensor, F1.0 lens",
+      "Smart white light up to 30m (full-color night vision)",
+      "two-way audio (built-in mic + speaker)",
+      "3K (3072x1728) @ 20fps",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i81em"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bh",
+    "brand": "Annke",
+    "model": "I91BH",
+    "aliases": [
+      "4K Panoramic Turret",
+      "Dual-Lens Panoramic Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 5120,
+      "max_height": 1440,
+      "label": "5120x1440 panoramic"
+    },
+    "sensor": "2x 1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "4 (fixed, dual lens)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K dual-lens panoramic turret (2x 1/1.8\" sensors)",
+      "180-degree panoramic 5120x1440",
+      "24/7 full-color imaging (warm light up to 40m)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF/ISAPI"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bh"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bi",
+    "brand": "Annke",
+    "model": "I91BI",
+    "aliases": [
+      "8MP Panoramic Camera",
+      "Dual-Lens Panoramic"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 5120,
+      "max_height": 1440,
+      "label": "5120x1440 panoramic"
+    },
+    "sensor": "2x 1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "4 (fixed, dual lens)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP dual-lens panoramic (2x 1/1.8\" sensors)",
+      "5120x1440 panoramic",
+      "24/7 full-color imaging (warm light up to 40m)",
+      "AI detection",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bi"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bk",
+    "brand": "Annke",
+    "model": "I91BK",
+    "aliases": [
+      "Mini Dome PTZ",
+      "4X Optical Zoom Mini PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom, 16x digital)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V (max 9.2W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "Mini dome PTZ",
+      "4x optical zoom (2.8-12mm), 16x digital zoom",
+      "IR night vision up to 20m",
+      "IK10 vandal-resistant",
+      "TVS 4000V lightning/surge protection",
+      "built-in mic + 1-ch audio in/out",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/G/T)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bk"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bv",
+    "brand": "Annke",
+    "model": "I91BV",
+    "aliases": [
+      "4K Full-Color Turret",
+      "Acme Color Night Vision Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" Progressive Scan CMOS",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "1/1.2\" large sensor",
+      "Acme full-color night vision (24/7 color imaging)",
+      "IR up to 40m",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bv"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "annke-nc400",
@@ -34671,6 +36772,210 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-nc500-i81hd",
+    "brand": "Annke",
+    "model": "NC500 I81HD",
+    "aliases": [
+      "NC500",
+      "NightChroma NC500",
+      "I81HD",
+      "AN-I81HD0102-V2",
+      "AN-I81HD",
+      "3K Full-Color Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "NightChroma full-color night vision (0.001 lux @ F1.0)",
+      "3K (3072x1728) bullet",
+      "white light supplement up to 30m",
+      "built-in microphone (audio recording)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nc500?variant=50076619899155"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-nc500-i81he",
+    "brand": "Annke",
+    "model": "NC500 I81HE",
+    "aliases": [
+      "NC500",
+      "NightChroma NC500",
+      "I81HE",
+      "AN-I81HE0102-V2",
+      "AN-I81HE",
+      "3K Full-Color Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "NightChroma full-color night vision (0.001 lux @ F1.0)",
+      "3K (3072x1728) turret",
+      "white light supplement up to 30m",
+      "built-in microphone (audio recording)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nc500"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-nc800",
     "brand": "Annke",
     "model": "NightChroma NC800",
@@ -34763,6 +37068,410 @@
       }
     },
     "added": "2026-06-06"
+  },
+  {
+    "id": "annke-ncbr800-i91dj",
+    "brand": "Annke",
+    "model": "NCBR800 I91DJ",
+    "aliases": [
+      "NCBR800",
+      "NightChroma NCBR800",
+      "I91DJ",
+      "AP-I91DJ0102",
+      "AP-I91DJ",
+      "4K Full-Color Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP NightChroma full-color bullet (1/1.8\" sensor, F1.0)",
+      "switchable white light / smart dual-light / IR (up to 30m)",
+      "full-color 0.0008 lux",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/ncbr800"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-ncbr800-i91du",
+    "brand": "Annke",
+    "model": "NCBR800 I91DU",
+    "aliases": [
+      "NCBR800",
+      "NightChroma NCBR800",
+      "I91DU",
+      "AN-I91DU0103",
+      "AN-I91DU",
+      "4K Full-Color Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP NightChroma full-color turret (1/1.8\" sensor, F1.0)",
+      "switchable white light / smart dual-light / IR (up to 30m)",
+      "full-color 0.0008 lux",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/ncbr800?variant=50144218579219"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-nct425-i81el",
+    "brand": "Annke",
+    "model": "NCT425 I81EL",
+    "aliases": [
+      "NCT425",
+      "NightChroma NCT425",
+      "I81EL",
+      "AU-I81EL0102",
+      "2-in-1 Dual-Lens PTZ"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP per channel (2560x1440)"
+    },
+    "sensor": "1/3\" (fixed bullet) + 1/2.8\" (PTZ) Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "bullet 2.8 (F1.0) + PTZ 4.8-120 (25x optical zoom)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE+ (802.3at, max 24W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "2-in-1 dual-lens: fixed bullet (2.8mm F1.0) + 25x optical zoom PTZ (4.8-120mm)",
+      "NightChroma full-color on bullet (0.0005 lux) + IR up to 100m on PTZ",
+      "4MP per channel @ 30fps",
+      "1-ch audio in / 1-ch audio out (external mic/speaker)",
+      "6000V lightning protection, IP66",
+      "H.265+",
+      "PoE+ (802.3at, 24W)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nct425"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works. Dual-channel: bullet + PTZ on separate channels."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-slpr400-i81hy",
+    "brand": "Annke",
+    "model": "SLPR400 I81HY",
+    "aliases": [
+      "SLPR400",
+      "I81HY",
+      "AU-I81HY0102",
+      "4MP ANPR LPR Bullet",
+      "License Plate Recognition Camera"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.7-13.5 (5x optical zoom)",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 60
+    },
+    "power": {
+      "method": "PoE"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "ANPR / LPR license plate recognition (deep-learning)",
+      "vehicle detection + block/allow list management",
+      "recognizes motorcycle plates",
+      "4MP motorized varifocal (2.7-13.5mm, 5x optical zoom, autofocus)",
+      "IR up to 60m (0.003 lux)",
+      "IK10 vandal-resistant, IP67",
+      "for traffic checkpoints / access control",
+      "H.265+"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/slpr400"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "annke-video-doorbell",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -33989,8 +33989,11 @@
   {
     "id": "annke-c1200",
     "brand": "Annke",
-    "model": "C1200",
+    "model": "C1200 I91DN",
     "aliases": [
+      "C1200",
+      "I91DN",
+      "C1200 Turret",
       "12MP PoE AI Turret"
     ],
     "type": "turret",
@@ -34091,6 +34094,207 @@
     "added": "2026-06-09"
   },
   {
+    "id": "annke-c1200-i91dd",
+    "brand": "Annke",
+    "model": "C1200 I91DD",
+    "aliases": [
+      "C1200",
+      "I91DD",
+      "C1200 Bullet",
+      "12MP Smart Dual Light Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 4096,
+      "max_height": 3072,
+      "label": "12MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 10
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "12MP (4096x3072) PoE bullet",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux)",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dd"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c1200d-i91dg",
+    "brand": "Annke",
+    "model": "C1200D I91DG",
+    "aliases": [
+      "C1200D",
+      "I91DG",
+      "AN-I91DG0102",
+      "AN-I91DG",
+      "12MP Smart Dual Light Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 4096,
+      "max_height": 3072,
+      "label": "12MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 10
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "12MP (4096x3072) PoE dome",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux @ F2.0)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/c1200d"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c500",
     "brand": "Annke",
     "model": "C500",
@@ -34185,10 +34389,112 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-c500d-i51dn",
+    "brand": "Annke",
+    "model": "C500D I51DN",
+    "aliases": [
+      "C500D",
+      "I51DN",
+      "AN-I51DN0102-V5",
+      "AN-I51DN",
+      "3K PoE Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 2592,
+      "max_height": 1944,
+      "label": "3K (2592x1944)"
+    },
+    "sensor": "1/3\" OmniVision Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "3K (2592x1944) PoE dome",
+      "EXIR 2.0 IR night vision up to 30m",
+      "noise-cancelling built-in microphone",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/c500d"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c800-bullet",
     "brand": "Annke",
-    "model": "C800 (Bullet)",
+    "model": "C800 I91BD",
     "aliases": [
+      "I91BD",
+      "C800 Bullet",
+      "C800 (Bullet)",
       "4K 8MP PoE Bullet"
     ],
     "type": "bullet",
@@ -34287,11 +34593,422 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-c800-i91db",
+    "brand": "Annke",
+    "model": "C800 I91DB",
+    "aliases": [
+      "I91DB",
+      "C800 Turret",
+      "4K Fixed Turret",
+      "4K Color Night Vision PoE Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "1/1.8\" large sensor",
+      "Color Night Vision",
+      "active deterrence (strobe light + siren)",
+      "two-way audio (built-in mic + speaker)",
+      "Smart IR up to 30m",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91db"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91df",
+    "brand": "Annke",
+    "model": "C800 I91DF",
+    "aliases": [
+      "I91DF",
+      "AN-I91DF0104-V2",
+      "AN-I91DF",
+      "C800D",
+      "C800 Dome",
+      "4K 8MP Smart Dual Light Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE dome",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91df"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91dl",
+    "brand": "Annke",
+    "model": "C800 I91DL",
+    "aliases": [
+      "I91DL",
+      "AN-I91DL0104-V3",
+      "AN-I91DL",
+      "C800 Bullet",
+      "4K Smart Dual Light Bullet",
+      "4K 8MP PoE Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE bullet",
+      "Smart Dual-Light (IR + white light)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "supplement light up to 30m",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dl"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-c800-i91dm",
+    "brand": "Annke",
+    "model": "C800 I91DM",
+    "aliases": [
+      "I91DM",
+      "AN-I91DM0104-V2",
+      "AN-I91DM",
+      "C800 Turret",
+      "4K 8MP Smart Dual Light Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "Smart Dual-Light (IR up to 30m + white light up to 20m)",
+      "Color Night Vision",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91dm"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-c800-turret",
     "brand": "Annke",
-    "model": "C800 (Turret)",
+    "model": "C800 I91BM",
     "aliases": [
-      "4K 8MP PoE Turret I91BM"
+      "I91BM",
+      "C800 Turret",
+      "C800 (Turret)",
+      "4K 8MP PoE Turret"
     ],
     "type": "turret",
     "connectivity": [
@@ -34488,6 +35205,906 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-cz425x-i81hb",
+    "brand": "Annke",
+    "model": "CZ425X I81HB",
+    "aliases": [
+      "CZ425X",
+      "I81HB",
+      "AU-I81HB0102-V2",
+      "AU-I81HB",
+      "4MP 25X Zoom PTZ Speed Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP (2560x1440)"
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8-120 (25x optical zoom, 16x digital)",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE+ (802.3at) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4MP PTZ speed dome",
+      "25x optical zoom (4.8-120mm), 16x digital",
+      "full-color night vision + IR up to 50m",
+      "IK10 vandal-resistant, 4000V lightning protection",
+      "1-ch audio in / 1-ch audio out (external mic/speaker)",
+      "H.265+",
+      "PoE+ (802.3at)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz425x"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz804-i91de",
+    "brand": "Annke",
+    "model": "CZ804 I91DE",
+    "aliases": [
+      "CZ804",
+      "I91DE",
+      "AN-I91DE0102",
+      "4K 4X Optical Zoom Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom)",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP bullet, 4x optical zoom (2.8-12mm motorized varifocal)",
+      "Smart Dual-Light (IR up to 50m + white light)",
+      "active deterrence (spotlight + strobe alarm)",
+      "Motion Detection 2.0 (human/vehicle)",
+      "Color Night Vision (0.005 lux @ F1.6)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz804?variant=50076426240275"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz804-i91dq",
+    "brand": "Annke",
+    "model": "CZ804 I91DQ",
+    "aliases": [
+      "CZ804",
+      "I91DQ",
+      "AN-I91DQ0102",
+      "4K 4X Optical Zoom Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3, max 12W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK08",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP dome, 4x optical zoom (2.8-12mm motorized varifocal)",
+      "Smart Dual-Light (IR up to 30m + white light)",
+      "active deterrence (spotlight + strobe alarm)",
+      "Motion Detection 2.0 (human/vehicle)",
+      "IK08 vandal-resistant",
+      "H.265+",
+      "built-in microphone (no two-way)",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz804"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-cz825x-i91bw",
+    "brand": "Annke",
+    "model": "CZ825X I91BW",
+    "aliases": [
+      "CZ825X",
+      "I91BW",
+      "25X Optical Zoom PTZ Speed Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-147.5 (25x optical zoom, 16x digital)",
+      "aperture": "F1.5",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 200
+    },
+    "power": {
+      "method": "Hi-PoE / 24VAC (max 42W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K PTZ speed dome",
+      "25x optical zoom (5.9-147.5mm), 16x digital",
+      "IR night vision up to 200m",
+      "color night vision (0.001 lux @ F1.5)",
+      "IK10 vandal-resistant",
+      "two-way audio (speaker range up to 30m)",
+      "H.265+",
+      "Hi-PoE / 24VAC"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/cz825x"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd600-i51fs",
+    "brand": "Annke",
+    "model": "FCD600 I51FS",
+    "aliases": [
+      "FCD600",
+      "I51FS",
+      "AN-I51FS0102",
+      "6MP Dual-Lens Bullet"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3632,
+      "max_height": 1632,
+      "label": "6MP panoramic (3632x1632)"
+    },
+    "sensor": "2x 1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "6MP dual-lens panoramic bullet (2x 1/2.5\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd600"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd800-i91et",
+    "brand": "Annke",
+    "model": "FCD800 I91ET",
+    "aliases": [
+      "FCD800",
+      "I91ET",
+      "AN-I91ET0102",
+      "4K Seamless Dual-Lens Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 4096,
+      "max_height": 1860,
+      "label": "4096x1860 panoramic"
+    },
+    "sensor": "2x 1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP seamless dual-lens panoramic turret (2x 1/2.4\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "active sound + light deterrence",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd800"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-fcd800-i91ev",
+    "brand": "Annke",
+    "model": "FCD800 I91EV",
+    "aliases": [
+      "FCD800",
+      "I91EV",
+      "AN-I91EV0102",
+      "4K Seamless Dual-Lens Bullet"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 4096,
+      "max_height": 1860,
+      "label": "4096x1860 panoramic"
+    },
+    "sensor": "2x 1/2.4\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 11.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP seamless dual-lens panoramic bullet (2x 1/2.4\" sensors)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "sound + light active deterrence (siren + spotlight)",
+      "Color Night Vision (0.005 lux)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/fcd800?variant=51933939400979"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i51dx",
+    "brand": "Annke",
+    "model": "I51DX",
+    "aliases": [
+      "6MP 180 Panoramic Turret",
+      "Dual-Lens Panoramic Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3632,
+      "max_height": 1632,
+      "label": "6MP panoramic (3632x1632)"
+    },
+    "sensor": "2x 1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (fixed, dual lens)",
+      "aperture": "F1.2",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "6MP 180-degree panoramic dual-lens turret (2x 1/2.5\" sensors)",
+      "Smart Dual-Light (white light up to 20m + IR up to 30m)",
+      "Color Night Vision (0.005 lux @ F1.2)",
+      "two-way audio (built-in mic + speaker)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i51dx"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i51ex",
+    "brand": "Annke",
+    "model": "I51EX",
+    "aliases": [
+      "3K Mini PT Speed Dome",
+      "Mini PTZ Dome"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "mini PT speed dome (pan-tilt)",
+      "Smart Dual-Light (IR + white light up to 30m)",
+      "Color Night Vision (0.01 lux color, 0.005 lux B/W)",
+      "two-way audio (built-in mic + speaker)",
+      "3K (3072x1728) @ 20fps",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i51ex"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-i61dq",
     "brand": "Annke",
     "model": "I61DQ",
@@ -34576,6 +36193,490 @@
       }
     },
     "added": "2026-06-09"
+  },
+  {
+    "id": "annke-i81em",
+    "brand": "Annke",
+    "model": "I81EM",
+    "aliases": [
+      "3K Outdoor PT Camera",
+      "Fixed PT Network Camera"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "pan-tilt (PT) network camera",
+      "1/1.8\" large sensor, F1.0 lens",
+      "Smart white light up to 30m (full-color night vision)",
+      "two-way audio (built-in mic + speaker)",
+      "3K (3072x1728) @ 20fps",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i81em"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bh",
+    "brand": "Annke",
+    "model": "I91BH",
+    "aliases": [
+      "4K Panoramic Turret",
+      "Dual-Lens Panoramic Turret"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 5120,
+      "max_height": 1440,
+      "label": "5120x1440 panoramic"
+    },
+    "sensor": "2x 1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "4 (fixed, dual lens)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K dual-lens panoramic turret (2x 1/1.8\" sensors)",
+      "180-degree panoramic 5120x1440",
+      "24/7 full-color imaging (warm light up to 40m)",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF/ISAPI"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bh"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bi",
+    "brand": "Annke",
+    "model": "I91BI",
+    "aliases": [
+      "8MP Panoramic Camera",
+      "Dual-Lens Panoramic"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 5120,
+      "max_height": 1440,
+      "label": "5120x1440 panoramic"
+    },
+    "sensor": "2x 1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "4 (fixed, dual lens)",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP dual-lens panoramic (2x 1/1.8\" sensors)",
+      "5120x1440 panoramic",
+      "24/7 full-color imaging (warm light up to 40m)",
+      "AI detection",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bi"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bk",
+    "brand": "Annke",
+    "model": "I91BK",
+    "aliases": [
+      "Mini Dome PTZ",
+      "4X Optical Zoom Mini PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8-12 (4x optical zoom, 16x digital)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 15
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE (802.3af) / DC 12V (max 9.2W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "Mini dome PTZ",
+      "4x optical zoom (2.8-12mm), 16x digital zoom",
+      "IR night vision up to 20m",
+      "IK10 vandal-resistant",
+      "TVS 4000V lightning/surge protection",
+      "built-in mic + 1-ch audio in/out",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/G/T)"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bk"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-i91bv",
+    "brand": "Annke",
+    "model": "I91BV",
+    "aliases": [
+      "4K Full-Color Turret",
+      "Acme Color Night Vision Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" Progressive Scan CMOS",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K 8MP PoE turret",
+      "1/1.2\" large sensor",
+      "Acme full-color night vision (24/7 color imaging)",
+      "IR up to 40m",
+      "H.265+",
+      "built-in microphone (audio recording)",
+      "RTSP/ONVIF"
+    ],
+    "sources": [
+      "https://www.annkecctv.com/products/i91bv"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "annke-nc400",
@@ -34671,6 +36772,210 @@
     "added": "2026-06-06"
   },
   {
+    "id": "annke-nc500-i81hd",
+    "brand": "Annke",
+    "model": "NC500 I81HD",
+    "aliases": [
+      "NC500",
+      "NightChroma NC500",
+      "I81HD",
+      "AN-I81HD0102-V2",
+      "AN-I81HD",
+      "3K Full-Color Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "NightChroma full-color night vision (0.001 lux @ F1.0)",
+      "3K (3072x1728) bullet",
+      "white light supplement up to 30m",
+      "built-in microphone (audio recording)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nc500?variant=50076619899155"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-nc500-i81he",
+    "brand": "Annke",
+    "model": "NC500 I81HE",
+    "aliases": [
+      "NC500",
+      "NightChroma NC500",
+      "I81HE",
+      "AN-I81HE0102-V2",
+      "AN-I81HE",
+      "3K Full-Color Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "3K (3072x1728)"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 6.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "NightChroma full-color night vision (0.001 lux @ F1.0)",
+      "3K (3072x1728) turret",
+      "white light supplement up to 30m",
+      "built-in microphone (audio recording)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G), ISAPI"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nc500"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "annke-nc800",
     "brand": "Annke",
     "model": "NightChroma NC800",
@@ -34763,6 +37068,410 @@
       }
     },
     "added": "2026-06-06"
+  },
+  {
+    "id": "annke-ncbr800-i91dj",
+    "brand": "Annke",
+    "model": "NCBR800 I91DJ",
+    "aliases": [
+      "NCBR800",
+      "NightChroma NCBR800",
+      "I91DJ",
+      "AP-I91DJ0102",
+      "AP-I91DJ",
+      "4K Full-Color Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP NightChroma full-color bullet (1/1.8\" sensor, F1.0)",
+      "switchable white light / smart dual-light / IR (up to 30m)",
+      "full-color 0.0008 lux",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/ncbr800"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-ncbr800-i91du",
+    "brand": "Annke",
+    "model": "NCBR800 I91DU",
+    "aliases": [
+      "NCBR800",
+      "NightChroma NCBR800",
+      "I91DU",
+      "AN-I91DU0103",
+      "AN-I91DU",
+      "4K Full-Color Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 (fixed)",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 25
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (802.3af, max 10.5W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP NightChroma full-color turret (1/1.8\" sensor, F1.0)",
+      "switchable white light / smart dual-light / IR (up to 30m)",
+      "full-color 0.0008 lux",
+      "two-way audio (built-in mic + speaker)",
+      "H.265+",
+      "RTSP/ONVIF (Profile S/T/G)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/ncbr800?variant=50144218579219"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-nct425-i81el",
+    "brand": "Annke",
+    "model": "NCT425 I81EL",
+    "aliases": [
+      "NCT425",
+      "NightChroma NCT425",
+      "I81EL",
+      "AU-I81EL0102",
+      "2-in-1 Dual-Lens PTZ"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP per channel (2560x1440)"
+    },
+    "sensor": "1/3\" (fixed bullet) + 1/2.8\" (PTZ) Progressive Scan CMOS",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "bullet 2.8 (F1.0) + PTZ 4.8-120 (25x optical zoom)",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE+ (802.3at, max 24W) / DC 12V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "2-in-1 dual-lens: fixed bullet (2.8mm F1.0) + 25x optical zoom PTZ (4.8-120mm)",
+      "NightChroma full-color on bullet (0.0005 lux) + IR up to 100m on PTZ",
+      "4MP per channel @ 30fps",
+      "1-ch audio in / 1-ch audio out (external mic/speaker)",
+      "6000V lightning protection, IP66",
+      "H.265+",
+      "PoE+ (802.3at, 24W)"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/nct425"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works. Dual-channel: bullet + PTZ on separate channels."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "annke-slpr400-i81hy",
+    "brand": "Annke",
+    "model": "SLPR400 I81HY",
+    "aliases": [
+      "SLPR400",
+      "I81HY",
+      "AU-I81HY0102",
+      "4MP ANPR LPR Bullet",
+      "License Plate Recognition Camera"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2560,
+      "max_height": 1440,
+      "label": "4MP"
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.7-13.5 (5x optical zoom)",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 60
+    },
+    "power": {
+      "method": "PoE"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "ip_rating": "IP67, IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "ANPR / LPR license plate recognition (deep-learning)",
+      "vehicle detection + block/allow list management",
+      "recognizes motorcycle plates",
+      "4MP motorized varifocal (2.7-13.5mm, 5x optical zoom, autofocus)",
+      "IR up to 60m (0.003 lux)",
+      "IK10 vandal-resistant, IP67",
+      "for traffic checkpoints / access control",
+      "H.265+"
+    ],
+    "sources": [
+      "https://ca-en.annke.com/products/slpr400"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-19",
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "notes": "Uses Hikvision protocol. ONVIF integration works."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select 'Hikvision' profile. Most Annke cameras use Hikvision protocol."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "annke-video-doorbell",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Closes #129.

Resolves the Annke marketing-umbrella problem reported by @fvdpol: the generic **C800 (Turret)/(Bullet)** entries are replaced by exact `I91xx` model numbers, and the **12MP models are correctly placed in the C1200 family** (a duplicate of the existing C1200 turret was removed). Also expands Annke coverage from official product pages.

**Net: 2,230 → 2,257 cameras (+27 new).** Annke 13 → 40.

## Disambiguation (issue #129)
- `C800 (Turret)` → **`C800 I91BM`**, `C800 (Bullet)` → **`C800 I91BD`** (the legacy 2020 revision our specs describe; **ids/URLs preserved**, old names kept as aliases).
- Current C800: `I91DB` (two-way), `I91DM`, `I91DL`, `I91DF` (dome).
- `C1200` → **`C1200 I91DN`** (enriched w/ model number) + **`C1200 I91DD`** bullet + **`C1200D I91DG`** dome.

## Added (highlights)
- **NightChroma**: NC500 (I81HE/I81HD), NCBR800 (I91DJ/I91DU), NCT425 I81EL (2-in-1 dual-lens PTZ)
- **Dual-lens panoramic**: FCD600 I51FS, FCD800 (I91ET/I91EV), I91BH, I91BI, I51DX
- **Zoom PTZ / speed dome**: CZ804 (I91DQ/I91DE), CZ825X I91BW, CZ425X I81HB, I91BK, I81EM, I51EX
- **Other**: C500D I51DN, I91BV, SLPR400 I81HY (ANPR/LPR)

## Notes
- Retail order SKUs (`AN-`/`AU-`/`AP-…`) captured as **aliases** on their models (a model ships under several order codes → one entry).
- Each verified against its **dedicated** product page (combined family pages mis-map form factors).
- Every entry: sources + `last_verified` + Frigate/HA/BlueIris config; AJV clean; git-derived `added` dates populated.
- **Not included** (spec tab wouldn't render — need datasheets): I81DZ, I91HN, I91RTWB.
- Minor flags for follow-up: legacy `I91BD` bullet audio (documented no-audio vs our mic:true); NCBR800 `I91DJ`/`I91DU` form-factor assignment; I91BH/I91BI are near-identical twins.