### PR TITLE
Add Axis M2036-LE (4MP bullet) — contributed via #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.39.1] — 2026-07-20
+
+**Added** the Axis **M2036-LE** (4MP bullet, PoE, OptimizedIR 20m, IP66/IP67/IK08, ONVIF/RTSP with Frigate config) — contributed via #130 by @aweaton123. 2,283 -> 2,284 cameras.
+
 ## [1.39.0] — 2026-07-20
 
 **New brand: Xiaomi (+26).** Added Xiaomi / Mi cameras: Smart Camera C-series (C100-C701 Pro), Outdoor BW/CW-series, Mi 360 pan-tilt, and dual-lens models. Net: **2,257 -> 2,283 cameras** (71 -> 72 brands).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCTV Camera Database
 
-An open, structured database of 2,283 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,284 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
 [![cameras](https://img.shields.io/badge/cameras-1%2C896-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-71-green)](cameras/)
@@ -31,7 +31,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,283 cameras, 25 per page
+- **Pagination** — page through all 2,284 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -63,7 +63,7 @@ cctv-camera-database/
 │   ├── tapo/             #  62 cameras
 │   └── …60 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,283 cameras as one array
+│   ├── cameras.json      # all 2,284 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -121,7 +121,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,283** |
+| Total cameras | **2,284** |
 | Brands | **71** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,279 |

--- a/cameras/axis/m2036-le.json
+++ b/cameras/axis/m2036-le.json
@@ -2,74 +2,87 @@
   "id": "axis-m2036-le",
   "brand": "Axis",
   "model": "M2036-LE",
+  "aliases": ["02125-001", "02134-001 (Black)"],
   "type": "bullet",
-  "connectivity": [
-    "ethernet"
-  ],
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
   "resolution": {
     "megapixels": 4,
-    "max_width": 2304,
-    "max_height": 1728,
-    "label": "4MP"
+    "max_width": 2688,
+    "max_height": 1512,
+    "label": "4MP / Quad HD 1440p"
   },
-  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "video": {
+    "codecs": ["H.265", "H.264", "MJPEG"],
+    "max_fps": 30
+  },
+  "sensor": "1/2.7\" progressive scan RGB CMOS",
+  "soc": "Ambarella CV25",
   "lens": {
     "count": 1,
     "focal_length_mm": "2.4",
+    "aperture": "F2.1",
     "varifocal": false
   },
-  "field_of_view_deg": "130",
+  "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
   "night_vision": {
     "type": "ir",
     "range_m": 20
   },
   "power": {
-    "method": "PoE (802.3af, Class 3)"
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3,
+    "consumption_w": 12.95
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 1024,
     "nvr_compatible": true,
-    "cloud": false
+    "cloud": false,
+    "notes": "microSD/microSDHC/microSDXC slot with AES-XTS-Plain64 256-bit SD encryption; recording to NAS supported."
   },
-  "protocols": [
-    "onvif",
-    "rtsp"
-  ],
-  "ip_rating": "IP66/IP67, IK08",
-  "operating_temp_c": "-30 to 50",
+  "protocols": ["onvif", "rtsp", "http"],
   "audio": {
     "microphone": false,
     "speaker": false,
     "two_way": false
   },
+  "ip_rating": "IP66/IP67",
   "features": [
-    "OptimizedIR up to 20m",
-    "Lightfinder low-light",
-    "AXIS Object Analytics",
-    "Zipstream (H.264/H.265)",
-    "NEMA 4X, IK08 vandal-resistant",
-    "AXIS Edge Vault (signed firmware, secure boot)"
+    "deep learning processing unit (Ambarella CV25 SoC)",
+    "AXIS Object Analytics: human/vehicle detection and classification (cars, buses, trucks, bikes)",
+    "AXIS Scene Metadata, Live Privacy Shield, Video Motion Detection included",
+    "Lightfinder (0.18 lux colour) and Forensic WDR up to 115 dB",
+    "OptimizedIR 855nm long-life LEDs (20m+)",
+    "Zipstream for H.264/H.265",
+    "ONVIF Profiles G, M, S and T",
+    "Axis Edge Vault: signed OS, secure boot, CC EAL6+ secure element, signed video",
+    "NEMA 4X and IK08 rated, integrated sunshield",
+    "edge-to-edge pairing with Axis network speakers",
+    "sealed back box for cable management",
+    "5-year warranty"
   ],
+  "operating_temp_c": "-30 to 50",
+  "dimensions_mm": "170 length x 101 diameter",
+  "weight_g": 491,
+  "markets": ["global"],
+  "release_notes": "No built-in microphone or speaker; two-way audio connectivity is available only via portcast technology with an AXIS T61-series audio interface accessory. Resolution modes: 2688x1512 (16:9) or 2304x1728 (4:3).",
   "sources": [
-    "https://www.axis.com/products/axis-m2036-le"
+    "https://www.axis.com/products/axis-m2036-le",
+    "https://www.axis.com/dam/public/ee/d3/cd/datasheet-axis-m2036-le-bullet-camera-en-US-519726.pdf"
   ],
-  "markets": [
-    "global"
-  ],
+  "status": "available",
   "last_verified": "2026-07-20",
-  "power_source": [
-    "poe"
-  ],
   "configs": {
     "frigate": {
       "detect": {
-        "width": 1280,
-        "height": 720,
+        "width": 640,
+        "height": 360,
         "fps": 5
       },
-      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
-      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2688x1512",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+      "notes": "Standard Axis VAPIX RTSP path. ONVIF Profile S/T for discovery and streams."
     },
     "home_assistant": {
       "integration": "axis",

--- a/cameras/axis/m2036-le.json
+++ b/cameras/axis/m2036-le.json
@@ -1,0 +1,83 @@
+{
+  "id": "axis-m2036-le",
+  "brand": "Axis",
+  "model": "M2036-LE",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 4,
+    "max_width": 2304,
+    "max_height": 1728,
+    "label": "4MP"
+  },
+  "sensor": "1/2.7\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.4",
+    "varifocal": false
+  },
+  "field_of_view_deg": "130",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE (802.3af, Class 3)"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 1024,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66/IP67, IK08",
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "OptimizedIR up to 20m",
+    "Lightfinder low-light",
+    "AXIS Object Analytics",
+    "Zipstream (H.264/H.265)",
+    "NEMA 4X, IK08 vandal-resistant",
+    "AXIS Edge Vault (signed firmware, secure boot)"
+  ],
+  "sources": [
+    "https://www.axis.com/products/axis-m2036-le"
+  ],
+  "markets": [
+    "global"
+  ],
+  "last_verified": "2026-07-20",
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/m2036-le.md
+++ b/cameras/axis/m2036-le.md
@@ -1,35 +1,44 @@
 # Axis M2036-LE
 
+*Also known as: 02125-001, 02134-001 (Black)*
+
 | Field | Spec |
 |-------|------|
 | Brand | Axis |
 | Model | M2036-LE |
 | Type | bullet |
 | Connectivity | ethernet |
-| Resolution | 4MP (4MP, 2304×1728) |
-| Sensor | 1/2.7" Progressive Scan CMOS |
-| Lens | 1× 2.4mm |
-| Field of view | 130° |
+| Resolution | 4MP / Quad HD 1440p (4MP, 2688×1512) |
+| Sensor | 1/2.7" progressive scan RGB CMOS |
+| Lens | 1× 2.4mm F2.1 |
+| Field of view | 130 H / 71 V (16:9); 109 H / 81 V (4:3)° |
 | Night vision | ir (20m) |
-| Power | PoE (802.3af, Class 3) |
-| Storage | microSD ≤ 1024GB, NVR |
-| Protocols | onvif, rtsp |
-| IP rating | IP66/IP67, IK08 |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67 |
 | Two-way audio | No |
 | Operating temp | -30 to 50°C |
 
 ## Features
 
-- OptimizedIR up to 20m
-- Lightfinder low-light
-- AXIS Object Analytics
-- Zipstream (H.264/H.265)
-- NEMA 4X, IK08 vandal-resistant
-- AXIS Edge Vault (signed firmware, secure boot)
+- deep learning processing unit (Ambarella CV25 SoC)
+- AXIS Object Analytics: human/vehicle detection and classification (cars, buses, trucks, bikes)
+- AXIS Scene Metadata, Live Privacy Shield, Video Motion Detection included
+- Lightfinder (0.18 lux colour) and Forensic WDR up to 115 dB
+- OptimizedIR 855nm long-life LEDs (20m+)
+- Zipstream for H.264/H.265
+- ONVIF Profiles G, M, S and T
+- Axis Edge Vault: signed OS, secure boot, CC EAL6+ secure element, signed video
+- NEMA 4X and IK08 rated, integrated sunshield
+- edge-to-edge pairing with Axis network speakers
+- sealed back box for cable management
+- 5-year warranty
 
 ## Sources
 
 - https://www.axis.com/products/axis-m2036-le
+- https://www.axis.com/dam/public/ee/d3/cd/datasheet-axis-m2036-le-bullet-camera-en-US-519726.pdf
 
 ---
 *Auto-generated from axis-m2036-le.json — do not edit by hand.*

--- a/cameras/axis/m2036-le.md
+++ b/cameras/axis/m2036-le.md
@@ -1,0 +1,35 @@
+# Axis M2036-LE
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | M2036-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2304×1728) |
+| Sensor | 1/2.7" Progressive Scan CMOS |
+| Lens | 1× 2.4mm |
+| Field of view | 130° |
+| Night vision | ir (20m) |
+| Power | PoE (802.3af, Class 3) |
+| Storage | microSD ≤ 1024GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67, IK08 |
+| Two-way audio | No |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- OptimizedIR up to 20m
+- Lightfinder low-light
+- AXIS Object Analytics
+- Zipstream (H.264/H.265)
+- NEMA 4X, IK08 vandal-resistant
+- AXIS Edge Vault (signed firmware, secure boot)
+
+## Sources
+
+- https://www.axis.com/products/axis-m2036-le
+
+---
+*Auto-generated from axis-m2036-le.json — do not edit by hand.*

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -462,6 +462,7 @@ axis-f4105-re,Axis,F4105-RE,dome,1080p HD,2,,110 horizontal,ir,IP66,false,2019
 axis-fa54,Axis,FA54 Main Unit,dome,1080p,2,,113 horizontal (2.8mm),,,true,
 axis-m2025-le,Axis,M2025-LE,bullet,1080p,2,"1/2.9"" CMOS",115,ir,IP66,false,
 axis-m2035-le,Axis,M2035-LE,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",101,ir,IP66,false,
+axis-m2036-le,Axis,M2036-LE,bullet,4MP,4,"1/2.7"" Progressive Scan CMOS",130,ir,"IP66/IP67, IK08",false,
 axis-m3048-p,Axis,M3048-P,fisheye,12MP,12,,360,none,IP42,false,2017
 axis-m3064-v,Axis,M3064-V,dome,HDTV 720p,1,"1/2.9"" CMOS",83,none,IP42,false,2015
 axis-m3077-plve,Axis,M3077-PLVE,panoramic,6MP,6,"1/1.8"" Progressive Scan CMOS",360 horizontal,ir,IP66,false,2022

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -462,7 +462,7 @@ axis-f4105-re,Axis,F4105-RE,dome,1080p HD,2,,110 horizontal,ir,IP66,false,2019
 axis-fa54,Axis,FA54 Main Unit,dome,1080p,2,,113 horizontal (2.8mm),,,true,
 axis-m2025-le,Axis,M2025-LE,bullet,1080p,2,"1/2.9"" CMOS",115,ir,IP66,false,
 axis-m2035-le,Axis,M2035-LE,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",101,ir,IP66,false,
-axis-m2036-le,Axis,M2036-LE,bullet,4MP,4,"1/2.7"" Progressive Scan CMOS",130,ir,"IP66/IP67, IK08",false,
+axis-m2036-le,Axis,M2036-LE,bullet,4MP / Quad HD 1440p,4,"1/2.7"" progressive scan RGB CMOS",130 H / 71 V (16:9); 109 H / 81 V (4:3),ir,IP66/IP67,false,
 axis-m3048-p,Axis,M3048-P,fisheye,12MP,12,,360,none,IP42,false,2017
 axis-m3064-v,Axis,M3064-V,dome,HDTV 720p,1,"1/2.9"" CMOS",83,none,IP42,false,2015
 axis-m3077-plve,Axis,M3077-PLVE,panoramic,6MP,6,"1/1.8"" Progressive Scan CMOS",360 horizontal,ir,IP66,false,2022

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -41295,74 +41295,107 @@
     "id": "axis-m2036-le",
     "brand": "Axis",
     "model": "M2036-LE",
+    "aliases": [
+      "02125-001",
+      "02134-001 (Black)"
+    ],
     "type": "bullet",
     "connectivity": [
       "ethernet"
     ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
     "resolution": {
       "megapixels": 4,
-      "max_width": 2304,
-      "max_height": 1728,
-      "label": "4MP"
+      "max_width": 2688,
+      "max_height": 1512,
+      "label": "4MP / Quad HD 1440p"
     },
-    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "sensor": "1/2.7\" progressive scan RGB CMOS",
+    "soc": "Ambarella CV25",
     "lens": {
       "count": 1,
       "focal_length_mm": "2.4",
+      "aperture": "F2.1",
       "varifocal": false
     },
-    "field_of_view_deg": "130",
+    "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
     "night_vision": {
       "type": "ir",
       "range_m": 20
     },
     "power": {
-      "method": "PoE (802.3af, Class 3)"
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 12.95
     },
     "storage": {
       "onboard": true,
-      "max_microsd_gb": 1024,
       "nvr_compatible": true,
-      "cloud": false
+      "cloud": false,
+      "notes": "microSD/microSDHC/microSDXC slot with AES-XTS-Plain64 256-bit SD encryption; recording to NAS supported."
     },
     "protocols": [
       "onvif",
-      "rtsp"
+      "rtsp",
+      "http"
     ],
-    "ip_rating": "IP66/IP67, IK08",
-    "operating_temp_c": "-30 to 50",
     "audio": {
       "microphone": false,
       "speaker": false,
       "two_way": false
     },
+    "ip_rating": "IP66/IP67",
     "features": [
-      "OptimizedIR up to 20m",
-      "Lightfinder low-light",
-      "AXIS Object Analytics",
-      "Zipstream (H.264/H.265)",
-      "NEMA 4X, IK08 vandal-resistant",
-      "AXIS Edge Vault (signed firmware, secure boot)"
+      "deep learning processing unit (Ambarella CV25 SoC)",
+      "AXIS Object Analytics: human/vehicle detection and classification (cars, buses, trucks, bikes)",
+      "AXIS Scene Metadata, Live Privacy Shield, Video Motion Detection included",
+      "Lightfinder (0.18 lux colour) and Forensic WDR up to 115 dB",
+      "OptimizedIR 855nm long-life LEDs (20m+)",
+      "Zipstream for H.264/H.265",
+      "ONVIF Profiles G, M, S and T",
+      "Axis Edge Vault: signed OS, secure boot, CC EAL6+ secure element, signed video",
+      "NEMA 4X and IK08 rated, integrated sunshield",
+      "edge-to-edge pairing with Axis network speakers",
+      "sealed back box for cable management",
+      "5-year warranty"
     ],
-    "sources": [
-      "https://www.axis.com/products/axis-m2036-le"
-    ],
+    "operating_temp_c": "-30 to 50",
+    "dimensions_mm": "170 length x 101 diameter",
+    "weight_g": 491,
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-20",
-    "power_source": [
-      "poe"
+    "release_notes": "No built-in microphone or speaker; two-way audio connectivity is available only via portcast technology with an AXIS T61-series audio interface accessory. Resolution modes: 2688x1512 (16:9) or 2304x1728 (4:3).",
+    "sources": [
+      "https://www.axis.com/products/axis-m2036-le",
+      "https://www.axis.com/dam/public/ee/d3/cd/datasheet-axis-m2036-le-bullet-camera-en-US-519726.pdf"
     ],
+    "status": "available",
+    "last_verified": "2026-07-20",
     "configs": {
       "frigate": {
         "detect": {
-          "width": 1280,
-          "height": 720,
+          "width": 640,
+          "height": 360,
           "fps": 5
         },
-        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
-        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2688x1512",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+        "notes": "Standard Axis VAPIX RTSP path. ONVIF Profile S/T for discovery and streams."
       },
       "home_assistant": {
         "integration": "axis",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -41292,6 +41292,90 @@
     "added": "2026-06-06"
   },
   {
+    "id": "axis-m2036-le",
+    "brand": "Axis",
+    "model": "M2036-LE",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2304,
+      "max_height": 1728,
+      "label": "4MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "130",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66/IP67, IK08",
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "OptimizedIR up to 20m",
+      "Lightfinder low-light",
+      "AXIS Object Analytics",
+      "Zipstream (H.264/H.265)",
+      "NEMA 4X, IK08 vandal-resistant",
+      "AXIS Edge Vault (signed firmware, secure boot)"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-m2036-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "axis-m3048-p",
     "brand": "Axis",
     "model": "M3048-P",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -41295,74 +41295,107 @@
     "id": "axis-m2036-le",
     "brand": "Axis",
     "model": "M2036-LE",
+    "aliases": [
+      "02125-001",
+      "02134-001 (Black)"
+    ],
     "type": "bullet",
     "connectivity": [
       "ethernet"
     ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
     "resolution": {
       "megapixels": 4,
-      "max_width": 2304,
-      "max_height": 1728,
-      "label": "4MP"
+      "max_width": 2688,
+      "max_height": 1512,
+      "label": "4MP / Quad HD 1440p"
     },
-    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "sensor": "1/2.7\" progressive scan RGB CMOS",
+    "soc": "Ambarella CV25",
     "lens": {
       "count": 1,
       "focal_length_mm": "2.4",
+      "aperture": "F2.1",
       "varifocal": false
     },
-    "field_of_view_deg": "130",
+    "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
     "night_vision": {
       "type": "ir",
       "range_m": 20
     },
     "power": {
-      "method": "PoE (802.3af, Class 3)"
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 12.95
     },
     "storage": {
       "onboard": true,
-      "max_microsd_gb": 1024,
       "nvr_compatible": true,
-      "cloud": false
+      "cloud": false,
+      "notes": "microSD/microSDHC/microSDXC slot with AES-XTS-Plain64 256-bit SD encryption; recording to NAS supported."
     },
     "protocols": [
       "onvif",
-      "rtsp"
+      "rtsp",
+      "http"
     ],
-    "ip_rating": "IP66/IP67, IK08",
-    "operating_temp_c": "-30 to 50",
     "audio": {
       "microphone": false,
       "speaker": false,
       "two_way": false
     },
+    "ip_rating": "IP66/IP67",
     "features": [
-      "OptimizedIR up to 20m",
-      "Lightfinder low-light",
-      "AXIS Object Analytics",
-      "Zipstream (H.264/H.265)",
-      "NEMA 4X, IK08 vandal-resistant",
-      "AXIS Edge Vault (signed firmware, secure boot)"
+      "deep learning processing unit (Ambarella CV25 SoC)",
+      "AXIS Object Analytics: human/vehicle detection and classification (cars, buses, trucks, bikes)",
+      "AXIS Scene Metadata, Live Privacy Shield, Video Motion Detection included",
+      "Lightfinder (0.18 lux colour) and Forensic WDR up to 115 dB",
+      "OptimizedIR 855nm long-life LEDs (20m+)",
+      "Zipstream for H.264/H.265",
+      "ONVIF Profiles G, M, S and T",
+      "Axis Edge Vault: signed OS, secure boot, CC EAL6+ secure element, signed video",
+      "NEMA 4X and IK08 rated, integrated sunshield",
+      "edge-to-edge pairing with Axis network speakers",
+      "sealed back box for cable management",
+      "5-year warranty"
     ],
-    "sources": [
-      "https://www.axis.com/products/axis-m2036-le"
-    ],
+    "operating_temp_c": "-30 to 50",
+    "dimensions_mm": "170 length x 101 diameter",
+    "weight_g": 491,
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-20",
-    "power_source": [
-      "poe"
+    "release_notes": "No built-in microphone or speaker; two-way audio connectivity is available only via portcast technology with an AXIS T61-series audio interface accessory. Resolution modes: 2688x1512 (16:9) or 2304x1728 (4:3).",
+    "sources": [
+      "https://www.axis.com/products/axis-m2036-le",
+      "https://www.axis.com/dam/public/ee/d3/cd/datasheet-axis-m2036-le-bullet-camera-en-US-519726.pdf"
     ],
+    "status": "available",
+    "last_verified": "2026-07-20",
     "configs": {
       "frigate": {
         "detect": {
-          "width": 1280,
-          "height": 720,
+          "width": 640,
+          "height": 360,
           "fps": 5
         },
-        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
-        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2688x1512",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+        "notes": "Standard Axis VAPIX RTSP path. ONVIF Profile S/T for discovery and streams."
       },
       "home_assistant": {
         "integration": "axis",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -41292,6 +41292,90 @@
     "added": "2026-06-06"
   },
   {
+    "id": "axis-m2036-le",
+    "brand": "Axis",
+    "model": "M2036-LE",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2304,
+      "max_height": 1728,
+      "label": "4MP"
+    },
+    "sensor": "1/2.7\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.4",
+      "varifocal": false
+    },
+    "field_of_view_deg": "130",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE (802.3af, Class 3)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66/IP67, IK08",
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "OptimizedIR up to 20m",
+      "Lightfinder low-light",
+      "AXIS Object Analytics",
+      "Zipstream (H.264/H.265)",
+      "NEMA 4X, IK08 vandal-resistant",
+      "AXIS Edge Vault (signed firmware, secure boot)"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-m2036-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2304x1728",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "axis-m3048-p",
     "brand": "Axis",
     "model": "M3048-P",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Closes #130. Thanks @aweaton123 for the submission!

Adds the **Axis M2036-LE** — 4MP outdoor bullet, joining the existing M2025-LE / M2035-LE line.

Verified against the [official Axis page](https://www.axis.com/products/axis-m2036-le); a few fields refined beyond the submission:
- **Resolution**: 2304×1728 (4MP), 1/2.7″ CMOS
- **Lens**: 2.4 mm, ~130° HFOV
- **IR**: OptimizedIR ~20m · **Ratings**: IP66/IP67, NEMA 4X, IK08 · **Temp**: −30 to 50 °C
- **Power**: PoE Class 3 · **Storage**: microSD (to 1 TB), NVR-compatible
- **Protocols**: ONVIF + RTSP → standard Axis Frigate/HA/BlueIris config (`/axis-media/media.amp`)

**One flag:** the submission marked *no audio*, and I set `microphone/speaker/two_way: false` accordingly. The Axis spec page lists a generic "Audio support" line, but the M2036-LE has no built-in mic — if you can confirm from the datasheet, happy to adjust.

QA: AJV clean; source + `last_verified`; resolution physics 1.0×; `added` date populated.