### PR TITLE
Add Axis P14-LE + Q18-LE bullet series (+10, v1.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.40.0] — 2026-07-20
+
+**Axis P14-LE + Q18-LE bullet series (+10).** ARTPEC-9 varifocal bullets **P1475/P1485/P1486/P1487/P1488-LE** (AV1 codec, Lightfinder, global-shutter P1486-LE) and the **Q18 series**: **Q1800-LE** (LPR, plates up to 250 km/h), **Q1805/Q1806-LE** (32x optical zoom, ARTPEC-8), **Q1808-LE** (10MP 4/3"), **Q1809-LE** (41MP). Net: 2,284 -> 2,294. The dedicated `soc` field is now populated on 7 cameras (ARTPEC-8/9), advancing #22/#122. Lens (wide/tele) and kit variants recorded as aliases.
+
 ## [1.39.1] — 2026-07-20
 
 **Added** the Axis **M2036-LE** (4MP bullet, PoE, OptimizedIR 20m, IP66/IP67/IK08, ONVIF/RTSP with Frigate config) — contributed via #130 by @aweaton123. 2,283 -> 2,284 cameras.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCTV Camera Database
 
-An open, structured database of 2,284 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,294 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
 [![cameras](https://img.shields.io/badge/cameras-1%2C896-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-71-green)](cameras/)
@@ -31,7 +31,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,284 cameras, 25 per page
+- **Pagination** — page through all 2,294 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -63,7 +63,7 @@ cctv-camera-database/
 │   ├── tapo/             #  62 cameras
 │   └── …60 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,284 cameras as one array
+│   ├── cameras.json      # all 2,294 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -121,7 +121,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,284** |
+| Total cameras | **2,294** |
 | Brands | **71** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,279 |

--- a/cameras/axis/p1475-le.json
+++ b/cameras/axis/p1475-le.json
@@ -1,0 +1,78 @@
+{
+  "id": "axis-p1475-le",
+  "brand": "Axis",
+  "model": "P1475-LE",
+  "aliases": ["03181-001"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": ["AV1", "H.265", "H.264"],
+    "max_fps": 60
+  },
+  "sensor": "1/2.8\" CMOS",
+  "soc": "ARTPEC-9",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.1-9.0 (2.91x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "117-36 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50
+  },
+  "power": {
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 1024,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+    "wide varifocal 3.1-9.0mm, 2.91x optical zoom",
+    "OptimizedIR up to 50m",
+    "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "microSD up to 1TB surveillance cards",
+    "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+    "-40 to 60 C"
+  ],
+  "sources": ["https://www.axis.com/products/axis-p1475-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/p1475-le.md
+++ b/cameras/axis/p1475-le.md
@@ -1,0 +1,39 @@
+# Axis P1475-LE
+
+*Also known as: 03181-001*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | P1475-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 3.1-9.0 (2.91x optical zoom)mm |
+| Field of view | 117-36 horizontal° |
+| Night vision | ir (50m) |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | microSD ≤ 1024GB, NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/2.8" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)
+- wide varifocal 3.1-9.0mm, 2.91x optical zoom
+- OptimizedIR up to 50m
+- Forensic WDR, AV1/H.265/H.264 with Zipstream
+- AXIS Object Analytics, Axis Edge Vault
+- microSD up to 1TB surveillance cards
+- NEMA 4X, IK10; audio + I/O via network/portcast accessories
+- -40 to 60 C
+
+## Sources
+
+- https://www.axis.com/products/axis-p1475-le
+
+---
+*Auto-generated from axis-p1475-le.json — do not edit by hand.*

--- a/cameras/axis/p1485-le.json
+++ b/cameras/axis/p1485-le.json
@@ -1,0 +1,78 @@
+{
+  "id": "axis-p1485-le",
+  "brand": "Axis",
+  "model": "P1485-LE",
+  "aliases": ["03182-001", "P1485-LE Kit"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": ["AV1", "H.265", "H.264"],
+    "max_fps": 60
+  },
+  "sensor": "1/2.8\" CMOS",
+  "soc": "ARTPEC-9",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "10.8-28.2 (2.61x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "29-11 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 80
+  },
+  "power": {
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3,
+    "consumption_w": 13.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+    "telephoto varifocal 10.8-28.2mm, 2.61x optical zoom (long-range)",
+    "OptimizedIR up to 80m",
+    "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+    "also sold as P1485-LE Kit (with mount/accessories)",
+    "-40 to 60 C"
+  ],
+  "sources": ["https://www.axis.com/products/axis-p1485-le", "https://www.axis.com/products/axis-p1485-le-kit"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/p1485-le.md
+++ b/cameras/axis/p1485-le.md
@@ -1,0 +1,40 @@
+# Axis P1485-LE
+
+*Also known as: 03182-001, P1485-LE Kit*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | P1485-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 10.8-28.2 (2.61x optical zoom)mm |
+| Field of view | 29-11 horizontal° |
+| Night vision | ir (80m) |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/2.8" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)
+- telephoto varifocal 10.8-28.2mm, 2.61x optical zoom (long-range)
+- OptimizedIR up to 80m
+- Forensic WDR, AV1/H.265/H.264 with Zipstream
+- AXIS Object Analytics, Axis Edge Vault
+- NEMA 4X, IK10; audio + I/O via network/portcast accessories
+- also sold as P1485-LE Kit (with mount/accessories)
+- -40 to 60 C
+
+## Sources
+
+- https://www.axis.com/products/axis-p1485-le
+- https://www.axis.com/products/axis-p1485-le-kit
+
+---
+*Auto-generated from axis-p1485-le.json — do not edit by hand.*

--- a/cameras/axis/p1486-le.json
+++ b/cameras/axis/p1486-le.json
@@ -1,0 +1,78 @@
+{
+  "id": "axis-p1486-le",
+  "brand": "Axis",
+  "model": "P1486-LE",
+  "aliases": ["03384-001", "P1486-LE Kit"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 3,
+    "max_width": 2048,
+    "max_height": 1536,
+    "label": "3MP"
+  },
+  "video": {
+    "codecs": ["AV1", "H.265", "H.264"],
+    "max_fps": 60
+  },
+  "sensor": "1/1.8\" CMOS global shutter",
+  "soc": "ARTPEC-9",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "10-40 (4x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "42-11 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 80
+  },
+  "power": {
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/1.8\" 3MP global-shutter sensor (crisp capture of fast motion / LPR)",
+    "ARTPEC-9 with deep learning processing unit (DLPU)",
+    "telephoto varifocal 10-40mm, 4x optical zoom",
+    "up to 60 fps at 3MP (up to 270 fps at lower resolution)",
+    "OptimizedIR up to 80m",
+    "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+    "-40 to 60 C"
+  ],
+  "sources": ["https://www.axis.com/products/axis-p1486-le", "https://www.axis.com/products/axis-p1486-le-kit"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2048x1536",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/p1486-le.md
+++ b/cameras/axis/p1486-le.md
@@ -1,0 +1,41 @@
+# Axis P1486-LE
+
+*Also known as: 03384-001, P1486-LE Kit*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | P1486-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 3MP (3MP, 2048×1536) |
+| Sensor | 1/1.8" CMOS global shutter |
+| Lens | 1× 10-40 (4x optical zoom)mm |
+| Field of view | 42-11 horizontal° |
+| Night vision | ir (80m) |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/1.8" 3MP global-shutter sensor (crisp capture of fast motion / LPR)
+- ARTPEC-9 with deep learning processing unit (DLPU)
+- telephoto varifocal 10-40mm, 4x optical zoom
+- up to 60 fps at 3MP (up to 270 fps at lower resolution)
+- OptimizedIR up to 80m
+- Forensic WDR, AV1/H.265/H.264 with Zipstream
+- AXIS Object Analytics, Axis Edge Vault
+- NEMA 4X, IK10; audio + I/O via network/portcast accessories
+- -40 to 60 C
+
+## Sources
+
+- https://www.axis.com/products/axis-p1486-le
+- https://www.axis.com/products/axis-p1486-le-kit
+
+---
+*Auto-generated from axis-p1486-le.json — do not edit by hand.*

--- a/cameras/axis/p1487-le.json
+++ b/cameras/axis/p1487-le.json
@@ -1,0 +1,77 @@
+{
+  "id": "axis-p1487-le",
+  "brand": "Axis",
+  "model": "P1487-LE",
+  "aliases": ["03183-001"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 2592,
+    "max_height": 1944,
+    "label": "5MP"
+  },
+  "video": {
+    "codecs": ["AV1", "H.265", "H.264"],
+    "max_fps": 30
+  },
+  "sensor": "1/2.8\" CMOS",
+  "soc": "ARTPEC-9",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.0-8.5 (2.86x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "106-35 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50
+  },
+  "power": {
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3,
+    "consumption_w": 13.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/2.8\" 5MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+    "varifocal 3.0-8.5mm, 2.86x optical zoom",
+    "OptimizedIR up to 50m",
+    "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+    "-40 to 60 C"
+  ],
+  "sources": ["https://www.axis.com/products/axis-p1487-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2592x1944",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/p1487-le.md
+++ b/cameras/axis/p1487-le.md
@@ -1,0 +1,38 @@
+# Axis P1487-LE
+
+*Also known as: 03183-001*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | P1487-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 2592×1944) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 3.0-8.5 (2.86x optical zoom)mm |
+| Field of view | 106-35 horizontal° |
+| Night vision | ir (50m) |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/2.8" 5MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)
+- varifocal 3.0-8.5mm, 2.86x optical zoom
+- OptimizedIR up to 50m
+- Forensic WDR, AV1/H.265/H.264 with Zipstream
+- AXIS Object Analytics, Axis Edge Vault
+- NEMA 4X, IK10; audio + I/O via network/portcast accessories
+- -40 to 60 C
+
+## Sources
+
+- https://www.axis.com/products/axis-p1487-le
+
+---
+*Auto-generated from axis-p1487-le.json — do not edit by hand.*

--- a/cameras/axis/p1488-le.json
+++ b/cameras/axis/p1488-le.json
@@ -1,0 +1,79 @@
+{
+  "id": "axis-p1488-le",
+  "brand": "Axis",
+  "model": "P1488-LE",
+  "aliases": ["03184-001"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD (8MP)"
+  },
+  "video": {
+    "codecs": ["AV1", "H.265", "H.264"],
+    "max_fps": 60
+  },
+  "sensor": "1/1.2\" CMOS",
+  "soc": "ARTPEC-9",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.9-13.8 (2.35x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "114-46 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50
+  },
+  "power": {
+    "method": "PoE IEEE 802.3af/802.3at Type 1",
+    "poe_class": 3,
+    "consumption_w": 13.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/1.2\" 8MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+    "varifocal 5.9-13.8mm, 2.35x optical zoom",
+    "OptimizedIR up to 50m",
+    "Lightfinder 2.0 (0.06 lux colour) + Forensic WDR",
+    "AV1, H.265, H.264 with Zipstream",
+    "AXIS Object Analytics (deep-learning human/vehicle)",
+    "Axis Edge Vault (secure boot, signed video)",
+    "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+    "-40 to 60 C"
+  ],
+  "sources": ["https://www.axis.com/products/axis-p1488-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3840x2160",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/p1488-le.md
+++ b/cameras/axis/p1488-le.md
@@ -1,0 +1,40 @@
+# Axis P1488-LE
+
+*Also known as: 03184-001*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | P1488-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP) (8MP, 3840×2160) |
+| Sensor | 1/1.2" CMOS |
+| Lens | 1× 5.9-13.8 (2.35x optical zoom)mm |
+| Field of view | 114-46 horizontal° |
+| Night vision | ir (50m) |
+| Power | PoE IEEE 802.3af/802.3at Type 1 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/1.2" 8MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)
+- varifocal 5.9-13.8mm, 2.35x optical zoom
+- OptimizedIR up to 50m
+- Lightfinder 2.0 (0.06 lux colour) + Forensic WDR
+- AV1, H.265, H.264 with Zipstream
+- AXIS Object Analytics (deep-learning human/vehicle)
+- Axis Edge Vault (secure boot, signed video)
+- NEMA 4X, IK10; audio + I/O via network/portcast accessories
+- -40 to 60 C
+
+## Sources
+
+- https://www.axis.com/products/axis-p1488-le
+
+---
+*Auto-generated from axis-p1488-le.json — do not edit by hand.*

--- a/cameras/axis/q1800-le.json
+++ b/cameras/axis/q1800-le.json
@@ -1,0 +1,77 @@
+{
+  "id": "axis-q1800-le",
+  "brand": "Axis",
+  "model": "Q1800-LE",
+  "aliases": ["03107-001", "Q1800-LE-3 (License Plate Verifier kit)"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": ["H.265", "H.264"],
+    "max_fps": 90
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "7-137 (varifocal, ~19.5x)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "38-2.3 horizontal",
+  "night_vision": {
+    "type": "none"
+  },
+  "power": {
+    "method": "PoE IEEE 802.3at Type 2",
+    "poe_class": 4,
+    "consumption_w": 29.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "dedicated License Plate Recognition (ANPR) camera",
+    "captures plates at speeds up to 250 km/h (single lane)",
+    "range up to 100m daylight / 50m at night (no built-in IR)",
+    "varifocal 7-137mm, 90 fps for fast-moving vehicles",
+    "vendor-agnostic: works with AXIS License Plate Verifier + 3rd-party LPR",
+    "optional AXIS T90D20 IR illuminator extends night range to 100m",
+    "IK10 body / IK08 glass, NEMA 4X",
+    "audio + I/O via network/portcast accessories"
+  ],
+  "sources": ["https://www.axis.com/products/axis-q1800-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+      "notes": "LPR camera — for plate capture use a dedicated stream/analytics rather than Frigate object detection."
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/q1800-le.md
+++ b/cameras/axis/q1800-le.md
@@ -1,0 +1,39 @@
+# Axis Q1800-LE
+
+*Also known as: 03107-001, Q1800-LE-3 (License Plate Verifier kit)*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | Q1800-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 7-137 (varifocal, ~19.5x)mm |
+| Field of view | 38-2.3 horizontal° |
+| Night vision | none |
+| Power | PoE IEEE 802.3at Type 2 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- dedicated License Plate Recognition (ANPR) camera
+- captures plates at speeds up to 250 km/h (single lane)
+- range up to 100m daylight / 50m at night (no built-in IR)
+- varifocal 7-137mm, 90 fps for fast-moving vehicles
+- vendor-agnostic: works with AXIS License Plate Verifier + 3rd-party LPR
+- optional AXIS T90D20 IR illuminator extends night range to 100m
+- IK10 body / IK08 glass, NEMA 4X
+- audio + I/O via network/portcast accessories
+
+## Sources
+
+- https://www.axis.com/products/axis-q1800-le
+
+---
+*Auto-generated from axis-q1800-le.json — do not edit by hand.*

--- a/cameras/axis/q1805-le.json
+++ b/cameras/axis/q1805-le.json
@@ -1,0 +1,77 @@
+{
+  "id": "axis-q1805-le",
+  "brand": "Axis",
+  "model": "Q1805-LE",
+  "aliases": ["02504-001"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": ["H.265", "H.264"],
+    "max_fps": 90
+  },
+  "sensor": "1/2.8\" CMOS",
+  "soc": "ARTPEC-8",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-137 (32x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "60-2.3 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE IEEE 802.3at Type 2",
+    "poe_class": 4,
+    "consumption_w": 29.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/2.8\" 2MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+    "32x optical zoom (4.3-137mm varifocal)",
+    "OptimizedIR up to 100m",
+    "electronic image stabilization (EIS)",
+    "90 fps, Forensic WDR, Lightfinder",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "IK10 body / IK08 glass; audio + I/O via accessories"
+  ],
+  "sources": ["https://www.axis.com/products/axis-q1805-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/q1805-le.md
+++ b/cameras/axis/q1805-le.md
@@ -1,0 +1,38 @@
+# Axis Q1805-LE
+
+*Also known as: 02504-001*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | Q1805-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.3-137 (32x optical zoom)mm |
+| Field of view | 60-2.3 horizontal° |
+| Night vision | ir (100m) |
+| Power | PoE IEEE 802.3at Type 2 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/2.8" 2MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)
+- 32x optical zoom (4.3-137mm varifocal)
+- OptimizedIR up to 100m
+- electronic image stabilization (EIS)
+- 90 fps, Forensic WDR, Lightfinder
+- AXIS Object Analytics, Axis Edge Vault
+- IK10 body / IK08 glass; audio + I/O via accessories
+
+## Sources
+
+- https://www.axis.com/products/axis-q1805-le
+
+---
+*Auto-generated from axis-q1805-le.json — do not edit by hand.*

--- a/cameras/axis/q1806-le.json
+++ b/cameras/axis/q1806-le.json
@@ -1,0 +1,77 @@
+{
+  "id": "axis-q1806-le",
+  "brand": "Axis",
+  "model": "Q1806-LE",
+  "aliases": ["02506-001"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 4,
+    "max_width": 2880,
+    "max_height": 1620,
+    "label": "4MP"
+  },
+  "video": {
+    "codecs": ["H.265", "H.264"],
+    "max_fps": 90
+  },
+  "sensor": "1/1.8\" CMOS",
+  "soc": "ARTPEC-8",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-137 (32x optical zoom)",
+    "varifocal": true
+  },
+  "field_of_view_deg": "60-2.3 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE IEEE 802.3at Type 2",
+    "poe_class": 4,
+    "consumption_w": 31.1
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "1/1.8\" 4MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+    "32x optical zoom (4.3-137mm varifocal)",
+    "OptimizedIR up to 100m",
+    "electronic + optical image stabilization (EIS/OIS)",
+    "90 fps, Forensic WDR, Lightfinder",
+    "AXIS Object Analytics, Axis Edge Vault",
+    "IK10 body / IK08 glass; audio + I/O via accessories"
+  ],
+  "sources": ["https://www.axis.com/products/axis-q1806-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2880x1620",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/q1806-le.md
+++ b/cameras/axis/q1806-le.md
@@ -1,0 +1,38 @@
+# Axis Q1806-LE
+
+*Also known as: 02506-001*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | Q1806-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2880×1620) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-137 (32x optical zoom)mm |
+| Field of view | 60-2.3 horizontal° |
+| Night vision | ir (100m) |
+| Power | PoE IEEE 802.3at Type 2 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 1/1.8" 4MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)
+- 32x optical zoom (4.3-137mm varifocal)
+- OptimizedIR up to 100m
+- electronic + optical image stabilization (EIS/OIS)
+- 90 fps, Forensic WDR, Lightfinder
+- AXIS Object Analytics, Axis Edge Vault
+- IK10 body / IK08 glass; audio + I/O via accessories
+
+## Sources
+
+- https://www.axis.com/products/axis-q1806-le
+
+---
+*Auto-generated from axis-q1806-le.json — do not edit by hand.*

--- a/cameras/axis/q1808-le.json
+++ b/cameras/axis/q1808-le.json
@@ -1,0 +1,76 @@
+{
+  "id": "axis-q1808-le",
+  "brand": "Axis",
+  "model": "Q1808-LE",
+  "aliases": ["02507-001", "02508-001 (150mm tele)"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 10,
+    "max_width": 3712,
+    "max_height": 2784,
+    "label": "10MP"
+  },
+  "video": {
+    "codecs": ["H.265", "H.264"],
+    "max_fps": 60
+  },
+  "sensor": "4/3\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "wide 12-48 (4x) or tele 50-150 (3x) — Canon varifocal",
+    "varifocal": true
+  },
+  "field_of_view_deg": "90-21 (wide) / 21-7 (tele) horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 120
+  },
+  "power": {
+    "method": "PoE IEEE 802.3at Type 2 (PoE out capable)",
+    "poe_class": 4,
+    "consumption_w": 25.5
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 60",
+  "features": [
+    "4/3\" 10MP large sensor for long-range detail",
+    "Canon varifocal lens: wide 12-48mm (4x) or 150mm tele 50-150mm (3x)",
+    "OptimizedIR up to 120m (tele)",
+    "electronic image stabilization (EIS)",
+    "Forensic WDR, Lightfinder, AXIS Object Analytics",
+    "Axis Edge Vault; PoE out to power an auxiliary device",
+    "IK10 body / IK08 glass, NEMA 4X; audio + I/O via accessories"
+  ],
+  "sources": ["https://www.axis.com/products/axis-q1808-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3712x2784",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/q1808-le.md
+++ b/cameras/axis/q1808-le.md
@@ -1,0 +1,38 @@
+# Axis Q1808-LE
+
+*Also known as: 02507-001, 02508-001 (150mm tele)*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | Q1808-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 10MP (10MP, 3712×2784) |
+| Sensor | 4/3" CMOS |
+| Lens | 1× wide 12-48 (4x) or tele 50-150 (3x) — Canon varifocalmm |
+| Field of view | 90-21 (wide) / 21-7 (tele) horizontal° |
+| Night vision | ir (120m) |
+| Power | PoE IEEE 802.3at Type 2 (PoE out capable) |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 4/3" 10MP large sensor for long-range detail
+- Canon varifocal lens: wide 12-48mm (4x) or 150mm tele 50-150mm (3x)
+- OptimizedIR up to 120m (tele)
+- electronic image stabilization (EIS)
+- Forensic WDR, Lightfinder, AXIS Object Analytics
+- Axis Edge Vault; PoE out to power an auxiliary device
+- IK10 body / IK08 glass, NEMA 4X; audio + I/O via accessories
+
+## Sources
+
+- https://www.axis.com/products/axis-q1808-le
+
+---
+*Auto-generated from axis-q1808-le.json — do not edit by hand.*

--- a/cameras/axis/q1809-le.json
+++ b/cameras/axis/q1809-le.json
@@ -1,0 +1,78 @@
+{
+  "id": "axis-q1809-le",
+  "brand": "Axis",
+  "model": "Q1809-LE",
+  "aliases": ["02870-001", "03019-001 (150mm tele)"],
+  "type": "bullet",
+  "connectivity": ["ethernet"],
+  "power_source": ["poe"],
+  "environment": ["indoor", "outdoor"],
+  "resolution": {
+    "megapixels": 41,
+    "max_width": 7424,
+    "max_height": 5568,
+    "label": "41MP"
+  },
+  "video": {
+    "codecs": ["H.265", "H.264"],
+    "max_fps": 15
+  },
+  "sensor": "4/3\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "wide 12-24 (2x) or tele 50-150 (3x) — Canon varifocal",
+    "varifocal": true
+  },
+  "field_of_view_deg": "90-44 (wide) / 21-7 (tele) horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE IEEE 802.3bt Type 3",
+    "poe_class": 6,
+    "consumption_w": 35.0
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": ["onvif", "rtsp", "http"],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66/IP67, IK10",
+  "operating_temp_c": "-40 to 55",
+  "features": [
+    "4/3\" 41MP sensor (7424x5568) — extreme detail over very wide areas",
+    "dual Axis system-on-chip",
+    "Canon varifocal lens: wide 12-24mm (2x) or 150mm tele 50-150mm (3x)",
+    "15 fps at 41MP (30 fps at 8K)",
+    "OptimizedIR up to 100m, electronic image stabilization (EIS)",
+    "Forensic WDR, AXIS Object Analytics, Axis Edge Vault",
+    "PoE Class 6 (802.3bt); IK10 body / IK08 glass, NEMA 4X",
+    "audio + I/O via network/portcast accessories"
+  ],
+  "sources": ["https://www.axis.com/products/axis-q1809-le"],
+  "markets": ["global"],
+  "last_verified": "2026-07-20",
+  "configs": {
+    "frigate": {
+      "detect": {"width": 640, "height": 360, "fps": 5},
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=7424x5568",
+      "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480",
+      "notes": "41MP main stream is very heavy — run detection on a low-res substream and record the full stream on motion."
+    },
+    "home_assistant": {
+      "integration": "axis",
+      "notes": "Native Axis integration with auto-discovery via Zeroconf."
+    },
+    "blue_iris": {
+      "profile": "Axis",
+      "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+    }
+  }
+}

--- a/cameras/axis/q1809-le.md
+++ b/cameras/axis/q1809-le.md
@@ -1,0 +1,39 @@
+# Axis Q1809-LE
+
+*Also known as: 02870-001, 03019-001 (150mm tele)*
+
+| Field | Spec |
+|-------|------|
+| Brand | Axis |
+| Model | Q1809-LE |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 41MP (41MP, 7424×5568) |
+| Sensor | 4/3" CMOS |
+| Lens | 1× wide 12-24 (2x) or tele 50-150 (3x) — Canon varifocalmm |
+| Field of view | 90-44 (wide) / 21-7 (tele) horizontal° |
+| Night vision | ir (100m) |
+| Power | PoE IEEE 802.3bt Type 3 |
+| Storage | NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67, IK10 |
+| Two-way audio | No |
+| Operating temp | -40 to 55°C |
+
+## Features
+
+- 4/3" 41MP sensor (7424x5568) — extreme detail over very wide areas
+- dual Axis system-on-chip
+- Canon varifocal lens: wide 12-24mm (2x) or 150mm tele 50-150mm (3x)
+- 15 fps at 41MP (30 fps at 8K)
+- OptimizedIR up to 100m, electronic image stabilization (EIS)
+- Forensic WDR, AXIS Object Analytics, Axis Edge Vault
+- PoE Class 6 (802.3bt); IK10 body / IK08 glass, NEMA 4X
+- audio + I/O via network/portcast accessories
+
+## Sources
+
+- https://www.axis.com/products/axis-q1809-le
+
+---
+*Auto-generated from axis-q1809-le.json — do not edit by hand.*

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -483,6 +483,11 @@ axis-p1368-e,Axis,P1368-E,box,4K UHD,8,,108h,none,IP66,false,2017
 axis-p1448-le,Axis,P1448-LE,bullet,4K UHD,8,"1/1.7"" Progressive Scan CMOS",109-37,ir,IP66,false,
 axis-p1465-le,Axis,P1465-LE,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",100-35 horizontal,ir,IP67,false,2023
 axis-p1465-le-3,Axis,P1465-LE-3 License Plate Verifier,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",100-35 horizontal,ir,IP67,false,2023
+axis-p1475-le,Axis,P1475-LE,bullet,1080p,2,"1/2.8"" CMOS",117-36 horizontal,ir,"IP66/IP67, IK10",false,
+axis-p1485-le,Axis,P1485-LE,bullet,1080p,2,"1/2.8"" CMOS",29-11 horizontal,ir,"IP66/IP67, IK10",false,
+axis-p1486-le,Axis,P1486-LE,bullet,3MP,3,"1/1.8"" CMOS global shutter",42-11 horizontal,ir,"IP66/IP67, IK10",false,
+axis-p1487-le,Axis,P1487-LE,bullet,5MP,5,"1/2.8"" CMOS",106-35 horizontal,ir,"IP66/IP67, IK10",false,
+axis-p1488-le,Axis,P1488-LE,bullet,4K UHD (8MP),8,"1/1.2"" CMOS",114-46 horizontal,ir,"IP66/IP67, IK10",false,
 axis-p3245-lv,Axis,P3245-LV,dome,1080p HD,2,,100-33h,ir,IP42,false,2021
 axis-p3245-lve,Axis,P3245-LVE,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",100-36 horizontal,ir,IP66,true,
 axis-p3245-lve-3,Axis,P3245-LVE-3,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",100-36 horizontal,ir,IP66,false,
@@ -505,6 +510,11 @@ axis-p5676-le,Axis,P5676-LE,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",57.1-2.1 h
 axis-q1656,Axis,Q1656,box,4K UHD,8,"1/1.7"" Progressive Scan CMOS",,none,IP42,false,
 axis-q1656-be,Axis,Q1656-BE,box,4K UHD,8,"1/1.7"" Progressive Scan CMOS",,none,IP66,false,
 axis-q1785-le,Axis,Q1785-LE,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",100-36 horizontal,ir,IP66,false,
+axis-q1800-le,Axis,Q1800-LE,bullet,1080p,2,"1/2.8"" CMOS",38-2.3 horizontal,none,"IP66, IK10",false,
+axis-q1805-le,Axis,Q1805-LE,bullet,1080p,2,"1/2.8"" CMOS",60-2.3 horizontal,ir,"IP66/IP67, IK10",false,
+axis-q1806-le,Axis,Q1806-LE,bullet,4MP,4,"1/1.8"" CMOS",60-2.3 horizontal,ir,"IP66/IP67, IK10",false,
+axis-q1808-le,Axis,Q1808-LE,bullet,10MP,10,"4/3"" CMOS",90-21 (wide) / 21-7 (tele) horizontal,ir,"IP66/IP67, IK10",false,
+axis-q1809-le,Axis,Q1809-LE,bullet,41MP,41,"4/3"" CMOS",90-44 (wide) / 21-7 (tele) horizontal,ir,"IP66/IP67, IK10",false,
 axis-q1942-e,Axis,Q1942-E,bullet,640x480 thermal,0.3,Thermal VOx LWIR uncooled microbolometer,,none,IP66,false,
 axis-q1952-e,Axis,Q1952-E,bullet,640x480 thermal,0.3,Uncooled microbolometer,61 horizontal,none,IP66,false,2022
 axis-q2101-e,Axis,Q2101-E Thermal,bullet,384×288 thermal,0.08,Uncooled microbolometer LWIR,45 horizontal (10mm),none,IP66,false,2021

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -43117,6 +43117,530 @@
     "added": "2026-06-09"
   },
   {
+    "id": "axis-p1475-le",
+    "brand": "Axis",
+    "model": "P1475-LE",
+    "aliases": [
+      "03181-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.1-9.0 (2.91x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "117-36 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "wide varifocal 3.1-9.0mm, 2.91x optical zoom",
+      "OptimizedIR up to 50m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "microSD up to 1TB surveillance cards",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1475-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1485-le",
+    "brand": "Axis",
+    "model": "P1485-LE",
+    "aliases": [
+      "03182-001",
+      "P1485-LE Kit"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "10.8-28.2 (2.61x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "29-11 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 80
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "telephoto varifocal 10.8-28.2mm, 2.61x optical zoom (long-range)",
+      "OptimizedIR up to 80m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "also sold as P1485-LE Kit (with mount/accessories)",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1485-le",
+      "https://www.axis.com/products/axis-p1485-le-kit"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1486-le",
+    "brand": "Axis",
+    "model": "P1486-LE",
+    "aliases": [
+      "03384-001",
+      "P1486-LE Kit"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 3,
+      "max_width": 2048,
+      "max_height": 1536,
+      "label": "3MP"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/1.8\" CMOS global shutter",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "10-40 (4x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "42-11 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 80
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.8\" 3MP global-shutter sensor (crisp capture of fast motion / LPR)",
+      "ARTPEC-9 with deep learning processing unit (DLPU)",
+      "telephoto varifocal 10-40mm, 4x optical zoom",
+      "up to 60 fps at 3MP (up to 270 fps at lower resolution)",
+      "OptimizedIR up to 80m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1486-le",
+      "https://www.axis.com/products/axis-p1486-le-kit"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2048x1536",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1487-le",
+    "brand": "Axis",
+    "model": "P1487-LE",
+    "aliases": [
+      "03183-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 2592,
+      "max_height": 1944,
+      "label": "5MP"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0-8.5 (2.86x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "106-35 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 5MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "varifocal 3.0-8.5mm, 2.86x optical zoom",
+      "OptimizedIR up to 50m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1487-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2592x1944",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1488-le",
+    "brand": "Axis",
+    "model": "P1488-LE",
+    "aliases": [
+      "03184-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD (8MP)"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/1.2\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8 (2.35x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "114-46 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.2\" 8MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "varifocal 5.9-13.8mm, 2.35x optical zoom",
+      "OptimizedIR up to 50m",
+      "Lightfinder 2.0 (0.06 lux colour) + Forensic WDR",
+      "AV1, H.265, H.264 with Zipstream",
+      "AXIS Object Analytics (deep-learning human/vehicle)",
+      "Axis Edge Vault (secure boot, signed video)",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1488-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3840x2160",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "axis-p3245-lv",
     "brand": "Axis",
     "model": "P3245-LV",
@@ -44993,6 +45517,519 @@
       }
     },
     "added": "2026-06-06"
+  },
+  {
+    "id": "axis-q1800-le",
+    "brand": "Axis",
+    "model": "Q1800-LE",
+    "aliases": [
+      "03107-001",
+      "Q1800-LE-3 (License Plate Verifier kit)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "7-137 (varifocal, ~19.5x)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "38-2.3 horizontal",
+    "night_vision": {
+      "type": "none"
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 29
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "dedicated License Plate Recognition (ANPR) camera",
+      "captures plates at speeds up to 250 km/h (single lane)",
+      "range up to 100m daylight / 50m at night (no built-in IR)",
+      "varifocal 7-137mm, 90 fps for fast-moving vehicles",
+      "vendor-agnostic: works with AXIS License Plate Verifier + 3rd-party LPR",
+      "optional AXIS T90D20 IR illuminator extends night range to 100m",
+      "IK10 body / IK08 glass, NEMA 4X",
+      "audio + I/O via network/portcast accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1800-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+        "notes": "LPR camera — for plate capture use a dedicated stream/analytics rather than Frigate object detection."
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1805-le",
+    "brand": "Axis",
+    "model": "Q1805-LE",
+    "aliases": [
+      "02504-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-8",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-137 (32x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "60-2.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 29
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+      "32x optical zoom (4.3-137mm varifocal)",
+      "OptimizedIR up to 100m",
+      "electronic image stabilization (EIS)",
+      "90 fps, Forensic WDR, Lightfinder",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "IK10 body / IK08 glass; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1805-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1806-le",
+    "brand": "Axis",
+    "model": "Q1806-LE",
+    "aliases": [
+      "02506-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2880,
+      "max_height": 1620,
+      "label": "4MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/1.8\" CMOS",
+    "soc": "ARTPEC-8",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-137 (32x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "60-2.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 31.1
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.8\" 4MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+      "32x optical zoom (4.3-137mm varifocal)",
+      "OptimizedIR up to 100m",
+      "electronic + optical image stabilization (EIS/OIS)",
+      "90 fps, Forensic WDR, Lightfinder",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "IK10 body / IK08 glass; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1806-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2880x1620",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1808-le",
+    "brand": "Axis",
+    "model": "Q1808-LE",
+    "aliases": [
+      "02507-001",
+      "02508-001 (150mm tele)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 10,
+      "max_width": 3712,
+      "max_height": 2784,
+      "label": "10MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "4/3\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "wide 12-48 (4x) or tele 50-150 (3x) — Canon varifocal",
+      "varifocal": true
+    },
+    "field_of_view_deg": "90-21 (wide) / 21-7 (tele) horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 120
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2 (PoE out capable)",
+      "poe_class": 4,
+      "consumption_w": 25.5
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "4/3\" 10MP large sensor for long-range detail",
+      "Canon varifocal lens: wide 12-48mm (4x) or 150mm tele 50-150mm (3x)",
+      "OptimizedIR up to 120m (tele)",
+      "electronic image stabilization (EIS)",
+      "Forensic WDR, Lightfinder, AXIS Object Analytics",
+      "Axis Edge Vault; PoE out to power an auxiliary device",
+      "IK10 body / IK08 glass, NEMA 4X; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1808-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3712x2784",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1809-le",
+    "brand": "Axis",
+    "model": "Q1809-LE",
+    "aliases": [
+      "02870-001",
+      "03019-001 (150mm tele)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 41,
+      "max_width": 7424,
+      "max_height": 5568,
+      "label": "41MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 15
+    },
+    "sensor": "4/3\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "wide 12-24 (2x) or tele 50-150 (3x) — Canon varifocal",
+      "varifocal": true
+    },
+    "field_of_view_deg": "90-44 (wide) / 21-7 (tele) horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3bt Type 3",
+      "poe_class": 6,
+      "consumption_w": 35
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 55",
+    "features": [
+      "4/3\" 41MP sensor (7424x5568) — extreme detail over very wide areas",
+      "dual Axis system-on-chip",
+      "Canon varifocal lens: wide 12-24mm (2x) or 150mm tele 50-150mm (3x)",
+      "15 fps at 41MP (30 fps at 8K)",
+      "OptimizedIR up to 100m, electronic image stabilization (EIS)",
+      "Forensic WDR, AXIS Object Analytics, Axis Edge Vault",
+      "PoE Class 6 (802.3bt); IK10 body / IK08 glass, NEMA 4X",
+      "audio + I/O via network/portcast accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1809-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=7424x5568",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480",
+        "notes": "41MP main stream is very heavy — run detection on a low-res substream and record the full stream on motion."
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "axis-q1942-e",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -43117,6 +43117,530 @@
     "added": "2026-06-09"
   },
   {
+    "id": "axis-p1475-le",
+    "brand": "Axis",
+    "model": "P1475-LE",
+    "aliases": [
+      "03181-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.1-9.0 (2.91x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "117-36 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "wide varifocal 3.1-9.0mm, 2.91x optical zoom",
+      "OptimizedIR up to 50m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "microSD up to 1TB surveillance cards",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1475-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1485-le",
+    "brand": "Axis",
+    "model": "P1485-LE",
+    "aliases": [
+      "03182-001",
+      "P1485-LE Kit"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "10.8-28.2 (2.61x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "29-11 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 80
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "telephoto varifocal 10.8-28.2mm, 2.61x optical zoom (long-range)",
+      "OptimizedIR up to 80m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "also sold as P1485-LE Kit (with mount/accessories)",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1485-le",
+      "https://www.axis.com/products/axis-p1485-le-kit"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1486-le",
+    "brand": "Axis",
+    "model": "P1486-LE",
+    "aliases": [
+      "03384-001",
+      "P1486-LE Kit"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 3,
+      "max_width": 2048,
+      "max_height": 1536,
+      "label": "3MP"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/1.8\" CMOS global shutter",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "10-40 (4x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "42-11 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 80
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.8\" 3MP global-shutter sensor (crisp capture of fast motion / LPR)",
+      "ARTPEC-9 with deep learning processing unit (DLPU)",
+      "telephoto varifocal 10-40mm, 4x optical zoom",
+      "up to 60 fps at 3MP (up to 270 fps at lower resolution)",
+      "OptimizedIR up to 80m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1486-le",
+      "https://www.axis.com/products/axis-p1486-le-kit"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2048x1536",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1487-le",
+    "brand": "Axis",
+    "model": "P1487-LE",
+    "aliases": [
+      "03183-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 2592,
+      "max_height": 1944,
+      "label": "5MP"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0-8.5 (2.86x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "106-35 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 5MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "varifocal 3.0-8.5mm, 2.86x optical zoom",
+      "OptimizedIR up to 50m",
+      "Forensic WDR, AV1/H.265/H.264 with Zipstream",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1487-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2592x1944",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-p1488-le",
+    "brand": "Axis",
+    "model": "P1488-LE",
+    "aliases": [
+      "03184-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD (8MP)"
+    },
+    "video": {
+      "codecs": [
+        "AV1",
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "1/1.2\" CMOS",
+    "soc": "ARTPEC-9",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8 (2.35x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "114-46 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "PoE IEEE 802.3af/802.3at Type 1",
+      "poe_class": 3,
+      "consumption_w": 13
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.2\" 8MP sensor, ARTPEC-9 with deep learning processing unit (DLPU)",
+      "varifocal 5.9-13.8mm, 2.35x optical zoom",
+      "OptimizedIR up to 50m",
+      "Lightfinder 2.0 (0.06 lux colour) + Forensic WDR",
+      "AV1, H.265, H.264 with Zipstream",
+      "AXIS Object Analytics (deep-learning human/vehicle)",
+      "Axis Edge Vault (secure boot, signed video)",
+      "NEMA 4X, IK10; audio + I/O via network/portcast accessories",
+      "-40 to 60 C"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-p1488-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3840x2160",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
     "id": "axis-p3245-lv",
     "brand": "Axis",
     "model": "P3245-LV",
@@ -44993,6 +45517,519 @@
       }
     },
     "added": "2026-06-06"
+  },
+  {
+    "id": "axis-q1800-le",
+    "brand": "Axis",
+    "model": "Q1800-LE",
+    "aliases": [
+      "03107-001",
+      "Q1800-LE-3 (License Plate Verifier kit)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "7-137 (varifocal, ~19.5x)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "38-2.3 horizontal",
+    "night_vision": {
+      "type": "none"
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 29
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "dedicated License Plate Recognition (ANPR) camera",
+      "captures plates at speeds up to 250 km/h (single lane)",
+      "range up to 100m daylight / 50m at night (no built-in IR)",
+      "varifocal 7-137mm, 90 fps for fast-moving vehicles",
+      "vendor-agnostic: works with AXIS License Plate Verifier + 3rd-party LPR",
+      "optional AXIS T90D20 IR illuminator extends night range to 100m",
+      "IK10 body / IK08 glass, NEMA 4X",
+      "audio + I/O via network/portcast accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1800-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360",
+        "notes": "LPR camera — for plate capture use a dedicated stream/analytics rather than Frigate object detection."
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1805-le",
+    "brand": "Axis",
+    "model": "Q1805-LE",
+    "aliases": [
+      "02504-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/2.8\" CMOS",
+    "soc": "ARTPEC-8",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-137 (32x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "60-2.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 29
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/2.8\" 2MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+      "32x optical zoom (4.3-137mm varifocal)",
+      "OptimizedIR up to 100m",
+      "electronic image stabilization (EIS)",
+      "90 fps, Forensic WDR, Lightfinder",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "IK10 body / IK08 glass; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1805-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=1920x1080",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1806-le",
+    "brand": "Axis",
+    "model": "Q1806-LE",
+    "aliases": [
+      "02506-001"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2880,
+      "max_height": 1620,
+      "label": "4MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 90
+    },
+    "sensor": "1/1.8\" CMOS",
+    "soc": "ARTPEC-8",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-137 (32x optical zoom)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "60-2.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2",
+      "poe_class": 4,
+      "consumption_w": 31.1
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "1/1.8\" 4MP sensor, ARTPEC-8 with deep learning processing unit (DLPU)",
+      "32x optical zoom (4.3-137mm varifocal)",
+      "OptimizedIR up to 100m",
+      "electronic + optical image stabilization (EIS/OIS)",
+      "90 fps, Forensic WDR, Lightfinder",
+      "AXIS Object Analytics, Axis Edge Vault",
+      "IK10 body / IK08 glass; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1806-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=2880x1620",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x360"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1808-le",
+    "brand": "Axis",
+    "model": "Q1808-LE",
+    "aliases": [
+      "02507-001",
+      "02508-001 (150mm tele)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 10,
+      "max_width": 3712,
+      "max_height": 2784,
+      "label": "10MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "sensor": "4/3\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "wide 12-48 (4x) or tele 50-150 (3x) — Canon varifocal",
+      "varifocal": true
+    },
+    "field_of_view_deg": "90-21 (wide) / 21-7 (tele) horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 120
+    },
+    "power": {
+      "method": "PoE IEEE 802.3at Type 2 (PoE out capable)",
+      "poe_class": 4,
+      "consumption_w": 25.5
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 60",
+    "features": [
+      "4/3\" 10MP large sensor for long-range detail",
+      "Canon varifocal lens: wide 12-48mm (4x) or 150mm tele 50-150mm (3x)",
+      "OptimizedIR up to 120m (tele)",
+      "electronic image stabilization (EIS)",
+      "Forensic WDR, Lightfinder, AXIS Object Analytics",
+      "Axis Edge Vault; PoE out to power an auxiliary device",
+      "IK10 body / IK08 glass, NEMA 4X; audio + I/O via accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1808-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=3712x2784",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480"
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
+  },
+  {
+    "id": "axis-q1809-le",
+    "brand": "Axis",
+    "model": "Q1809-LE",
+    "aliases": [
+      "02870-001",
+      "03019-001 (150mm tele)"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "resolution": {
+      "megapixels": 41,
+      "max_width": 7424,
+      "max_height": 5568,
+      "label": "41MP"
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 15
+    },
+    "sensor": "4/3\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "wide 12-24 (2x) or tele 50-150 (3x) — Canon varifocal",
+      "varifocal": true
+    },
+    "field_of_view_deg": "90-44 (wide) / 21-7 (tele) horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE IEEE 802.3bt Type 3",
+      "poe_class": 6,
+      "consumption_w": 35
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66/IP67, IK10",
+    "operating_temp_c": "-40 to 55",
+    "features": [
+      "4/3\" 41MP sensor (7424x5568) — extreme detail over very wide areas",
+      "dual Axis system-on-chip",
+      "Canon varifocal lens: wide 12-24mm (2x) or 150mm tele 50-150mm (3x)",
+      "15 fps at 41MP (30 fps at 8K)",
+      "OptimizedIR up to 100m, electronic image stabilization (EIS)",
+      "Forensic WDR, AXIS Object Analytics, Axis Edge Vault",
+      "PoE Class 6 (802.3bt); IK10 body / IK08 glass, NEMA 4X",
+      "audio + I/O via network/portcast accessories"
+    ],
+    "sources": [
+      "https://www.axis.com/products/axis-q1809-le"
+    ],
+    "markets": [
+      "global"
+    ],
+    "last_verified": "2026-07-20",
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 360,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=7424x5568",
+        "best_substream": "rtsp://{user}:{pass}@{ip}/axis-media/media.amp?resolution=640x480",
+        "notes": "41MP main stream is very heavy — run detection on a low-res substream and record the full stream on motion."
+      },
+      "home_assistant": {
+        "integration": "axis",
+        "notes": "Native Axis integration with auto-discovery via Zeroconf."
+      },
+      "blue_iris": {
+        "profile": "Axis",
+        "notes": "Select 'Axis' profile. Auto-discovery via ONVIF usually works."
+      }
+    },
+    "added": "2026-07-20"
   },
   {
     "id": "axis-q1942-e",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Adds **10 Axis bullet cameras** across the P14-LE and Q18-LE lines (2,284 → 2,294).

## P14-LE (ARTPEC-9)
`P1475-LE` (2MP wide), `P1485-LE` (2MP telephoto), `P1486-LE` (3MP **global shutter**, LPR/fast-motion), `P1487-LE` (5MP), `P1488-LE` (8MP, 1/1.2″). AV1 codec, Lightfinder 2.0, Forensic WDR, Object Analytics, Edge Vault.

## Q18-LE
`Q1800-LE` (**LPR**, plates to 250 km/h, no built-in IR), `Q1805-LE`/`Q1806-LE` (2MP/4MP **32× optical zoom**, ARTPEC-8), `Q1808-LE` (**10MP** 4/3″, Canon wide/tele), `Q1809-LE` (**41MP** 4/3″, PoE Class 6).

## Notes
- Verified per-model against official axis.com pages. All ONVIF/RTSP → standard Axis Frigate config (`/axis-media/media.amp`).
- **`soc` field** populated on the ARTPEC-8/9 models — dataset now has 7 cameras with SoC (advances #22/#122).
- Lens variants (Q1808/Q1809 wide + 150mm tele part numbers) and the Q1800-LE-3 verifier kit recorded as **aliases**, not separate entries.
- Audio `false` (Axis pro bullets — audio via portcast/accessory); Q1800-LE `night_vision: none` (optional T90D20 IR).
- AJV clean; physics pass; sources + `last_verified` + `added` dates on all.