### PR TITLE
Add Xiaomi / Mi cameras — new brand (+26, v1.39.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.39.0] — 2026-07-20
+
+**New brand: Xiaomi (+26).** Added Xiaomi / Mi cameras: Smart Camera C-series (C100-C701 Pro), Outdoor BW/CW-series, Mi 360 pan-tilt, and dual-lens models. Net: **2,257 -> 2,283 cameras** (71 -> 72 brands).
+
+### Notes
+- All Xiaomi models are **Wi-Fi, Mi Home app-only with no native RTSP/ONVIF** — recorded honestly with no fabricated `protocols` or `rtsp_url_template`.
+- The 7 models with a documented Frigate path use a **go2rtc `xiaomi://` cloud-source** note (per-camera MIoT model IDs, codecs, subnet/key-exchange caveats) rather than a fake RTSP URL — the real way to bring these into Frigate/go2rtc.
+- Specs + sources from official mi.com product/spec/FAQ pages.
+
 ## [1.38.0] — 2026-07-20
 
 **Annke catalogue expansion + C800/C1200 model-number disambiguation** (issue #129). Replaced the generic "C800 (Turret)/(Bullet)" umbrella entries with exact `I91xx` model numbers, corrected the 12MP line to the **C1200** family (removing a duplicate of the existing C1200 turret), and added the current Annke line-ups. Net: **2,230 -> 2,257 cameras** (+27; brand count unchanged). Thanks to @fvdpol (#129) for the report.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCTV Camera Database
 
-An open, structured database of 2,257 CCTV / IP camera models and their technical specifications, covering 71 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,283 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
 [![cameras](https://img.shields.io/badge/cameras-1%2C896-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-71-green)](cameras/)
@@ -31,7 +31,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,257 cameras, 25 per page
+- **Pagination** — page through all 2,283 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -63,7 +63,7 @@ cctv-camera-database/
 │   ├── tapo/             #  62 cameras
 │   └── …60 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,257 cameras as one array
+│   ├── cameras.json      # all 2,283 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -121,7 +121,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,257** |
+| Total cameras | **2,283** |
 | Brands | **71** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,279 |
@@ -132,7 +132,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | 1080p–2MP | 487 |
 | With integration configs (Frigate / Home Assistant) | 1,507 | 1,505 | 1,507 | 1,514 | 1,533 | 1,321 |
 
-### All 71 brands
+### All 72 brands
 
 | Brand | Cameras | Segment |
 |-------|---------|---------|

--- a/cameras/xiaomi/aw300.json
+++ b/cameras/xiaomi/aw300.json
@@ -1,0 +1,80 @@
+{
+  "id": "xiaomi-aw300",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera AW300",
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "field_of_view_deg": "101.7",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "12V DC 1A adapter (3m cable; official 6m 22AWG extension supported)",
+    "voltage": "12V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 32-256GB (FAT32) or cloud storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "2x 850nm IR lights + 2x LED spotlights for full-colour night vision",
+    "WDR for complex outdoor lighting",
+    "focus zone detection with audible alarm and flashing lights",
+    "AI human detection, face recognition via Xiaomi Home Secure",
+    "full-duplex two-way calls",
+    "split-screen multi-camera viewing (up to 4)",
+    "Alexa / Google Assistant"
+  ],
+  "ip_rating": "IP66",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "173 x 70 x 75",
+  "weight_g": 249,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model mxiang.camera.mod13, protocol cs2+udp, H.265 video + Opus audio).",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-12521/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=mxiang.camera.mod13 (protocol cs2+udp; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/aw300.md
+++ b/cameras/xiaomi/aw300.md
@@ -1,0 +1,36 @@
+# Xiaomi Outdoor Camera AW300
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera AW300 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 1× F2.0 |
+| Field of view | 101.7° |
+| Night vision | hybrid |
+| Power | 12V DC 1A adapter (3m cable; official 6m 22AWG extension supported) |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2x 850nm IR lights + 2x LED spotlights for full-colour night vision
+- WDR for complex outdoor lighting
+- focus zone detection with audible alarm and flashing lights
+- AI human detection, face recognition via Xiaomi Home Secure
+- full-duplex two-way calls
+- split-screen multi-camera viewing (up to 4)
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/specs/
+- https://www.mi.com/global/support/faq/details/KA-12521/
+
+---
+*Auto-generated from xiaomi-aw300.json — do not edit by hand.*

--- a/cameras/xiaomi/bw300.json
+++ b/cameras/xiaomi/bw300.json
@@ -1,0 +1,56 @@
+{
+  "id": "xiaomi-bw300",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera BW300",
+  "aliases": [
+    "BW300"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "battery"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "field_of_view_deg": "130 D",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "Built-in 4900mAh rechargeable battery; optional solar panel"
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "7-day rolling cloud service included; extended cloud storage is a paid subscription."
+  },
+  "features": [
+    "4900mAh battery: up to 120 days (20 triggers/day) or 180 days (10 triggers/day)",
+    "intelligent full-colour night vision",
+    "AI dynamic capture and tracking",
+    "IP67 tested by SGS",
+    "wire-free installation",
+    "Google Home / Alexa smart link"
+  ],
+  "ip_rating": "IP67",
+  "operating_temp_c": "-20 to 55",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-128861/",
+    "https://www.mi.com/global/support/faq/details/KA-228932/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/bw300.md
+++ b/cameras/xiaomi/bw300.md
@@ -1,0 +1,35 @@
+# Xiaomi Outdoor Camera BW300
+
+*Also known as: BW300*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera BW300 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Field of view | 130 D° |
+| Night vision | hybrid |
+| Power | Built-in 4900mAh rechargeable battery; optional solar panel |
+| IP rating | IP67 |
+| Operating temp | -20 to 55°C |
+
+## Features
+
+- 4900mAh battery: up to 120 days (20 triggers/day) or 180 days (10 triggers/day)
+- intelligent full-colour night vision
+- AI dynamic capture and tracking
+- IP67 tested by SGS
+- wire-free installation
+- Google Home / Alexa smart link
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/specs/
+- https://www.mi.com/global/support/faq/details/KA-128861/
+- https://www.mi.com/global/support/faq/details/KA-228932/
+
+---
+*Auto-generated from xiaomi-bw300.json — do not edit by hand.*

--- a/cameras/xiaomi/bw400-pro.json
+++ b/cameras/xiaomi/bw400-pro.json
@@ -1,0 +1,62 @@
+{
+  "id": "xiaomi-bw400-pro",
+  "brand": "Xiaomi",
+  "model": "Solar Outdoor Camera BW400 Pro Set",
+  "aliases": [
+    "BW400 Pro"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "battery",
+    "solar"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2.5K",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "field_of_view_deg": "132",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "Built-in 10000mAh battery with integrated solar panel; USB Type-C charging"
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "Camera pairs 1:1 with the included indoor base station, which handles signal, data processing and storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true
+  },
+  "features": [
+    "camera + base station set (no direct router connection required)",
+    "self-sufficient with 2+ hours of daily direct sunlight (20 recordings/day)",
+    "~180-day battery life (20x 10s recordings/day)",
+    "AI detection: person, vehicle, animal, package",
+    "thermal (PIR) and photosensitive sensors",
+    "white-light indicator",
+    "8m sound pick-up distance",
+    "MJA1 security chipset"
+  ],
+  "operating_temp_c": "-20 to 55",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Official spec table lists resolution as '2.5K' (Xiaomi defines 2.5K as 2560 x 1440).",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/",
+    "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-227286/",
+    "https://www.mi.com/global/support/faq/details/KA-227291/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/bw400-pro.md
+++ b/cameras/xiaomi/bw400-pro.md
@@ -1,0 +1,37 @@
+# Xiaomi Solar Outdoor Camera BW400 Pro Set
+
+*Also known as: BW400 Pro*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Solar Outdoor Camera BW400 Pro Set |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2.5K (4MP, 2560×1440) |
+| Field of view | 132° |
+| Night vision | hybrid |
+| Power | Built-in 10000mAh battery with integrated solar panel; USB Type-C charging |
+| Two-way audio | No |
+| Operating temp | -20 to 55°C |
+
+## Features
+
+- camera + base station set (no direct router connection required)
+- self-sufficient with 2+ hours of daily direct sunlight (20 recordings/day)
+- ~180-day battery life (20x 10s recordings/day)
+- AI detection: person, vehicle, animal, package
+- thermal (PIR) and photosensitive sensors
+- white-light indicator
+- 8m sound pick-up distance
+- MJA1 security chipset
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/
+- https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/specs/
+- https://www.mi.com/global/support/faq/details/KA-227286/
+- https://www.mi.com/global/support/faq/details/KA-227291/
+
+---
+*Auto-generated from xiaomi-bw400-pro.json — do not edit by hand.*

--- a/cameras/xiaomi/bw500.json
+++ b/cameras/xiaomi/bw500.json
@@ -1,0 +1,68 @@
+{
+  "id": "xiaomi-bw500",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera BW500",
+  "aliases": [
+    "MJSXJ06BY"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "battery"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p)",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "f/1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "136 (lens angle)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "Built-in 10000mAh battery (5V 2A charging, ~6-7h); optional 5W solar panel"
+  },
+  "storage": {
+    "onboard": true,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "Built-in 8GB eMMC storage; optional cloud storage. No microSD slot listed."
+  },
+  "features": [
+    "up to 180 days battery life (max 20x 10s recordings/day)",
+    "2.5K full-colour night vision",
+    "WDR for backlit scenes",
+    "AI human and vehicle detection with audio-visual deterrent (white light + alarm)",
+    "low-power on-demand system design",
+    "anti-theft base",
+    "Wi-Fi 6 (2.4GHz)",
+    "Google Assistant / Alexa"
+  ],
+  "ip_rating": "IP67",
+  "operating_temp_c": "-20 to 55",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-204760/",
+    "https://www.mi.com/global/support/faq/details/KA-226557/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/bw500.md
+++ b/cameras/xiaomi/bw500.md
@@ -1,0 +1,38 @@
+# Xiaomi Outdoor Camera BW500
+
+*Also known as: MJSXJ06BY*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera BW500 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2.5K (1440p) (4MP, 2560×1440) |
+| Lens | 1× f/1.6 |
+| Field of view | 136 (lens angle)° |
+| Night vision | hybrid |
+| Power | Built-in 10000mAh battery (5V 2A charging, ~6-7h); optional 5W solar panel |
+| IP rating | IP67 |
+| Operating temp | -20 to 55°C |
+
+## Features
+
+- up to 180 days battery life (max 20x 10s recordings/day)
+- 2.5K full-colour night vision
+- WDR for backlit scenes
+- AI human and vehicle detection with audio-visual deterrent (white light + alarm)
+- low-power on-demand system design
+- anti-theft base
+- Wi-Fi 6 (2.4GHz)
+- Google Assistant / Alexa
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/specs/
+- https://www.mi.com/global/support/faq/details/KA-204760/
+- https://www.mi.com/global/support/faq/details/KA-226557/
+
+---
+*Auto-generated from xiaomi-bw500.json — do not edit by hand.*

--- a/cameras/xiaomi/c100.json
+++ b/cameras/xiaomi/c100.json
@@ -1,0 +1,65 @@
+{
+  "id": "xiaomi-c100",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C100",
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "night_vision": {
+    "type": "color"
+  },
+  "power": {
+    "method": "5V DC 1A via USB Type-C (2m cable)",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "compact fixed indoor camera",
+    "3MP full colour in low light",
+    "manual slide-cover physical lens shielding",
+    "AI baby cry detection, human detection, virtual fence",
+    "3A audio algorithm (AEC/ANS/AGC)",
+    "Wi-Fi 6 (2.4GHz) with Bluetooth 5.2",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 45",
+  "dimensions_mm": "69 x 68 x 115",
+  "weight_g": 170,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c100/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c100/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-573427/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c100.md
+++ b/cameras/xiaomi/c100.md
@@ -1,0 +1,33 @@
+# Xiaomi Smart Camera C100
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C100 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Night vision | color |
+| Power | 5V DC 1A via USB Type-C (2m cable) |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 45°C |
+
+## Features
+
+- compact fixed indoor camera
+- 3MP full colour in low light
+- manual slide-cover physical lens shielding
+- AI baby cry detection, human detection, virtual fence
+- 3A audio algorithm (AEC/ANS/AGC)
+- Wi-Fi 6 (2.4GHz) with Bluetooth 5.2
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c100/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c100/specs/
+- https://www.mi.com/global/support/faq/details/KA-573427/
+
+---
+*Auto-generated from xiaomi-c100.json — do not edit by hand.*

--- a/cameras/xiaomi/c200.json
+++ b/cameras/xiaomi/c200.json
@@ -1,0 +1,85 @@
+{
+  "id": "xiaomi-c200",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C200",
+  "aliases": [
+    "MJSXJ14CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "1080p Full HD",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F2.1",
+    "varifocal": false
+  },
+  "field_of_view_deg": "pan 360 (horizontal)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 9
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "Supports NAS transfer via inserted microSD card (SD card acts as relay to NAS storage)."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "1080p entry pan-tilt indoor",
+    "AI human detection and tracking",
+    "infrared night vision (9m)",
+    "two-way voice calls via Xiaomi Home app",
+    "NAS transfer support",
+    "continues local recording during network outage",
+    "Xiaomi security chip"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.046c04, protocol cs2, H.265 video + Opus audio).",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c200/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c200/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-86464/",
+    "https://www.mi.com/global/support/faq/details/KA-235580/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.046c04 (protocol cs2; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/c200.md
+++ b/cameras/xiaomi/c200.md
@@ -1,0 +1,38 @@
+# Xiaomi Smart Camera C200
+
+*Also known as: MJSXJ14CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C200 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 1080p Full HD (2MP, 1920×1080) |
+| Lens | 1× F2.1 |
+| Field of view | pan 360 (horizontal)° |
+| Night vision | ir (9m) |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- 1080p entry pan-tilt indoor
+- AI human detection and tracking
+- infrared night vision (9m)
+- two-way voice calls via Xiaomi Home app
+- NAS transfer support
+- continues local recording during network outage
+- Xiaomi security chip
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c200/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c200/specs/
+- https://www.mi.com/global/support/faq/details/KA-86464/
+- https://www.mi.com/global/support/faq/details/KA-235580/
+
+---
+*Auto-generated from xiaomi-c200.json — do not edit by hand.*

--- a/cameras/xiaomi/c201.json
+++ b/cameras/xiaomi/c201.json
@@ -1,0 +1,65 @@
+{
+  "id": "xiaomi-c201",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C201",
+  "aliases": [
+    "MBC27"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "1080p Full HD",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 1A (power adapter not included; user-supplied)",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB or cloud storage."
+  },
+  "features": [
+    "dual-axis pan-tilt gimbal",
+    "six built-in no-glow infrared illuminators",
+    "local AI human detection with motion tracking",
+    "pet detection and tracking (cats/dogs)",
+    "MJA1 security chipset with AES-128 cloud encryption",
+    "Wi-Fi 6 (2.4GHz)",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "78 x 76 x 115",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c201/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c201/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-600067/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c201.md
+++ b/cameras/xiaomi/c201.md
@@ -1,0 +1,34 @@
+# Xiaomi Smart Camera C201
+
+*Also known as: MBC27*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C201 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 1080p Full HD (2MP, 1920×1080) |
+| Night vision | hybrid |
+| Power | 5V DC 1A (power adapter not included; user-supplied) |
+| Storage | microSD ≤ 256GB |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- dual-axis pan-tilt gimbal
+- six built-in no-glow infrared illuminators
+- local AI human detection with motion tracking
+- pet detection and tracking (cats/dogs)
+- MJA1 security chipset with AES-128 cloud encryption
+- Wi-Fi 6 (2.4GHz)
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c201/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c201/specs/
+- https://www.mi.com/global/support/faq/details/KA-600067/
+
+---
+*Auto-generated from xiaomi-c201.json — do not edit by hand.*

--- a/cameras/xiaomi/c300-dual.json
+++ b/cameras/xiaomi/c300-dual.json
@@ -1,0 +1,69 @@
+{
+  "id": "xiaomi-c300-dual",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C300 Dual",
+  "type": "dual-lens",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "6 (telephoto PTZ lens)",
+    "varifocal": false
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 16-256GB."
+  },
+  "features": [
+    "true dual camera: fixed wide + 6mm telephoto PTZ",
+    "PTZ auto-rotates to track humans detected by the fixed camera",
+    "press-and-hold on fixed footage rotates PTZ for close-ups",
+    "AI detection on both cameras",
+    "virtual fence",
+    "pet detection and tracking (cats/dogs)",
+    "baby cry detection",
+    "dual-band Wi-Fi 6 with Bluetooth 5.3",
+    "Xiaomi HyperOS Connect"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "78 x 78 x 126",
+  "weight_g": 384,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c300-dual.md
+++ b/cameras/xiaomi/c300-dual.md
@@ -1,0 +1,34 @@
+# Xiaomi Smart Camera C300 Dual
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C300 Dual |
+| Type | dual-lens |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 2× 6 (telephoto PTZ lens)mm |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- true dual camera: fixed wide + 6mm telephoto PTZ
+- PTZ auto-rotates to track humans detected by the fixed camera
+- press-and-hold on fixed footage rotates PTZ for close-ups
+- AI detection on both cameras
+- virtual fence
+- pet detection and tracking (cats/dogs)
+- baby cry detection
+- dual-band Wi-Fi 6 with Bluetooth 5.3
+- Xiaomi HyperOS Connect
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/specs/
+
+---
+*Auto-generated from xiaomi-c300-dual.json — do not edit by hand.*

--- a/cameras/xiaomi/c300.json
+++ b/cameras/xiaomi/c300.json
@@ -1,0 +1,68 @@
+{
+  "id": "xiaomi-c300",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C300",
+  "aliases": [
+    "XMC01"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F1.4",
+    "varifocal": false
+  },
+  "field_of_view_deg": "pan 360 (horizontal), tilt 108 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "features": [
+    "2K with F1.4 large aperture 6P lens",
+    "full colour in low light",
+    "940nm no-glow infrared LEDs",
+    "AI human detection",
+    "dual-motor pan-tilt",
+    "BSI Kitemark certified (residential IoT)"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "115 x 78 x 78",
+  "weight_g": 327,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c300/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c300/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-130637/",
+    "https://www.mi.com/global/support/faq/details/KA-231317/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c300.md
+++ b/cameras/xiaomi/c300.md
@@ -1,0 +1,36 @@
+# Xiaomi Smart Camera C300
+
+*Also known as: XMC01*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C300 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 1× F1.4 |
+| Field of view | pan 360 (horizontal), tilt 108 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- 2K with F1.4 large aperture 6P lens
+- full colour in low light
+- 940nm no-glow infrared LEDs
+- AI human detection
+- dual-motor pan-tilt
+- BSI Kitemark certified (residential IoT)
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c300/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c300/specs/
+- https://www.mi.com/global/support/faq/details/KA-130637/
+- https://www.mi.com/global/support/faq/details/KA-231317/
+
+---
+*Auto-generated from xiaomi-c300.json — do not edit by hand.*

--- a/cameras/xiaomi/c301.json
+++ b/cameras/xiaomi/c301.json
@@ -1,0 +1,71 @@
+{
+  "id": "xiaomi-c301",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C301",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 1A",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB or cloud storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "3MP 2K with large-aperture 4P lens",
+    "dual-gimbal pan-tilt",
+    "full colour night vision",
+    "local AI human detection with alerts",
+    "large-diameter speaker for remote calls",
+    "MJA1-class security chip with AES-128 cloud encryption",
+    "flat and inverted mounting",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 45",
+  "dimensions_mm": "78 x 76 x 115",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c301/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c301/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c301.md
+++ b/cameras/xiaomi/c301.md
@@ -1,0 +1,34 @@
+# Xiaomi Smart Camera C301
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C301 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 1× |
+| Night vision | hybrid |
+| Power | 5V DC 1A |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 45°C |
+
+## Features
+
+- 3MP 2K with large-aperture 4P lens
+- dual-gimbal pan-tilt
+- full colour night vision
+- local AI human detection with alerts
+- large-diameter speaker for remote calls
+- MJA1-class security chip with AES-128 cloud encryption
+- flat and inverted mounting
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c301/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c301/specs/
+
+---
+*Auto-generated from xiaomi-c301.json — do not edit by hand.*

--- a/cameras/xiaomi/c302.json
+++ b/cameras/xiaomi/c302.json
@@ -1,0 +1,68 @@
+{
+  "id": "xiaomi-c302",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C302",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 1A via USB Type-C",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB or cloud storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "local AI: human detection and tracking",
+    "pet detection (cats/dogs)",
+    "baby cry and abnormal sound detection (e.g. glass breaking)",
+    "virtual fence and custom detection zones",
+    "physical lens shield (privacy masking)",
+    "MJA1 security chipset with AES-128 cloud encryption",
+    "Wi-Fi 6 (2.4GHz) with Bluetooth 5.0",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "78 x 76 x 115",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c302/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c302/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-616066/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c302.md
+++ b/cameras/xiaomi/c302.md
@@ -1,0 +1,34 @@
+# Xiaomi Smart Camera C302
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C302 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Night vision | hybrid |
+| Power | 5V DC 1A via USB Type-C |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- local AI: human detection and tracking
+- pet detection (cats/dogs)
+- baby cry and abnormal sound detection (e.g. glass breaking)
+- virtual fence and custom detection zones
+- physical lens shield (privacy masking)
+- MJA1 security chipset with AES-128 cloud encryption
+- Wi-Fi 6 (2.4GHz) with Bluetooth 5.0
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c302/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c302/specs/
+- https://www.mi.com/global/support/faq/details/KA-616066/
+
+---
+*Auto-generated from xiaomi-c302.json — do not edit by hand.*

--- a/cameras/xiaomi/c400.json
+++ b/cameras/xiaomi/c400.json
@@ -1,0 +1,67 @@
+{
+  "id": "xiaomi-c400",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C400",
+  "aliases": [
+    "MJSXJ23CM",
+    "MJSXJ11CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p)",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "pan 360 (horizontal)",
+  "night_vision": {
+    "type": "ir"
+  },
+  "power": {
+    "method": "5V DC 2A power adapter (2m cable)",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "features": [
+    "2.5K with large-aperture 6P lens",
+    "940nm no-glow infrared night vision",
+    "AI human detection",
+    "dual-motor pan-tilt",
+    "2.4GHz/5GHz dual-band Wi-Fi",
+    "Mi Home security chip"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "119 x 78 x 78",
+  "weight_g": 318,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Model number updated from MJSXJ11CM to MJSXJ23CM with no functional changes (per official spec page).",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c400/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c400/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-12475/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c400.md
+++ b/cameras/xiaomi/c400.md
@@ -1,0 +1,35 @@
+# Xiaomi Smart Camera C400
+
+*Also known as: MJSXJ23CM, MJSXJ11CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C400 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2.5K (1440p) (4MP, 2560×1440) |
+| Lens | 1× |
+| Field of view | pan 360 (horizontal)° |
+| Night vision | ir |
+| Power | 5V DC 2A power adapter (2m cable) |
+| Storage | microSD ≤ 256GB |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- 2.5K with large-aperture 6P lens
+- 940nm no-glow infrared night vision
+- AI human detection
+- dual-motor pan-tilt
+- 2.4GHz/5GHz dual-band Wi-Fi
+- Mi Home security chip
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c400/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c400/specs/
+- https://www.mi.com/global/support/faq/details/KA-12475/
+
+---
+*Auto-generated from xiaomi-c400.json — do not edit by hand.*

--- a/cameras/xiaomi/c500-dual.json
+++ b/cameras/xiaomi/c500-dual.json
@@ -1,0 +1,69 @@
+{
+  "id": "xiaomi-c500-dual",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C500 Dual",
+  "type": "dual-lens",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p) per camera",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "6 (telephoto PTZ lens)",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "58 H (telephoto camera)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 16-256GB, cloud storage, or NAS networked storage."
+  },
+  "features": [
+    "true dual camera: fixed 4MP + 6mm telephoto PTZ (both 4MP F1.6)",
+    "sixteen 940nm infrared illuminators across both cameras",
+    "PTZ rotates to close-ups via press-and-hold on fixed footage",
+    "pet detection and tracking (cats/dogs)",
+    "baby cry detection",
+    "virtual fence on fixed camera",
+    "dual-band Wi-Fi 6 with Bluetooth 5.3",
+    "Xiaomi HyperOS Connect"
+  ],
+  "dimensions_mm": "78 x 77 x 128",
+  "weight_g": 305,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c500-dual.md
+++ b/cameras/xiaomi/c500-dual.md
@@ -1,0 +1,33 @@
+# Xiaomi Smart Camera C500 Dual
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C500 Dual |
+| Type | dual-lens |
+| Connectivity | wifi |
+| Resolution | 2.5K (1440p) per camera (4MP, 2560×1440) |
+| Lens | 2× 6 (telephoto PTZ lens)mm F1.6 |
+| Field of view | 58 H (telephoto camera)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+
+## Features
+
+- true dual camera: fixed 4MP + 6mm telephoto PTZ (both 4MP F1.6)
+- sixteen 940nm infrared illuminators across both cameras
+- PTZ rotates to close-ups via press-and-hold on fixed footage
+- pet detection and tracking (cats/dogs)
+- baby cry detection
+- virtual fence on fixed camera
+- dual-band Wi-Fi 6 with Bluetooth 5.3
+- Xiaomi HyperOS Connect
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/specs/
+
+---
+*Auto-generated from xiaomi-c500-dual.json — do not edit by hand.*

--- a/cameras/xiaomi/c500-pro.json
+++ b/cameras/xiaomi/c500-pro.json
@@ -1,0 +1,76 @@
+{
+  "id": "xiaomi-c500-pro",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C500 Pro",
+  "aliases": [
+    "MJSXJ16CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "3K",
+    "max_width": 2960,
+    "max_height": 1666,
+    "megapixels": 5
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB, cloud storage (AES-128 encrypted), or NAS backup from microSD."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "5MP 3K with HDR mode",
+    "ultra-low light colour mode plus IR illuminator",
+    "local human detection and tracking",
+    "local pet detection",
+    "loud noise and crying baby detection",
+    "physical lens shield (privacy masking)",
+    "MJA1 security chip",
+    "dual-band Wi-Fi with Bluetooth 5.2",
+    "high-power speaker for two-way calls",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 45",
+  "dimensions_mm": "78 x 78 x 124",
+  "weight_g": 301,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-78565/",
+    "https://www.mi.com/global/support/faq/details/KA-78747/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c500-pro.md
+++ b/cameras/xiaomi/c500-pro.md
@@ -1,0 +1,40 @@
+# Xiaomi Smart Camera C500 Pro
+
+*Also known as: MJSXJ16CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C500 Pro |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 3K (5MP, 2960×1666) |
+| Field of view | pan 360 (horizontal), tilt 114 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 45°C |
+
+## Features
+
+- 5MP 3K with HDR mode
+- ultra-low light colour mode plus IR illuminator
+- local human detection and tracking
+- local pet detection
+- loud noise and crying baby detection
+- physical lens shield (privacy masking)
+- MJA1 security chip
+- dual-band Wi-Fi with Bluetooth 5.2
+- high-power speaker for two-way calls
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/specs/
+- https://www.mi.com/global/support/faq/details/KA-78565/
+- https://www.mi.com/global/support/faq/details/KA-78747/
+
+---
+*Auto-generated from xiaomi-c500-pro.json — do not edit by hand.*

--- a/cameras/xiaomi/c500.json
+++ b/cameras/xiaomi/c500.json
@@ -1,0 +1,76 @@
+{
+  "id": "xiaomi-c500",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C500",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "3.5K UHD",
+    "max_width": 3200,
+    "max_height": 1800,
+    "megapixels": 6
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "sensor": "1/2.45\" BSI CMOS",
+  "lens": {
+    "count": 1,
+    "aperture": "f/1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "pan 360 (horizontal), tilt 116 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB, cloud storage, or NAS network-attached storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "Xiaomi's first 6MP indoor camera (3.5K)",
+    "6P optical lens with WDR",
+    "8x 940nm no-glow infrared fill lights",
+    "ultra-low-light full colour imaging",
+    "1 TOPS AI chip with local human and pet detection/tracking",
+    "physical lens shield (privacy masking)",
+    "dual-band Wi-Fi 6",
+    "Alexa / Google Assistant",
+    "Xiaomi HyperOS Connect"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "79 x 79 x 119",
+  "release_year": 2025,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c500/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c500.md
+++ b/cameras/xiaomi/c500.md
@@ -1,0 +1,38 @@
+# Xiaomi Smart Camera C500
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C500 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 3.5K UHD (6MP, 3200×1800) |
+| Sensor | 1/2.45" BSI CMOS |
+| Lens | 1× f/1.6 |
+| Field of view | pan 360 (horizontal), tilt 116 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+| Released | 2025 |
+
+## Features
+
+- Xiaomi's first 6MP indoor camera (3.5K)
+- 6P optical lens with WDR
+- 8x 940nm no-glow infrared fill lights
+- ultra-low-light full colour imaging
+- 1 TOPS AI chip with local human and pet detection/tracking
+- physical lens shield (privacy masking)
+- dual-band Wi-Fi 6
+- Alexa / Google Assistant
+- Xiaomi HyperOS Connect
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c500/specs/
+
+---
+*Auto-generated from xiaomi-c500.json — do not edit by hand.*

--- a/cameras/xiaomi/c700.json
+++ b/cameras/xiaomi/c700.json
@@ -1,0 +1,78 @@
+{
+  "id": "xiaomi-c700",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C700",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "4K UHD",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 10
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A via USB Type-C",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "8MP 4K with HDR mode",
+    "ten 940nm no-glow infrared illuminators (10m)",
+    "full colour night vision in low light",
+    "physical lens shield with customisable timing",
+    "human tracking, pet, baby cry detection",
+    "stream quality selectable: 4K / 1080p / 480p",
+    "dual-band Wi-Fi 6 with Bluetooth 5.3",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "82 x 82 x 130",
+  "weight_g": 362,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.81ac1, protocol cs2+udp, H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c700/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c700/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-501385/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.81ac1 (protocol cs2+udp; H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/c700.md
+++ b/cameras/xiaomi/c700.md
@@ -1,0 +1,34 @@
+# Xiaomi Smart Camera C700
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C700 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Night vision | hybrid (10m) |
+| Power | 5V DC 2A via USB Type-C |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- 8MP 4K with HDR mode
+- ten 940nm no-glow infrared illuminators (10m)
+- full colour night vision in low light
+- physical lens shield with customisable timing
+- human tracking, pet, baby cry detection
+- stream quality selectable: 4K / 1080p / 480p
+- dual-band Wi-Fi 6 with Bluetooth 5.3
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c700/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c700/specs/
+- https://www.mi.com/global/support/faq/details/KA-501385/
+
+---
+*Auto-generated from xiaomi-c700.json — do not edit by hand.*

--- a/cameras/xiaomi/c701-pro.json
+++ b/cameras/xiaomi/c701-pro.json
@@ -1,0 +1,81 @@
+{
+  "id": "xiaomi-c701-pro",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C701 Pro",
+  "aliases": [
+    "MJSXJ31CM"
+  ],
+  "type": "dual-lens",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "4K UHD",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "2.8 (8MP ultra-wide, 5P) / 8 (5MP telephoto, 6P)",
+    "aperture": "f/1.6 (both lenses)",
+    "varifocal": false
+  },
+  "field_of_view_deg": "127 (ultra-wide lens); pan 360 (horizontal), tilt 180 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A via concealed USB Type-C",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 16-256GB (FAT32, Class 10+), NAS backup via microSD, or cloud."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "dual camera: 8MP ultra-wide + 5MP ultra-telephoto, 9x hybrid zoom",
+    "automatic lens zoom with adaptive-speed subject tracking (30% faster motor vs C700)",
+    "180-degree vertical pan-tilt (ceiling mount without blind spots)",
+    "10x 940nm no-glow infrared LEDs",
+    "ultra-low-light full-colour technology",
+    "gesture recognition: 'OK' gesture starts a voice call",
+    "AI: human, pet, motion, abnormal sound, crying baby detection, virtual fence",
+    "1 TOPS AI chip, MJA1 security chipset",
+    "physical lens shielding (app or manual)",
+    "dual-band Wi-Fi 6 with Bluetooth 5.4",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "78 x 72 x 127",
+  "release_year": 2026,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Requires Xiaomi Home app 10.8+. go2rtc supports the second lens of dual cameras via channel=2.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/c701-pro.md
+++ b/cameras/xiaomi/c701-pro.md
@@ -1,0 +1,41 @@
+# Xiaomi Smart Camera C701 Pro
+
+*Also known as: MJSXJ31CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C701 Pro |
+| Type | dual-lens |
+| Connectivity | wifi |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Lens | 2× 2.8 (8MP ultra-wide, 5P) / 8 (5MP telephoto, 6P)mm f/1.6 (both lenses) |
+| Field of view | 127 (ultra-wide lens); pan 360 (horizontal), tilt 180 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A via concealed USB Type-C |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+| Released | 2026 |
+
+## Features
+
+- dual camera: 8MP ultra-wide + 5MP ultra-telephoto, 9x hybrid zoom
+- automatic lens zoom with adaptive-speed subject tracking (30% faster motor vs C700)
+- 180-degree vertical pan-tilt (ceiling mount without blind spots)
+- 10x 940nm no-glow infrared LEDs
+- ultra-low-light full-colour technology
+- gesture recognition: 'OK' gesture starts a voice call
+- AI: human, pet, motion, abnormal sound, crying baby detection, virtual fence
+- 1 TOPS AI chip, MJA1 security chipset
+- physical lens shielding (app or manual)
+- dual-band Wi-Fi 6 with Bluetooth 5.4
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/specs/
+
+---
+*Auto-generated from xiaomi-c701-pro.json — do not edit by hand.*

--- a/cameras/xiaomi/c701.json
+++ b/cameras/xiaomi/c701.json
@@ -1,0 +1,81 @@
+{
+  "id": "xiaomi-c701",
+  "brand": "Xiaomi",
+  "model": "Smart Camera C701",
+  "aliases": [
+    "MJSXJ27CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "4K UHD",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "5V DC 2A power adapter (2m cable)",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB (Class 10+, FAT32), NAS network-attached storage, or cloud."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "8MP 4K with HDR",
+    "940nm no-glow infrared fill light",
+    "physical lens cover (privacy protection)",
+    "local AI: loud sound, baby cry and pet detection; human motion tracking",
+    "large-diameter box speaker with independent sound cavity",
+    "stream quality: 4K / 480p",
+    "dual-band Wi-Fi 6 with Bluetooth 5.4",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "79 x 79 x 119",
+  "release_year": 2025,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.079ae2, protocol cs2+udp, H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Unlike the C700 (4K/1080p/480p), the C701 only offers 4K and 480p stream quality options.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c701/",
+    "https://www.mi.com/global/product/xiaomi-smart-camera-c701/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-608921/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.079ae2 (protocol cs2+udp; H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/c701.md
+++ b/cameras/xiaomi/c701.md
@@ -1,0 +1,38 @@
+# Xiaomi Smart Camera C701
+
+*Also known as: MJSXJ27CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Smart Camera C701 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Field of view | pan 360 (horizontal), tilt 109 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter (2m cable) |
+| Storage | microSD ≤ 256GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 40°C |
+| Released | 2025 |
+
+## Features
+
+- 8MP 4K with HDR
+- 940nm no-glow infrared fill light
+- physical lens cover (privacy protection)
+- local AI: loud sound, baby cry and pet detection; human motion tracking
+- large-diameter box speaker with independent sound cavity
+- stream quality: 4K / 480p
+- dual-band Wi-Fi 6 with Bluetooth 5.4
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-smart-camera-c701/
+- https://www.mi.com/global/product/xiaomi-smart-camera-c701/specs/
+- https://www.mi.com/global/support/faq/details/KA-608921/
+
+---
+*Auto-generated from xiaomi-c701.json — do not edit by hand.*

--- a/cameras/xiaomi/cw300.json
+++ b/cameras/xiaomi/cw300.json
@@ -1,0 +1,68 @@
+{
+  "id": "xiaomi-cw300",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera CW300",
+  "type": "ptz",
+  "connectivity": [
+    "wifi",
+    "ethernet"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p)",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "12V DC 1A power adapter",
+    "voltage": "12V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 8-256GB or cloud storage."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "dual-motor pan-tilt gimbal",
+    "2x 850nm IR lights + 2x white lights for full-colour night vision",
+    "local AI human detection (no cloud needed)",
+    "audible alarm with high-frequency flashing lights",
+    "AI noise-cancelling microphone and high-power speaker",
+    "built-in Ethernet port (waterproof kit included)",
+    "Alexa / Google Assistant"
+  ],
+  "ip_rating": "IP66",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "168 x 100 x 123",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/cw300.md
+++ b/cameras/xiaomi/cw300.md
@@ -1,0 +1,33 @@
+# Xiaomi Outdoor Camera CW300
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera CW300 |
+| Type | ptz |
+| Connectivity | wifi, ethernet |
+| Resolution | 2.5K (1440p) (4MP, 2560×1440) |
+| Night vision | hybrid |
+| Power | 12V DC 1A power adapter |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- dual-motor pan-tilt gimbal
+- 2x 850nm IR lights + 2x white lights for full-colour night vision
+- local AI human detection (no cloud needed)
+- audible alarm with high-frequency flashing lights
+- AI noise-cancelling microphone and high-power speaker
+- built-in Ethernet port (waterproof kit included)
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/specs/
+
+---
+*Auto-generated from xiaomi-cw300.json — do not edit by hand.*

--- a/cameras/xiaomi/cw400.json
+++ b/cameras/xiaomi/cw400.json
@@ -1,0 +1,75 @@
+{
+  "id": "xiaomi-cw400",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera CW400",
+  "aliases": [
+    "MJSXJ04HL"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p)",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "113 (lens angle)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "12V DC 1A power adapter",
+    "voltage": "12V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "dual-gimbal pan-tilt",
+    "four-light smart full-colour night vision (IR + white fill lights)",
+    "AI human detection with alarm recording",
+    "audible alarm with flashing lights",
+    "dual-antenna Wi-Fi",
+    "time-lapse photography",
+    "voice call support (firmware 5.1.5_0228+)"
+  ],
+  "ip_rating": "IP66",
+  "operating_temp_c": "-30 to 60",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. No Bluetooth gateway function.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-44187/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/cw400.md
+++ b/cameras/xiaomi/cw400.md
@@ -1,0 +1,38 @@
+# Xiaomi Outdoor Camera CW400
+
+*Also known as: MJSXJ04HL*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera CW400 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2.5K (1440p) (4MP, 2560×1440) |
+| Lens | 1× F1.6 |
+| Field of view | 113 (lens angle)° |
+| Night vision | hybrid |
+| Power | 12V DC 1A power adapter |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- dual-gimbal pan-tilt
+- four-light smart full-colour night vision (IR + white fill lights)
+- AI human detection with alarm recording
+- audible alarm with flashing lights
+- dual-antenna Wi-Fi
+- time-lapse photography
+- voice call support (firmware 5.1.5_0228+)
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/specs/
+- https://www.mi.com/global/support/faq/details/KA-44187/
+
+---
+*Auto-generated from xiaomi-cw400.json — do not edit by hand.*

--- a/cameras/xiaomi/cw500-dual.json
+++ b/cameras/xiaomi/cw500-dual.json
@@ -1,0 +1,70 @@
+{
+  "id": "xiaomi-cw500-dual",
+  "brand": "Xiaomi",
+  "model": "Outdoor Camera CW500 Dual",
+  "aliases": [
+    "MJSXJ08HL"
+  ],
+  "type": "dual-lens",
+  "connectivity": [
+    "wifi",
+    "ethernet"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "resolution": {
+    "label": "2.5K (1440p) per camera",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 2,
+    "aperture": "F/1.6",
+    "varifocal": false
+  },
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "ptz": {
+    "autotracking": true
+  },
+  "power": {
+    "method": "12V DC 1A power adapter",
+    "voltage": "12V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 256,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD 16-256GB, NAS network-attached storage, or Xiaomi Cloud (dual-path)."
+  },
+  "features": [
+    "dual 4MP cameras: fixed wide + controllable PTZ",
+    "linked tracking: PTZ auto-tracks humans detected by the fixed camera",
+    "AI human and vehicle detection on both cameras",
+    "2x white lights + 2x IR lights per camera for full-colour night vision",
+    "audible alarm with high-frequency flashing lights",
+    "dual-band Wi-Fi 6 plus Ethernet port (waterproof kit included)",
+    "security chip"
+  ],
+  "ip_rating": "IP66",
+  "operating_temp_c": "-30 to 60",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+  "sources": [
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/",
+    "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/cw500-dual.md
+++ b/cameras/xiaomi/cw500-dual.md
@@ -1,0 +1,35 @@
+# Xiaomi Outdoor Camera CW500 Dual
+
+*Also known as: MJSXJ08HL*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Outdoor Camera CW500 Dual |
+| Type | dual-lens |
+| Connectivity | wifi, ethernet |
+| Resolution | 2.5K (1440p) per camera (4MP, 2560×1440) |
+| Lens | 2× F/1.6 |
+| Night vision | hybrid |
+| Power | 12V DC 1A power adapter |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- dual 4MP cameras: fixed wide + controllable PTZ
+- linked tracking: PTZ auto-tracks humans detected by the fixed camera
+- AI human and vehicle detection on both cameras
+- 2x white lights + 2x IR lights per camera for full-colour night vision
+- audible alarm with high-frequency flashing lights
+- dual-band Wi-Fi 6 plus Ethernet port (waterproof kit included)
+- security chip
+
+## Sources
+
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/
+- https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/specs/
+
+---
+*Auto-generated from xiaomi-cw500-dual.json — do not edit by hand.*

--- a/cameras/xiaomi/mi-360-2k-pro.json
+++ b/cameras/xiaomi/mi-360-2k-pro.json
@@ -1,0 +1,74 @@
+{
+  "id": "xiaomi-mi-360-2k-pro",
+  "brand": "Xiaomi",
+  "model": "Mi 360° Home Security Camera 2K Pro",
+  "aliases": [
+    "MJSXJ06CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F1.4",
+    "varifocal": false
+  },
+  "field_of_view_deg": "110 (lens angle)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "5V DC 2A power adapter",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 32,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "features": [
+    "F1.4 aperture with 6P lens",
+    "940nm no-glow infrared night vision, full colour in low light",
+    "physical lens shield",
+    "dual-microphone noise reduction",
+    "dual-band Wi-Fi (2.4/5GHz) with Bluetooth 4.2 gateway",
+    "AI human detection"
+  ],
+  "operating_temp_c": "-10 to 50",
+  "dimensions_mm": "122 x 78 x 78",
+  "weight_g": 349,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.021a04, protocol cs2, H.265 video). Manufactured by Shanghai Imilab Technology (Mi Ecosystem). 32GB microSD cap. Global spec page lists lens angle 110; the India regional page lists 118.",
+  "sources": [
+    "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/",
+    "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.021a04 (protocol cs2; H.265 video). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/mi-360-2k-pro.md
+++ b/cameras/xiaomi/mi-360-2k-pro.md
@@ -1,0 +1,34 @@
+# Xiaomi Mi 360° Home Security Camera 2K Pro
+
+*Also known as: MJSXJ06CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Mi 360° Home Security Camera 2K Pro |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 1× F1.4 |
+| Field of view | 110 (lens angle)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A power adapter |
+| Storage | microSD ≤ 32GB |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- F1.4 aperture with 6P lens
+- 940nm no-glow infrared night vision, full colour in low light
+- physical lens shield
+- dual-microphone noise reduction
+- dual-band Wi-Fi (2.4/5GHz) with Bluetooth 4.2 gateway
+- AI human detection
+
+## Sources
+
+- https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/
+- https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/specs/
+
+---
+*Auto-generated from xiaomi-mi-360-2k-pro.json — do not edit by hand.*

--- a/cameras/xiaomi/mi-360-2k.json
+++ b/cameras/xiaomi/mi-360-2k.json
@@ -1,0 +1,76 @@
+{
+  "id": "xiaomi-mi-360-2k",
+  "brand": "Xiaomi",
+  "model": "Mi 360° Home Security Camera 2K",
+  "aliases": [
+    "MJSXJ09CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F1.4",
+    "varifocal": false
+  },
+  "field_of_view_deg": "110 (lens angle)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "5V DC 2A",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 32,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "features": [
+    "940nm no-glow infrared night vision",
+    "full colour in low light",
+    "AI human detection with false-alarm filtering",
+    "dual-axis pan-tilt (360 horizontal, 108 vertical)",
+    "Mi Smart Clock video output",
+    "BSI Kitemark certified (residential IoT)",
+    "Alexa / Google Assistant"
+  ],
+  "operating_temp_c": "-10 to 50",
+  "dimensions_mm": "115 x 78 x 78",
+  "weight_g": 310,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.029a02, protocol cs2+udp, H.265 video + PCMA audio). Note the low 32GB microSD cap versus 256GB on the newer C-series.",
+  "sources": [
+    "https://www.mi.com/global/product/mi-360-home-security-camera-2k/",
+    "https://www.mi.com/global/product/mi-360-home-security-camera-2k/specs/",
+    "https://www.mi.com/global/support/faq/details/KA-06539/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.029a02 (protocol cs2+udp; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/mi-360-2k.md
+++ b/cameras/xiaomi/mi-360-2k.md
@@ -1,0 +1,36 @@
+# Xiaomi Mi 360° Home Security Camera 2K
+
+*Also known as: MJSXJ09CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Mi 360° Home Security Camera 2K |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Lens | 1× F1.4 |
+| Field of view | 110 (lens angle)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A |
+| Storage | microSD ≤ 32GB |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- 940nm no-glow infrared night vision
+- full colour in low light
+- AI human detection with false-alarm filtering
+- dual-axis pan-tilt (360 horizontal, 108 vertical)
+- Mi Smart Clock video output
+- BSI Kitemark certified (residential IoT)
+- Alexa / Google Assistant
+
+## Sources
+
+- https://www.mi.com/global/product/mi-360-home-security-camera-2k/
+- https://www.mi.com/global/product/mi-360-home-security-camera-2k/specs/
+- https://www.mi.com/global/support/faq/details/KA-06539/
+
+---
+*Auto-generated from xiaomi-mi-360-2k.json — do not edit by hand.*

--- a/cameras/xiaomi/mi-360-camera-1080p.json
+++ b/cameras/xiaomi/mi-360-camera-1080p.json
@@ -1,0 +1,57 @@
+{
+  "id": "xiaomi-mi-360-camera-1080p",
+  "brand": "Xiaomi",
+  "model": "Mi 360° Camera (1080p)",
+  "aliases": [
+    "MJSXJ10CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "1080p Full HD",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F2.1",
+    "varifocal": false
+  },
+  "field_of_view_deg": "110 (angle of view)",
+  "night_vision": {
+    "type": "ir"
+  },
+  "power": {
+    "method": "5V DC 2A",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 32,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "features": [
+    "compact 360-degree pan-tilt",
+    "F2.1 aperture",
+    "1080p entry-level indoor monitoring"
+  ],
+  "operating_temp_c": "-10 to 40",
+  "dimensions_mm": "108 x 75 x 75",
+  "weight_g": 254,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Revised compact successor to the MJSXJ05CM 360 1080P.  32GB microSD cap.",
+  "sources": [
+    "https://www.mi.com/global/product/mi-360-camera-1080p/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/mi-360-camera-1080p.md
+++ b/cameras/xiaomi/mi-360-camera-1080p.md
@@ -1,0 +1,30 @@
+# Xiaomi Mi 360° Camera (1080p)
+
+*Also known as: MJSXJ10CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Mi 360° Camera (1080p) |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 1080p Full HD (2MP, 1920×1080) |
+| Lens | 1× F2.1 |
+| Field of view | 110 (angle of view)° |
+| Night vision | ir |
+| Power | 5V DC 2A |
+| Storage | microSD ≤ 32GB |
+| Operating temp | -10 to 40°C |
+
+## Features
+
+- compact 360-degree pan-tilt
+- F2.1 aperture
+- 1080p entry-level indoor monitoring
+
+## Sources
+
+- https://www.mi.com/global/product/mi-360-camera-1080p/specs/
+
+---
+*Auto-generated from xiaomi-mi-360-camera-1080p.json — do not edit by hand.*

--- a/cameras/xiaomi/mi-camera-2k-magnetic-mount.json
+++ b/cameras/xiaomi/mi-camera-2k-magnetic-mount.json
@@ -1,0 +1,69 @@
+{
+  "id": "xiaomi-mi-camera-2k-magnetic-mount",
+  "brand": "Xiaomi",
+  "model": "Mi Camera 2K (Magnetic Mount)",
+  "aliases": [
+    "MJSXJ03HL"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "2K (1296p)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "field_of_view_deg": "125 (lens angle)",
+  "night_vision": {
+    "type": "ir"
+  },
+  "power": {
+    "method": "5V DC 1A",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": true,
+    "nvr_compatible": false,
+    "notes": "microSD card (no maximum capacity stated on official spec page)."
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true
+  },
+  "features": [
+    "ultra-compact (60 x 48 x 67.5mm) with detachable adjustable magnetic base",
+    "125-degree wide-angle fixed lens",
+    "metal pad included for flexible magnetic placement"
+  ],
+  "operating_temp_c": "-10 to 50",
+  "dimensions_mm": "60 x 48 x 67.5",
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model isa.camera.hlc7, protocol cs2, H.265 video + PCMA audio). Manufactured by Tianjin Hualai Technology (Mi Ecosystem, same manufacturer as Wyze cameras).",
+  "sources": [
+    "https://www.mi.com/global/product/mi-camera-2k-magnetic-mount/specs/",
+    "https://www.mi.com/uk/product/mi-camera-2k-magnetic-mount/specs/"
+  ],
+  "status": "available",
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "recommended_stream_type": "go2rtc",
+      "verified": true,
+      "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+      "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=isa.camera.hlc7 (protocol cs2; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+    }
+  }
+}

--- a/cameras/xiaomi/mi-camera-2k-magnetic-mount.md
+++ b/cameras/xiaomi/mi-camera-2k-magnetic-mount.md
@@ -1,0 +1,30 @@
+# Xiaomi Mi Camera 2K (Magnetic Mount)
+
+*Also known as: MJSXJ03HL*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Mi Camera 2K (Magnetic Mount) |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2K (1296p) (3MP, 2304×1296) |
+| Field of view | 125 (lens angle)° |
+| Night vision | ir |
+| Power | 5V DC 1A |
+| Two-way audio | No |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- ultra-compact (60 x 48 x 67.5mm) with detachable adjustable magnetic base
+- 125-degree wide-angle fixed lens
+- metal pad included for flexible magnetic placement
+
+## Sources
+
+- https://www.mi.com/global/product/mi-camera-2k-magnetic-mount/specs/
+- https://www.mi.com/uk/product/mi-camera-2k-magnetic-mount/specs/
+
+---
+*Auto-generated from xiaomi-mi-camera-2k-magnetic-mount.json — do not edit by hand.*

--- a/cameras/xiaomi/mi-home-360-1080p.json
+++ b/cameras/xiaomi/mi-home-360-1080p.json
@@ -1,0 +1,70 @@
+{
+  "id": "xiaomi-mi-home-360-1080p",
+  "brand": "Xiaomi",
+  "model": "Mi Home Security Camera 360° 1080P",
+  "aliases": [
+    "MJSXJ05CM"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "resolution": {
+    "label": "1080p Full HD",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "codecs": [
+      "H.265"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "aperture": "F2.1",
+    "varifocal": false
+  },
+  "field_of_view_deg": "110 (lens angle); pan 360 (horizontal), tilt 96 (vertical)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "power": {
+    "method": "5V DC 2A via Micro USB",
+    "voltage": "5V"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 64,
+    "cloud": true,
+    "nvr_compatible": false
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "dual-motor 360/96 pan-tilt with silent shockproof design",
+    "low-light true colour technology",
+    "8-bulb 940nm infrared illuminator",
+    "motion detection with talkback",
+    "inverted installation support",
+    "Alexa support"
+  ],
+  "operating_temp_c": "-10 to 50",
+  "dimensions_mm": "118 x 78 x 78",
+  "weight_g": 310,
+  "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Legacy model (Micro USB, 64GB microSD cap); superseded by the Mi 360 2K series and C-series. Manufactured by Shanghai Imilab Technology (Mi Ecosystem).",
+  "sources": [
+    "https://www.mi.com/global/camera-360",
+    "https://i01.appmifile.com/webfile/globalimg/Global_UG/Mi_Ecosystem/Mi_Home_Security_Camera_360_1080P/en_V2.pdf"
+  ],
+  "last_verified": "2026-07-20"
+}

--- a/cameras/xiaomi/mi-home-360-1080p.md
+++ b/cameras/xiaomi/mi-home-360-1080p.md
@@ -1,0 +1,35 @@
+# Xiaomi Mi Home Security Camera 360° 1080P
+
+*Also known as: MJSXJ05CM*
+
+| Field | Spec |
+|-------|------|
+| Brand | Xiaomi |
+| Model | Mi Home Security Camera 360° 1080P |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 1080p Full HD (2MP, 1920×1080) |
+| Lens | 1× F2.1 |
+| Field of view | 110 (lens angle); pan 360 (horizontal), tilt 96 (vertical)° |
+| Night vision | hybrid |
+| Power | 5V DC 2A via Micro USB |
+| Storage | microSD ≤ 64GB |
+| Two-way audio | Yes |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- dual-motor 360/96 pan-tilt with silent shockproof design
+- low-light true colour technology
+- 8-bulb 940nm infrared illuminator
+- motion detection with talkback
+- inverted installation support
+- Alexa support
+
+## Sources
+
+- https://www.mi.com/global/camera-360
+- https://i01.appmifile.com/webfile/globalimg/Global_UG/Mi_Ecosystem/Mi_Home_Security_Camera_360_1080P/en_V2.pdf
+
+---
+*Auto-generated from xiaomi-mi-home-360-1080p.json — do not edit by hand.*

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -2249,6 +2249,32 @@ wyze-cam-v4,Wyze,Cam v4,box,2.5K QHD,4,"1/2.7"" CMOS (upgraded vs v3)",118 diago
 wyze-floodlight-cam-v2,Wyze,Floodlight Cam v2,bullet,3MP,3,CMOS,160 diagonal,color,IP65,true,2023
 wyze-video-doorbell-pro,Wyze,Video Doorbell Pro,doorbell,1080p,2,,160 diagonal,color,IP44,true,2022
 wyze-video-doorbell-v2,Wyze,Video Doorbell v2,doorbell,3MP,3,,150 diagonal,color,IP65,true,2024
+xiaomi-aw300,Xiaomi,Outdoor Camera AW300,bullet,2K (1296p),3,,101.7,hybrid,IP66,true,
+xiaomi-bw300,Xiaomi,Outdoor Camera BW300,bullet,2K (1296p),3,,130 D,hybrid,IP67,,
+xiaomi-bw400-pro,Xiaomi,Solar Outdoor Camera BW400 Pro Set,bullet,2.5K,4,,132,hybrid,,,
+xiaomi-bw500,Xiaomi,Outdoor Camera BW500,bullet,2.5K (1440p),4,,136 (lens angle),hybrid,IP67,,
+xiaomi-c100,Xiaomi,Smart Camera C100,bullet,2K (1296p),3,,,color,,true,
+xiaomi-c200,Xiaomi,Smart Camera C200,ptz,1080p Full HD,2,,pan 360 (horizontal),ir,,true,
+xiaomi-c201,Xiaomi,Smart Camera C201,ptz,1080p Full HD,2,,,hybrid,,,
+xiaomi-c300,Xiaomi,Smart Camera C300,ptz,2K (1296p),3,,"pan 360 (horizontal), tilt 108 (vertical)",hybrid,,,
+xiaomi-c300-dual,Xiaomi,Smart Camera C300 Dual,dual-lens,2K (1296p),3,,,hybrid,,,
+xiaomi-c301,Xiaomi,Smart Camera C301,ptz,2K (1296p),3,,,hybrid,,true,
+xiaomi-c302,Xiaomi,Smart Camera C302,ptz,2K (1296p),3,,,hybrid,,true,
+xiaomi-c400,Xiaomi,Smart Camera C400,ptz,2.5K (1440p),4,,pan 360 (horizontal),ir,,,
+xiaomi-c500,Xiaomi,Smart Camera C500,ptz,3.5K UHD,6,"1/2.45"" BSI CMOS","pan 360 (horizontal), tilt 116 (vertical)",hybrid,,true,2025
+xiaomi-c500-dual,Xiaomi,Smart Camera C500 Dual,dual-lens,2.5K (1440p) per camera,4,,58 H (telephoto camera),hybrid,,,
+xiaomi-c500-pro,Xiaomi,Smart Camera C500 Pro,ptz,3K,5,,"pan 360 (horizontal), tilt 114 (vertical)",hybrid,,true,
+xiaomi-c700,Xiaomi,Smart Camera C700,ptz,4K UHD,8,,,hybrid,,true,
+xiaomi-c701,Xiaomi,Smart Camera C701,ptz,4K UHD,8,,"pan 360 (horizontal), tilt 109 (vertical)",hybrid,,true,2025
+xiaomi-c701-pro,Xiaomi,Smart Camera C701 Pro,dual-lens,4K UHD,8,,"127 (ultra-wide lens); pan 360 (horizontal), tilt 180 (vertical)",hybrid,,true,2026
+xiaomi-cw300,Xiaomi,Outdoor Camera CW300,ptz,2.5K (1440p),4,,,hybrid,IP66,true,
+xiaomi-cw400,Xiaomi,Outdoor Camera CW400,ptz,2.5K (1440p),4,,113 (lens angle),hybrid,IP66,true,
+xiaomi-cw500-dual,Xiaomi,Outdoor Camera CW500 Dual,dual-lens,2.5K (1440p) per camera,4,,,hybrid,IP66,,
+xiaomi-mi-360-2k,Xiaomi,Mi 360° Home Security Camera 2K,ptz,2K (1296p),3,,110 (lens angle),hybrid,,,
+xiaomi-mi-360-2k-pro,Xiaomi,Mi 360° Home Security Camera 2K Pro,ptz,2K (1296p),3,,110 (lens angle),hybrid,,,
+xiaomi-mi-360-camera-1080p,Xiaomi,Mi 360° Camera (1080p),ptz,1080p Full HD,2,,110 (angle of view),ir,,,
+xiaomi-mi-camera-2k-magnetic-mount,Xiaomi,Mi Camera 2K (Magnetic Mount),bullet,2K (1296p),3,,125 (lens angle),ir,,,
+xiaomi-mi-home-360-1080p,Xiaomi,Mi Home Security Camera 360° 1080P,ptz,1080p Full HD,2,,"110 (lens angle); pan 360 (horizontal), tilt 96 (vertical)",hybrid,,true,
 yale-sv-abfx-w,Yale,SV-ABFX-W,bullet,1080p HD,2,,110 horizontal,ir,IP65,true,2022
 yale-sv-dafx-w,Yale,SV-DAFX-W,bullet,1080p HD,2,,110 horizontal,ir,IP65,true,2020
 yale-sv-dbc-b,Yale,Smart Video Doorbell Colour,doorbell,1080p HD,2,,150h,color,IP55,true,2022

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -202354,6 +202354,1876 @@
     "added": "2026-06-09"
   },
   {
+    "id": "xiaomi-aw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera AW300",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "101.7",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "12V DC 1A adapter (3m cable; official 6m 22AWG extension supported)",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 32-256GB (FAT32) or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "2x 850nm IR lights + 2x LED spotlights for full-colour night vision",
+      "WDR for complex outdoor lighting",
+      "focus zone detection with audible alarm and flashing lights",
+      "AI human detection, face recognition via Xiaomi Home Secure",
+      "full-duplex two-way calls",
+      "split-screen multi-camera viewing (up to 4)",
+      "Alexa / Google Assistant"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "173 x 70 x 75",
+    "weight_g": 249,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model mxiang.camera.mod13, protocol cs2+udp, H.265 video + Opus audio).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-12521/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=mxiang.camera.mod13 (protocol cs2+udp; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera BW300",
+    "aliases": [
+      "BW300"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "field_of_view_deg": "130 D",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 4900mAh rechargeable battery; optional solar panel"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "7-day rolling cloud service included; extended cloud storage is a paid subscription."
+    },
+    "features": [
+      "4900mAh battery: up to 120 days (20 triggers/day) or 180 days (10 triggers/day)",
+      "intelligent full-colour night vision",
+      "AI dynamic capture and tracking",
+      "IP67 tested by SGS",
+      "wire-free installation",
+      "Google Home / Alexa smart link"
+    ],
+    "ip_rating": "IP67",
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-128861/",
+      "https://www.mi.com/global/support/faq/details/KA-228932/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw400-pro",
+    "brand": "Xiaomi",
+    "model": "Solar Outdoor Camera BW400 Pro Set",
+    "aliases": [
+      "BW400 Pro"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "field_of_view_deg": "132",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 10000mAh battery with integrated solar panel; USB Type-C charging"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Camera pairs 1:1 with the included indoor base station, which handles signal, data processing and storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true
+    },
+    "features": [
+      "camera + base station set (no direct router connection required)",
+      "self-sufficient with 2+ hours of daily direct sunlight (20 recordings/day)",
+      "~180-day battery life (20x 10s recordings/day)",
+      "AI detection: person, vehicle, animal, package",
+      "thermal (PIR) and photosensitive sensors",
+      "white-light indicator",
+      "8m sound pick-up distance",
+      "MJA1 security chipset"
+    ],
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Official spec table lists resolution as '2.5K' (Xiaomi defines 2.5K as 2560 x 1440).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/",
+      "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-227286/",
+      "https://www.mi.com/global/support/faq/details/KA-227291/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw500",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera BW500",
+    "aliases": [
+      "MJSXJ06BY"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "f/1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "136 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 10000mAh battery (5V 2A charging, ~6-7h); optional 5W solar panel"
+    },
+    "storage": {
+      "onboard": true,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Built-in 8GB eMMC storage; optional cloud storage. No microSD slot listed."
+    },
+    "features": [
+      "up to 180 days battery life (max 20x 10s recordings/day)",
+      "2.5K full-colour night vision",
+      "WDR for backlit scenes",
+      "AI human and vehicle detection with audio-visual deterrent (white light + alarm)",
+      "low-power on-demand system design",
+      "anti-theft base",
+      "Wi-Fi 6 (2.4GHz)",
+      "Google Assistant / Alexa"
+    ],
+    "ip_rating": "IP67",
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-204760/",
+      "https://www.mi.com/global/support/faq/details/KA-226557/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c100",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C100",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "color"
+    },
+    "power": {
+      "method": "5V DC 1A via USB Type-C (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "compact fixed indoor camera",
+      "3MP full colour in low light",
+      "manual slide-cover physical lens shielding",
+      "AI baby cry detection, human detection, virtual fence",
+      "3A audio algorithm (AEC/ANS/AGC)",
+      "Wi-Fi 6 (2.4GHz) with Bluetooth 5.2",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "69 x 68 x 115",
+    "weight_g": 170,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c100/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c100/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-573427/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c200",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C200",
+    "aliases": [
+      "MJSXJ14CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Supports NAS transfer via inserted microSD card (SD card acts as relay to NAS storage)."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "1080p entry pan-tilt indoor",
+      "AI human detection and tracking",
+      "infrared night vision (9m)",
+      "two-way voice calls via Xiaomi Home app",
+      "NAS transfer support",
+      "continues local recording during network outage",
+      "Xiaomi security chip"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.046c04, protocol cs2, H.265 video + Opus audio).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c200/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c200/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-86464/",
+      "https://www.mi.com/global/support/faq/details/KA-235580/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.046c04 (protocol cs2; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c201",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C201",
+    "aliases": [
+      "MBC27"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A (power adapter not included; user-supplied)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "features": [
+      "dual-axis pan-tilt gimbal",
+      "six built-in no-glow infrared illuminators",
+      "local AI human detection with motion tracking",
+      "pet detection and tracking (cats/dogs)",
+      "MJA1 security chipset with AES-128 cloud encryption",
+      "Wi-Fi 6 (2.4GHz)",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c201/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c201/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-600067/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c300",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C300",
+    "aliases": [
+      "XMC01"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 108 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "2K with F1.4 large aperture 6P lens",
+      "full colour in low light",
+      "940nm no-glow infrared LEDs",
+      "AI human detection",
+      "dual-motor pan-tilt",
+      "BSI Kitemark certified (residential IoT)"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "115 x 78 x 78",
+    "weight_g": 327,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-130637/",
+      "https://www.mi.com/global/support/faq/details/KA-231317/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c300-dual",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C300 Dual",
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "6 (telephoto PTZ lens)",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB."
+    },
+    "features": [
+      "true dual camera: fixed wide + 6mm telephoto PTZ",
+      "PTZ auto-rotates to track humans detected by the fixed camera",
+      "press-and-hold on fixed footage rotates PTZ for close-ups",
+      "AI detection on both cameras",
+      "virtual fence",
+      "pet detection and tracking (cats/dogs)",
+      "baby cry detection",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Xiaomi HyperOS Connect"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 78 x 126",
+    "weight_g": 384,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c301",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C301",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "3MP 2K with large-aperture 4P lens",
+      "dual-gimbal pan-tilt",
+      "full colour night vision",
+      "local AI human detection with alerts",
+      "large-diameter speaker for remote calls",
+      "MJA1-class security chip with AES-128 cloud encryption",
+      "flat and inverted mounting",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c301/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c301/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c302",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C302",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A via USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "local AI: human detection and tracking",
+      "pet detection (cats/dogs)",
+      "baby cry and abnormal sound detection (e.g. glass breaking)",
+      "virtual fence and custom detection zones",
+      "physical lens shield (privacy masking)",
+      "MJA1 security chipset with AES-128 cloud encryption",
+      "Wi-Fi 6 (2.4GHz) with Bluetooth 5.0",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c302/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c302/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-616066/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c400",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C400",
+    "aliases": [
+      "MJSXJ23CM",
+      "MJSXJ11CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "2.5K with large-aperture 6P lens",
+      "940nm no-glow infrared night vision",
+      "AI human detection",
+      "dual-motor pan-tilt",
+      "2.4GHz/5GHz dual-band Wi-Fi",
+      "Mi Home security chip"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "119 x 78 x 78",
+    "weight_g": 318,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Model number updated from MJSXJ11CM to MJSXJ23CM with no functional changes (per official spec page).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c400/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c400/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-12475/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "3.5K UHD",
+      "max_width": 3200,
+      "max_height": 1800,
+      "megapixels": 6
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "sensor": "1/2.45\" BSI CMOS",
+    "lens": {
+      "count": 1,
+      "aperture": "f/1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 116 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB, cloud storage, or NAS network-attached storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Xiaomi's first 6MP indoor camera (3.5K)",
+      "6P optical lens with WDR",
+      "8x 940nm no-glow infrared fill lights",
+      "ultra-low-light full colour imaging",
+      "1 TOPS AI chip with local human and pet detection/tracking",
+      "physical lens shield (privacy masking)",
+      "dual-band Wi-Fi 6",
+      "Alexa / Google Assistant",
+      "Xiaomi HyperOS Connect"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "79 x 79 x 119",
+    "release_year": 2025,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500-dual",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500 Dual",
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p) per camera",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "6 (telephoto PTZ lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "58 H (telephoto camera)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB, cloud storage, or NAS networked storage."
+    },
+    "features": [
+      "true dual camera: fixed 4MP + 6mm telephoto PTZ (both 4MP F1.6)",
+      "sixteen 940nm infrared illuminators across both cameras",
+      "PTZ rotates to close-ups via press-and-hold on fixed footage",
+      "pet detection and tracking (cats/dogs)",
+      "baby cry detection",
+      "virtual fence on fixed camera",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Xiaomi HyperOS Connect"
+    ],
+    "dimensions_mm": "78 x 77 x 128",
+    "weight_g": 305,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500-pro",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500 Pro",
+    "aliases": [
+      "MJSXJ16CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "3K",
+      "max_width": 2960,
+      "max_height": 1666,
+      "megapixels": 5
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB, cloud storage (AES-128 encrypted), or NAS backup from microSD."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "5MP 3K with HDR mode",
+      "ultra-low light colour mode plus IR illuminator",
+      "local human detection and tracking",
+      "local pet detection",
+      "loud noise and crying baby detection",
+      "physical lens shield (privacy masking)",
+      "MJA1 security chip",
+      "dual-band Wi-Fi with Bluetooth 5.2",
+      "high-power speaker for two-way calls",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "78 x 78 x 124",
+    "weight_g": 301,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-78565/",
+      "https://www.mi.com/global/support/faq/details/KA-78747/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c700",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C700",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A via USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP 4K with HDR mode",
+      "ten 940nm no-glow infrared illuminators (10m)",
+      "full colour night vision in low light",
+      "physical lens shield with customisable timing",
+      "human tracking, pet, baby cry detection",
+      "stream quality selectable: 4K / 1080p / 480p",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "82 x 82 x 130",
+    "weight_g": 362,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.81ac1, protocol cs2+udp, H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c700/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c700/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-501385/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.81ac1 (protocol cs2+udp; H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c701",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C701",
+    "aliases": [
+      "MJSXJ27CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB (Class 10+, FAT32), NAS network-attached storage, or cloud."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP 4K with HDR",
+      "940nm no-glow infrared fill light",
+      "physical lens cover (privacy protection)",
+      "local AI: loud sound, baby cry and pet detection; human motion tracking",
+      "large-diameter box speaker with independent sound cavity",
+      "stream quality: 4K / 480p",
+      "dual-band Wi-Fi 6 with Bluetooth 5.4",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "79 x 79 x 119",
+    "release_year": 2025,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.079ae2, protocol cs2+udp, H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Unlike the C700 (4K/1080p/480p), the C701 only offers 4K and 480p stream quality options.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-608921/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.079ae2 (protocol cs2+udp; H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c701-pro",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C701 Pro",
+    "aliases": [
+      "MJSXJ31CM"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (8MP ultra-wide, 5P) / 8 (5MP telephoto, 6P)",
+      "aperture": "f/1.6 (both lenses)",
+      "varifocal": false
+    },
+    "field_of_view_deg": "127 (ultra-wide lens); pan 360 (horizontal), tilt 180 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A via concealed USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB (FAT32, Class 10+), NAS backup via microSD, or cloud."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual camera: 8MP ultra-wide + 5MP ultra-telephoto, 9x hybrid zoom",
+      "automatic lens zoom with adaptive-speed subject tracking (30% faster motor vs C700)",
+      "180-degree vertical pan-tilt (ceiling mount without blind spots)",
+      "10x 940nm no-glow infrared LEDs",
+      "ultra-low-light full-colour technology",
+      "gesture recognition: 'OK' gesture starts a voice call",
+      "AI: human, pet, motion, abnormal sound, crying baby detection, virtual fence",
+      "1 TOPS AI chip, MJA1 security chipset",
+      "physical lens shielding (app or manual)",
+      "dual-band Wi-Fi 6 with Bluetooth 5.4",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 72 x 127",
+    "release_year": 2026,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Requires Xiaomi Home app 10.8+. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW300",
+    "type": "ptz",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-motor pan-tilt gimbal",
+      "2x 850nm IR lights + 2x white lights for full-colour night vision",
+      "local AI human detection (no cloud needed)",
+      "audible alarm with high-frequency flashing lights",
+      "AI noise-cancelling microphone and high-power speaker",
+      "built-in Ethernet port (waterproof kit included)",
+      "Alexa / Google Assistant"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "168 x 100 x 123",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw400",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW400",
+    "aliases": [
+      "MJSXJ04HL"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "113 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-gimbal pan-tilt",
+      "four-light smart full-colour night vision (IR + white fill lights)",
+      "AI human detection with alarm recording",
+      "audible alarm with flashing lights",
+      "dual-antenna Wi-Fi",
+      "time-lapse photography",
+      "voice call support (firmware 5.1.5_0228+)"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. No Bluetooth gateway function.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-44187/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw500-dual",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW500 Dual",
+    "aliases": [
+      "MJSXJ08HL"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p) per camera",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "aperture": "F/1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB, NAS network-attached storage, or Xiaomi Cloud (dual-path)."
+    },
+    "features": [
+      "dual 4MP cameras: fixed wide + controllable PTZ",
+      "linked tracking: PTZ auto-tracks humans detected by the fixed camera",
+      "AI human and vehicle detection on both cameras",
+      "2x white lights + 2x IR lights per camera for full-colour night vision",
+      "audible alarm with high-frequency flashing lights",
+      "dual-band Wi-Fi 6 plus Ethernet port (waterproof kit included)",
+      "security chip"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-2k",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Home Security Camera 2K",
+    "aliases": [
+      "MJSXJ09CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "940nm no-glow infrared night vision",
+      "full colour in low light",
+      "AI human detection with false-alarm filtering",
+      "dual-axis pan-tilt (360 horizontal, 108 vertical)",
+      "Mi Smart Clock video output",
+      "BSI Kitemark certified (residential IoT)",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "115 x 78 x 78",
+    "weight_g": 310,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.029a02, protocol cs2+udp, H.265 video + PCMA audio). Note the low 32GB microSD cap versus 256GB on the newer C-series.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k/",
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-06539/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.029a02 (protocol cs2+udp; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-2k-pro",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Home Security Camera 2K Pro",
+    "aliases": [
+      "MJSXJ06CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "F1.4 aperture with 6P lens",
+      "940nm no-glow infrared night vision, full colour in low light",
+      "physical lens shield",
+      "dual-microphone noise reduction",
+      "dual-band Wi-Fi (2.4/5GHz) with Bluetooth 4.2 gateway",
+      "AI human detection"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "122 x 78 x 78",
+    "weight_g": 349,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.021a04, protocol cs2, H.265 video). Manufactured by Shanghai Imilab Technology (Mi Ecosystem). 32GB microSD cap. Global spec page lists lens angle 110; the India regional page lists 118.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/",
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.021a04 (protocol cs2; H.265 video). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-camera-1080p",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Camera (1080p)",
+    "aliases": [
+      "MJSXJ10CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (angle of view)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 2A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "compact 360-degree pan-tilt",
+      "F2.1 aperture",
+      "1080p entry-level indoor monitoring"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "108 x 75 x 75",
+    "weight_g": 254,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Revised compact successor to the MJSXJ05CM 360 1080P.  32GB microSD cap.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-camera-1080p/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-camera-2k-magnetic-mount",
+    "brand": "Xiaomi",
+    "model": "Mi Camera 2K (Magnetic Mount)",
+    "aliases": [
+      "MJSXJ03HL"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "125 (lens angle)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 1A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD card (no maximum capacity stated on official spec page)."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true
+    },
+    "features": [
+      "ultra-compact (60 x 48 x 67.5mm) with detachable adjustable magnetic base",
+      "125-degree wide-angle fixed lens",
+      "metal pad included for flexible magnetic placement"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "60 x 48 x 67.5",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model isa.camera.hlc7, protocol cs2, H.265 video + PCMA audio). Manufactured by Tianjin Hualai Technology (Mi Ecosystem, same manufacturer as Wyze cameras).",
+    "sources": [
+      "https://www.mi.com/global/product/mi-camera-2k-magnetic-mount/specs/",
+      "https://www.mi.com/uk/product/mi-camera-2k-magnetic-mount/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=isa.camera.hlc7 (protocol cs2; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-home-360-1080p",
+    "brand": "Xiaomi",
+    "model": "Mi Home Security Camera 360° 1080P",
+    "aliases": [
+      "MJSXJ05CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle); pan 360 (horizontal), tilt 96 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A via Micro USB",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 64,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-motor 360/96 pan-tilt with silent shockproof design",
+      "low-light true colour technology",
+      "8-bulb 940nm infrared illuminator",
+      "motion detection with talkback",
+      "inverted installation support",
+      "Alexa support"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "118 x 78 x 78",
+    "weight_g": 310,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Legacy model (Micro USB, 64GB microSD cap); superseded by the Mi 360 2K series and C-series. Manufactured by Shanghai Imilab Technology (Mi Ecosystem).",
+    "sources": [
+      "https://www.mi.com/global/camera-360",
+      "https://i01.appmifile.com/webfile/globalimg/Global_UG/Mi_Ecosystem/Mi_Home_Security_Camera_360_1080P/en_V2.pdf"
+    ],
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
     "id": "yale-sv-abfx-w",
     "brand": "Yale",
     "model": "SV-ABFX-W",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -202354,6 +202354,1876 @@
     "added": "2026-06-09"
   },
   {
+    "id": "xiaomi-aw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera AW300",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "101.7",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "12V DC 1A adapter (3m cable; official 6m 22AWG extension supported)",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 32-256GB (FAT32) or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "2x 850nm IR lights + 2x LED spotlights for full-colour night vision",
+      "WDR for complex outdoor lighting",
+      "focus zone detection with audible alarm and flashing lights",
+      "AI human detection, face recognition via Xiaomi Home Secure",
+      "full-duplex two-way calls",
+      "split-screen multi-camera viewing (up to 4)",
+      "Alexa / Google Assistant"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "173 x 70 x 75",
+    "weight_g": 249,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model mxiang.camera.mod13, protocol cs2+udp, H.265 video + Opus audio).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-aw300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-12521/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=mxiang.camera.mod13 (protocol cs2+udp; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera BW300",
+    "aliases": [
+      "BW300"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "field_of_view_deg": "130 D",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 4900mAh rechargeable battery; optional solar panel"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "7-day rolling cloud service included; extended cloud storage is a paid subscription."
+    },
+    "features": [
+      "4900mAh battery: up to 120 days (20 triggers/day) or 180 days (10 triggers/day)",
+      "intelligent full-colour night vision",
+      "AI dynamic capture and tracking",
+      "IP67 tested by SGS",
+      "wire-free installation",
+      "Google Home / Alexa smart link"
+    ],
+    "ip_rating": "IP67",
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-128861/",
+      "https://www.mi.com/global/support/faq/details/KA-228932/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw400-pro",
+    "brand": "Xiaomi",
+    "model": "Solar Outdoor Camera BW400 Pro Set",
+    "aliases": [
+      "BW400 Pro"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "field_of_view_deg": "132",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 10000mAh battery with integrated solar panel; USB Type-C charging"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Camera pairs 1:1 with the included indoor base station, which handles signal, data processing and storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true
+    },
+    "features": [
+      "camera + base station set (no direct router connection required)",
+      "self-sufficient with 2+ hours of daily direct sunlight (20 recordings/day)",
+      "~180-day battery life (20x 10s recordings/day)",
+      "AI detection: person, vehicle, animal, package",
+      "thermal (PIR) and photosensitive sensors",
+      "white-light indicator",
+      "8m sound pick-up distance",
+      "MJA1 security chipset"
+    ],
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Official spec table lists resolution as '2.5K' (Xiaomi defines 2.5K as 2560 x 1440).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/",
+      "https://www.mi.com/global/product/xiaomi-solar-outdoor-camera-bw-400-pro-set/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-227286/",
+      "https://www.mi.com/global/support/faq/details/KA-227291/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-bw500",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera BW500",
+    "aliases": [
+      "MJSXJ06BY"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "battery"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "f/1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "136 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "Built-in 10000mAh battery (5V 2A charging, ~6-7h); optional 5W solar panel"
+    },
+    "storage": {
+      "onboard": true,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Built-in 8GB eMMC storage; optional cloud storage. No microSD slot listed."
+    },
+    "features": [
+      "up to 180 days battery life (max 20x 10s recordings/day)",
+      "2.5K full-colour night vision",
+      "WDR for backlit scenes",
+      "AI human and vehicle detection with audio-visual deterrent (white light + alarm)",
+      "low-power on-demand system design",
+      "anti-theft base",
+      "Wi-Fi 6 (2.4GHz)",
+      "Google Assistant / Alexa"
+    ],
+    "ip_rating": "IP67",
+    "operating_temp_c": "-20 to 55",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-bw500/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-204760/",
+      "https://www.mi.com/global/support/faq/details/KA-226557/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c100",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C100",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "color"
+    },
+    "power": {
+      "method": "5V DC 1A via USB Type-C (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "compact fixed indoor camera",
+      "3MP full colour in low light",
+      "manual slide-cover physical lens shielding",
+      "AI baby cry detection, human detection, virtual fence",
+      "3A audio algorithm (AEC/ANS/AGC)",
+      "Wi-Fi 6 (2.4GHz) with Bluetooth 5.2",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "69 x 68 x 115",
+    "weight_g": 170,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c100/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c100/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-573427/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c200",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C200",
+    "aliases": [
+      "MJSXJ14CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "Supports NAS transfer via inserted microSD card (SD card acts as relay to NAS storage)."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "1080p entry pan-tilt indoor",
+      "AI human detection and tracking",
+      "infrared night vision (9m)",
+      "two-way voice calls via Xiaomi Home app",
+      "NAS transfer support",
+      "continues local recording during network outage",
+      "Xiaomi security chip"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.046c04, protocol cs2, H.265 video + Opus audio).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c200/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c200/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-86464/",
+      "https://www.mi.com/global/support/faq/details/KA-235580/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.046c04 (protocol cs2; H.265 video + Opus audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c201",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C201",
+    "aliases": [
+      "MBC27"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A (power adapter not included; user-supplied)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "features": [
+      "dual-axis pan-tilt gimbal",
+      "six built-in no-glow infrared illuminators",
+      "local AI human detection with motion tracking",
+      "pet detection and tracking (cats/dogs)",
+      "MJA1 security chipset with AES-128 cloud encryption",
+      "Wi-Fi 6 (2.4GHz)",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c201/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c201/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-600067/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c300",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C300",
+    "aliases": [
+      "XMC01"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 108 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "2K with F1.4 large aperture 6P lens",
+      "full colour in low light",
+      "940nm no-glow infrared LEDs",
+      "AI human detection",
+      "dual-motor pan-tilt",
+      "BSI Kitemark certified (residential IoT)"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "115 x 78 x 78",
+    "weight_g": 327,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-130637/",
+      "https://www.mi.com/global/support/faq/details/KA-231317/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c300-dual",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C300 Dual",
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "6 (telephoto PTZ lens)",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB."
+    },
+    "features": [
+      "true dual camera: fixed wide + 6mm telephoto PTZ",
+      "PTZ auto-rotates to track humans detected by the fixed camera",
+      "press-and-hold on fixed footage rotates PTZ for close-ups",
+      "AI detection on both cameras",
+      "virtual fence",
+      "pet detection and tracking (cats/dogs)",
+      "baby cry detection",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Xiaomi HyperOS Connect"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 78 x 126",
+    "weight_g": 384,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c300-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c301",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C301",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "3MP 2K with large-aperture 4P lens",
+      "dual-gimbal pan-tilt",
+      "full colour night vision",
+      "local AI human detection with alerts",
+      "large-diameter speaker for remote calls",
+      "MJA1-class security chip with AES-128 cloud encryption",
+      "flat and inverted mounting",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c301/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c301/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c302",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C302",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 1A via USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "local AI: human detection and tracking",
+      "pet detection (cats/dogs)",
+      "baby cry and abnormal sound detection (e.g. glass breaking)",
+      "virtual fence and custom detection zones",
+      "physical lens shield (privacy masking)",
+      "MJA1 security chipset with AES-128 cloud encryption",
+      "Wi-Fi 6 (2.4GHz) with Bluetooth 5.0",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 76 x 115",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c302/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c302/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-616066/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c400",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C400",
+    "aliases": [
+      "MJSXJ23CM",
+      "MJSXJ11CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "2.5K with large-aperture 6P lens",
+      "940nm no-glow infrared night vision",
+      "AI human detection",
+      "dual-motor pan-tilt",
+      "2.4GHz/5GHz dual-band Wi-Fi",
+      "Mi Home security chip"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "119 x 78 x 78",
+    "weight_g": 318,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Model number updated from MJSXJ11CM to MJSXJ23CM with no functional changes (per official spec page).",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c400/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c400/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-12475/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "3.5K UHD",
+      "max_width": 3200,
+      "max_height": 1800,
+      "megapixels": 6
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "sensor": "1/2.45\" BSI CMOS",
+    "lens": {
+      "count": 1,
+      "aperture": "f/1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 116 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB, cloud storage, or NAS network-attached storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Xiaomi's first 6MP indoor camera (3.5K)",
+      "6P optical lens with WDR",
+      "8x 940nm no-glow infrared fill lights",
+      "ultra-low-light full colour imaging",
+      "1 TOPS AI chip with local human and pet detection/tracking",
+      "physical lens shield (privacy masking)",
+      "dual-band Wi-Fi 6",
+      "Alexa / Google Assistant",
+      "Xiaomi HyperOS Connect"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "79 x 79 x 119",
+    "release_year": 2025,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500-dual",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500 Dual",
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p) per camera",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "6 (telephoto PTZ lens)",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "58 H (telephoto camera)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB, cloud storage, or NAS networked storage."
+    },
+    "features": [
+      "true dual camera: fixed 4MP + 6mm telephoto PTZ (both 4MP F1.6)",
+      "sixteen 940nm infrared illuminators across both cameras",
+      "PTZ rotates to close-ups via press-and-hold on fixed footage",
+      "pet detection and tracking (cats/dogs)",
+      "baby cry detection",
+      "virtual fence on fixed camera",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Xiaomi HyperOS Connect"
+    ],
+    "dimensions_mm": "78 x 77 x 128",
+    "weight_g": 305,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c500-pro",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C500 Pro",
+    "aliases": [
+      "MJSXJ16CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "3K",
+      "max_width": 2960,
+      "max_height": 1666,
+      "megapixels": 5
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB, cloud storage (AES-128 encrypted), or NAS backup from microSD."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "5MP 3K with HDR mode",
+      "ultra-low light colour mode plus IR illuminator",
+      "local human detection and tracking",
+      "local pet detection",
+      "loud noise and crying baby detection",
+      "physical lens shield (privacy masking)",
+      "MJA1 security chip",
+      "dual-band Wi-Fi with Bluetooth 5.2",
+      "high-power speaker for two-way calls",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 45",
+    "dimensions_mm": "78 x 78 x 124",
+    "weight_g": 301,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c500-pro/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-78565/",
+      "https://www.mi.com/global/support/faq/details/KA-78747/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c700",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C700",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 10
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A via USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP 4K with HDR mode",
+      "ten 940nm no-glow infrared illuminators (10m)",
+      "full colour night vision in low light",
+      "physical lens shield with customisable timing",
+      "human tracking, pet, baby cry detection",
+      "stream quality selectable: 4K / 1080p / 480p",
+      "dual-band Wi-Fi 6 with Bluetooth 5.3",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "82 x 82 x 130",
+    "weight_g": 362,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.81ac1, protocol cs2+udp, H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c700/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c700/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-501385/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.81ac1 (protocol cs2+udp; H.265 video + Opus audio). Full 4K (3840x2160) requires quality subtype=3. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c701",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C701",
+    "aliases": [
+      "MJSXJ27CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A power adapter (2m cable)",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB (Class 10+, FAT32), NAS network-attached storage, or cloud."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "8MP 4K with HDR",
+      "940nm no-glow infrared fill light",
+      "physical lens cover (privacy protection)",
+      "local AI: loud sound, baby cry and pet detection; human motion tracking",
+      "large-diameter box speaker with independent sound cavity",
+      "stream quality: 4K / 480p",
+      "dual-band Wi-Fi 6 with Bluetooth 5.4",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "79 x 79 x 119",
+    "release_year": 2025,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.079ae2, protocol cs2+udp, H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Unlike the C700 (4K/1080p/480p), the C701 only offers 4K and 480p stream quality options.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-608921/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.079ae2 (protocol cs2+udp; H.265 video + Opus audio). Two-way audio confirmed working; near-realtime via WebRTC. Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-c701-pro",
+    "brand": "Xiaomi",
+    "model": "Smart Camera C701 Pro",
+    "aliases": [
+      "MJSXJ31CM"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "4K UHD",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "2.8 (8MP ultra-wide, 5P) / 8 (5MP telephoto, 6P)",
+      "aperture": "f/1.6 (both lenses)",
+      "varifocal": false
+    },
+    "field_of_view_deg": "127 (ultra-wide lens); pan 360 (horizontal), tilt 180 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "5V DC 2A via concealed USB Type-C",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB (FAT32, Class 10+), NAS backup via microSD, or cloud."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual camera: 8MP ultra-wide + 5MP ultra-telephoto, 9x hybrid zoom",
+      "automatic lens zoom with adaptive-speed subject tracking (30% faster motor vs C700)",
+      "180-degree vertical pan-tilt (ceiling mount without blind spots)",
+      "10x 940nm no-glow infrared LEDs",
+      "ultra-low-light full-colour technology",
+      "gesture recognition: 'OK' gesture starts a voice call",
+      "AI: human, pet, motion, abnormal sound, crying baby detection, virtual fence",
+      "1 TOPS AI chip, MJA1 security chipset",
+      "physical lens shielding (app or manual)",
+      "dual-band Wi-Fi 6 with Bluetooth 5.4",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "78 x 72 x 127",
+    "release_year": 2026,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. Requires Xiaomi Home app 10.8+. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/",
+      "https://www.mi.com/global/product/xiaomi-smart-camera-c701-pro/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw300",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW300",
+    "type": "ptz",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 8-256GB or cloud storage."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-motor pan-tilt gimbal",
+      "2x 850nm IR lights + 2x white lights for full-colour night vision",
+      "local AI human detection (no cloud needed)",
+      "audible alarm with high-frequency flashing lights",
+      "AI noise-cancelling microphone and high-power speaker",
+      "built-in Ethernet port (waterproof kit included)",
+      "Alexa / Google Assistant"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "168 x 100 x 123",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw300/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw400",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW400",
+    "aliases": [
+      "MJSXJ04HL"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p)",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "113 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-gimbal pan-tilt",
+      "four-light smart full-colour night vision (IR + white fill lights)",
+      "AI human detection with alarm recording",
+      "audible alarm with flashing lights",
+      "dual-antenna Wi-Fi",
+      "time-lapse photography",
+      "voice call support (firmware 5.1.5_0228+)"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. No Bluetooth gateway function.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw400/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-44187/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-cw500-dual",
+    "brand": "Xiaomi",
+    "model": "Outdoor Camera CW500 Dual",
+    "aliases": [
+      "MJSXJ08HL"
+    ],
+    "type": "dual-lens",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "resolution": {
+      "label": "2.5K (1440p) per camera",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "aperture": "F/1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "ptz": {
+      "autotracking": true
+    },
+    "power": {
+      "method": "12V DC 1A power adapter",
+      "voltage": "12V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 256,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD 16-256GB, NAS network-attached storage, or Xiaomi Cloud (dual-path)."
+    },
+    "features": [
+      "dual 4MP cameras: fixed wide + controllable PTZ",
+      "linked tracking: PTZ auto-tracks humans detected by the fixed camera",
+      "AI human and vehicle detection on both cameras",
+      "2x white lights + 2x IR lights per camera for full-colour night vision",
+      "audible alarm with high-frequency flashing lights",
+      "dual-band Wi-Fi 6 plus Ethernet port (waterproof kit included)",
+      "security chip"
+    ],
+    "ip_rating": "IP66",
+    "operating_temp_c": "-30 to 60",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. go2rtc's maintainer indicates cameras released after 2020 (unified 'miss' protocol, cs2) generally work; this specific model is not yet in the community-verified list (AlexxIT/go2rtc#1982) - test and report. go2rtc supports the second lens of dual cameras via channel=2.",
+    "sources": [
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/",
+      "https://www.mi.com/global/product/xiaomi-outdoor-camera-cw500-dual/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-2k",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Home Security Camera 2K",
+    "aliases": [
+      "MJSXJ09CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "940nm no-glow infrared night vision",
+      "full colour in low light",
+      "AI human detection with false-alarm filtering",
+      "dual-axis pan-tilt (360 horizontal, 108 vertical)",
+      "Mi Smart Clock video output",
+      "BSI Kitemark certified (residential IoT)",
+      "Alexa / Google Assistant"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "115 x 78 x 78",
+    "weight_g": 310,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.029a02, protocol cs2+udp, H.265 video + PCMA audio). Note the low 32GB microSD cap versus 256GB on the newer C-series.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k/",
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k/specs/",
+      "https://www.mi.com/global/support/faq/details/KA-06539/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.029a02 (protocol cs2+udp; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-2k-pro",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Home Security Camera 2K Pro",
+    "aliases": [
+      "MJSXJ06CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F1.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A power adapter",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "F1.4 aperture with 6P lens",
+      "940nm no-glow infrared night vision, full colour in low light",
+      "physical lens shield",
+      "dual-microphone noise reduction",
+      "dual-band Wi-Fi (2.4/5GHz) with Bluetooth 4.2 gateway",
+      "AI human detection"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "122 x 78 x 78",
+    "weight_g": 349,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model chuangmi.camera.021a04, protocol cs2, H.265 video). Manufactured by Shanghai Imilab Technology (Mi Ecosystem). 32GB microSD cap. Global spec page lists lens angle 110; the India regional page lists 118.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/",
+      "https://www.mi.com/global/product/mi-360-home-security-camera-2k-pro/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=chuangmi.camera.021a04 (protocol cs2; H.265 video). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-360-camera-1080p",
+    "brand": "Xiaomi",
+    "model": "Mi 360° Camera (1080p)",
+    "aliases": [
+      "MJSXJ10CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (angle of view)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 2A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 32,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "features": [
+      "compact 360-degree pan-tilt",
+      "F2.1 aperture",
+      "1080p entry-level indoor monitoring"
+    ],
+    "operating_temp_c": "-10 to 40",
+    "dimensions_mm": "108 x 75 x 75",
+    "weight_g": 254,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Revised compact successor to the MJSXJ05CM 360 1080P.  32GB microSD cap.",
+    "sources": [
+      "https://www.mi.com/global/product/mi-360-camera-1080p/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-camera-2k-magnetic-mount",
+    "brand": "Xiaomi",
+    "model": "Mi Camera 2K (Magnetic Mount)",
+    "aliases": [
+      "MJSXJ03HL"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "2K (1296p)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "field_of_view_deg": "125 (lens angle)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "power": {
+      "method": "5V DC 1A",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": true,
+      "nvr_compatible": false,
+      "notes": "microSD card (no maximum capacity stated on official spec page)."
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true
+    },
+    "features": [
+      "ultra-compact (60 x 48 x 67.5mm) with detachable adjustable magnetic base",
+      "125-degree wide-angle fixed lens",
+      "metal pad included for flexible magnetic placement"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "60 x 48 x 67.5",
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. Community-verified working (miot model isa.camera.hlc7, protocol cs2, H.265 video + PCMA audio). Manufactured by Tianjin Hualai Technology (Mi Ecosystem, same manufacturer as Wyze cameras).",
+    "sources": [
+      "https://www.mi.com/global/product/mi-camera-2k-magnetic-mount/specs/",
+      "https://www.mi.com/uk/product/mi-camera-2k-magnetic-mount/specs/"
+    ],
+    "status": "available",
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "recommended_stream_type": "go2rtc",
+        "verified": true,
+        "tested_by": "go2rtc community (AlexxIT/go2rtc#1982)",
+        "notes": "No native RTSP. Use go2rtc v1.9.13+ xiaomi:// source: add Xiaomi account in go2rtc WebUI, then stream URL xiaomi://{account}:{region}@{camera_ip}?did={device_id}&model=isa.camera.hlc7 (protocol cs2; H.265 video + PCMA audio). Camera and go2rtc must be on the same subnet; internet required at connect time for key exchange. Quality: subtype=hd/sd/auto/0-5. Point Frigate at the go2rtc restream."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "xiaomi-mi-home-360-1080p",
+    "brand": "Xiaomi",
+    "model": "Mi Home Security Camera 360° 1080P",
+    "aliases": [
+      "MJSXJ05CM"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "codecs": [
+        "H.265"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "aperture": "F2.1",
+      "varifocal": false
+    },
+    "field_of_view_deg": "110 (lens angle); pan 360 (horizontal), tilt 96 (vertical)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "power": {
+      "method": "5V DC 2A via Micro USB",
+      "voltage": "5V"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 64,
+      "cloud": true,
+      "nvr_compatible": false
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual-motor 360/96 pan-tilt with silent shockproof design",
+      "low-light true colour technology",
+      "8-bulb 940nm infrared illuminator",
+      "motion detection with talkback",
+      "inverted installation support",
+      "Alexa support"
+    ],
+    "operating_temp_c": "-10 to 50",
+    "dimensions_mm": "118 x 78 x 78",
+    "weight_g": 310,
+    "release_notes": "No official RTSP or ONVIF support (streaming is normally via the Xiaomi Home app only). Supported by go2rtc v1.9.13+ via the xiaomi:// source using Xiaomi's 'miss' (Mi Secure Streaming) protocol: streaming is local (same subnet), but internet access is required at each connection to obtain encryption keys. Frigate can consume the go2rtc restream. As a pre-2020/legacy-format model it may fall under go2rtc's xiaomi/legacy or tutk support, which is less reliable; not in the community-verified list (AlexxIT/go2rtc#1982). Legacy model (Micro USB, 64GB microSD cap); superseded by the Mi 360 2K series and C-series. Manufactured by Shanghai Imilab Technology (Mi Ecosystem).",
+    "sources": [
+      "https://www.mi.com/global/camera-360",
+      "https://i01.appmifile.com/webfile/globalimg/Global_UG/Mi_Ecosystem/Mi_Home_Security_Camera_360_1080P/en_V2.pdf"
+    ],
+    "last_verified": "2026-07-20",
+    "added": "2026-07-20"
+  },
+  {
     "id": "yale-sv-abfx-w",
     "brand": "Yale",
     "model": "SV-ABFX-W",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Adds **Xiaomi / Mi** as a new brand (**+26 cameras**, 2,257 → 2,283; 71 → 72 brands): Smart Camera C-series (C100–C701 Pro), Outdoor BW/CW-series, Mi 360 pan-tilt, and dual-lens models.

## RTSP honesty (important for this brand)
All 26 are **Wi-Fi, Mi Home app-only with no native RTSP/ONVIF**. They're recorded honestly:
- **No fabricated** `protocols` (`rtsp`/`onvif`) or `rtsp_url_template` on any entry.
- The 7 models with a documented Frigate path use a **`configs.frigate.notes`** describing the real **go2rtc `xiaomi://` cloud source** (with the correct per-camera MIoT model ID, e.g. `chuangmi.camera.046c04`, protocol, codecs, and same-subnet / key-exchange caveats) — not a fake RTSP URL. This won't trigger the "Frigate Config" SEO title (which requires an `rtsp_url_template`), but does document the genuine path.

## QA
- AJV clean; sources + `last_verified` on all; ids match filenames; resolution physics pass.
- Specs/sources from official mi.com product / spec / FAQ pages.

