### PR TITLE
Extend schema with minimum illumination (lux) required for color night vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.45.0] — 2026-07-25
+
+**New field: `night_vision.min_lux_color`** (#143 — thanks @fvdpol!). Captures the minimum illumination, in lux, required to render a usable **colour** image — the objective figure behind vendor marketing terms like ColorVu, Starlight, DarkFighter and NightChroma, so low-light colour capability can actually be compared. Migrated the value into **96 cameras** where it was documented (range 0.0001–0.18 lx). Also updates `docs/glossary.md`, the `add-camera` wizard, `gen-docs` (renders "… lux color" on the Night vision row) and the `docs/demo.html` viewer. (Maintainer follow-ups: normalised the schema indentation and added `minimum: 0`.)
+
 ## [1.44.2] — 2026-07-22
 
 **Reseller-source audit close-out** (#138, #140). Resolved the last flagged reseller-sourced entries and a duplicate:

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Common optional fields:
 | `connectivity` | `string[]` | `["poe", "wifi", "ethernet"]` |
 | `night_vision.type` | `string` | `"color"` / `"ir"` / `"none"` |
 | `night_vision.range_m` | `number` | `30` |
+| `night_vision.min_lux_color` | `number` | `0.01` |
 | `power.method` | `string` | `"PoE (802.3af) / DC 12V"` |
 | `ip_rating` | `string` | `"IP67"` |
 | `ik_rating` | `string` | `"IK10"` |

--- a/cameras/abus/ipcb44510a.json
+++ b/cameras/abus/ipcb44510a.json
@@ -33,7 +33,8 @@
   "field_of_view_deg": "109 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (IEEE 802.3af) / 12V DC"

--- a/cameras/abus/ipcs64511b.json
+++ b/cameras/abus/ipcs64511b.json
@@ -54,7 +54,8 @@
   "field_of_view_deg": "95 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (IEEE 802.3af) or 12V DC"

--- a/cameras/annke/ac400-i81hq.json
+++ b/cameras/annke/ac400-i81hq.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "104 horizontal (123 diagonal)",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/ac800.json
+++ b/cameras/annke/ac800.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "102 horizontal (134 diagonal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/annke/c1200-i91dd.json
+++ b/cameras/annke/c1200-i91dd.json
@@ -36,7 +36,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/c1200d-i91dg.json
+++ b/cameras/annke/c1200d-i91dg.json
@@ -38,7 +38,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/c800-i91bd.json
+++ b/cameras/annke/c800-i91bd.json
@@ -36,7 +36,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91bl.json
+++ b/cameras/annke/c800-i91bl.json
@@ -36,7 +36,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91bm.json
+++ b/cameras/annke/c800-i91bm.json
@@ -36,7 +36,9 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
+
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91bn.json
+++ b/cameras/annke/c800-i91bn.json
@@ -36,7 +36,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91df.json
+++ b/cameras/annke/c800-i91df.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/c800-i91dl.json
+++ b/cameras/annke/c800-i91dl.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/c800-i91dm-28mm.json
+++ b/cameras/annke/c800-i91dm-28mm.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/c800-i91dm-40mm.json
+++ b/cameras/annke/c800-i91dm-40mm.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/cz804-i91de.json
+++ b/cameras/annke/cz804-i91de.json
@@ -37,7 +37,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"

--- a/cameras/annke/cz825x-i91bw.json
+++ b/cameras/annke/cz825x-i91bw.json
@@ -34,7 +34,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "Hi-PoE / 24VAC (max 42W)"

--- a/cameras/annke/fcd600-i51fs.json
+++ b/cameras/annke/fcd600-i51fs.json
@@ -37,7 +37,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 11.5W) / DC 12V"

--- a/cameras/annke/fcd800-i91et.json
+++ b/cameras/annke/fcd800-i91et.json
@@ -37,7 +37,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 11.5W) / DC 12V"

--- a/cameras/annke/fcd800-i91ev.json
+++ b/cameras/annke/fcd800-i91ev.json
@@ -37,7 +37,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af, max 11.5W) / DC 12V"

--- a/cameras/annke/i51dx.json
+++ b/cameras/annke/i51dx.json
@@ -33,7 +33,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/i51ex.json
+++ b/cameras/annke/i51ex.json
@@ -35,7 +35,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af, max 10.5W) / DC 12V"

--- a/cameras/annke/nc500-i81hd.json
+++ b/cameras/annke/nc500-i81hd.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/nc500-i81he.json
+++ b/cameras/annke/nc500-i81he.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af, max 6.5W) / DC 12V"

--- a/cameras/annke/nc800-i91hj.json
+++ b/cameras/annke/nc800-i91hj.json
@@ -28,7 +28,8 @@
   "field_of_view_deg": "102h",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af, Class 3) / DC 12V",

--- a/cameras/annke/ncbr800-i91dj.json
+++ b/cameras/annke/ncbr800-i91dj.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af, max 10.5W) / DC 12V"

--- a/cameras/annke/ncbr800-i91du.json
+++ b/cameras/annke/ncbr800-i91du.json
@@ -39,7 +39,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af, max 10.5W) / DC 12V"

--- a/cameras/annke/nct425-i81el.json
+++ b/cameras/annke/nct425-i81el.json
@@ -37,7 +37,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE+ (802.3at, max 24W) / DC 12V"

--- a/cameras/annke/slpr400-i81hy.json
+++ b/cameras/annke/slpr400-i81hy.json
@@ -36,7 +36,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE"

--- a/cameras/axis/m2036-le.json
+++ b/cameras/axis/m2036-le.json
@@ -42,7 +42,8 @@
   "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
   "night_vision": {
     "type": "ir",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.18
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1",

--- a/cameras/axis/p1488-le.json
+++ b/cameras/axis/p1488-le.json
@@ -40,7 +40,8 @@
   "field_of_view_deg": "114-46 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.06
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1",

--- a/cameras/bosch/nue-3702-f06.json
+++ b/cameras/bosch/nue-3702-f06.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "58.5 (H) x 31.3 (V)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.1
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1, Class 3",

--- a/cameras/bosch/nue-3703-f04.json
+++ b/cameras/bosch/nue-3703-f04.json
@@ -32,7 +32,8 @@
   },
   "field_of_view_deg": "101",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.15
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at Type 1)",

--- a/cameras/bosch/nuv-3703-f02.json
+++ b/cameras/bosch/nuv-3703-f02.json
@@ -32,7 +32,8 @@
   },
   "field_of_view_deg": "131",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.15
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at Type 1, Class 3)",

--- a/cameras/camius/iris-5mp.json
+++ b/cameras/camius/iris-5mp.json
@@ -20,7 +20,8 @@
   "field_of_view_deg": "110 (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (IEEE 802.3af) / DC 12V"

--- a/cameras/canon/vb-h47.json
+++ b/cameras/canon/vb-h47.json
@@ -23,6 +23,10 @@
     "varifocal": true
   },
   "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+  "night_vision": {
+    "type": "none",
+    "min_lux_color": 0.02
+  },
   "power": {
     "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
   },

--- a/cameras/canon/vb-m46.json
+++ b/cameras/canon/vb-m46.json
@@ -23,6 +23,10 @@
     "varifocal": true
   },
   "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+  "night_vision": {
+    "type": "none",
+    "min_lux_color": 0.02
+  },
   "power": {
     "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
   },

--- a/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
+++ b/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
@@ -25,7 +25,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.001
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/hac-hfw2249e-a-led.json
+++ b/cameras/dahua/hac-hfw2249e-a-led.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "89.5",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "video": {
     "max_fps": 30

--- a/cameras/dahua/ipc-hdw2649t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2649t-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "92",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2849h-s-prox.json
+++ b/cameras/dahua/ipc-hdw2849h-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "105",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2849t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2849t-s-pro.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "110 (2.8mm) / 93 (3.6mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],

--- a/cameras/dahua/ipc-hfw2849m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2849m-s-b-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "93 (3.6mm) / 57 (6mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0004
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw5442e-ze-s3.json
+++ b/cameras/dahua/ipc-hfw5442e-ze-s3.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "110-30h",
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hi-focus/hc-ipc-di3212dvzk-n5-o.json
+++ b/cameras/hi-focus/hc-ipc-di3212dvzk-n5-o.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/hi-focus/hc-ipc-sdq53320s.json
+++ b/cameras/hi-focus/hc-ipc-sdq53320s.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.001
   },
   "ptz": {
     "autotracking": true

--- a/cameras/hi-focus/hipc-d3022e-i2.json
+++ b/cameras/hi-focus/hipc-d3022e-i2.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.02
   },
   "power": {
     "method": "PoE"

--- a/cameras/hi-focus/hipc-d3315-dls-i2.json
+++ b/cameras/hi-focus/hipc-d3315-dls-i2.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.02
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/hi-focus/hipc-t4024-dl-i2.json
+++ b/cameras/hi-focus/hipc-t4024-dl-i2.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.02
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/hi-focus/hipc-t4404-dl-r1.json
+++ b/cameras/hi-focus/hipc-t4404-dl-r1.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/hi-focus/hipc-t4512-adls-i2.json
+++ b/cameras/hi-focus/hipc-t4512-adls-i2.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V"

--- a/cameras/hikvision/ds-2cc12d9t-a.json
+++ b/cameras/hikvision/ds-2cc12d9t-a.json
@@ -13,7 +13,8 @@
     "label": "1080p"
   },
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12 VDC / 24 VAC"

--- a/cameras/hikvision/ds-2cc12d9t-ait3ze.json
+++ b/cameras/hikvision/ds-2cc12d9t-ait3ze.json
@@ -14,7 +14,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12 VDC / 24 VAC / PoC"

--- a/cameras/hikvision/ds-2cd1327g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1327g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1347g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1347g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1367g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1367g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2025fwd-i.json
+++ b/cameras/hikvision/ds-2cd2025fwd-i.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "103h",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2027g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2027g2h-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2046g2-iu-sl.json
+++ b/cameras/hikvision/ds-2cd2046g2-iu-sl.json
@@ -57,7 +57,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd2047g2h-li.json
+++ b/cameras/hikvision/ds-2cd2047g2h-li.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2066g2-iu-sl.json
+++ b/cameras/hikvision/ds-2cd2066g2-iu-sl.json
@@ -57,7 +57,8 @@
   "field_of_view_deg": "105 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd2067g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2067g2h-liu.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g2h-li.json
+++ b/cameras/hikvision/ds-2cd2087g2h-li.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g3-li2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2087g3-li2uy-sl.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd2147g2h-li-su.json
+++ b/cameras/hikvision/ds-2cd2147g2h-li-su.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "111 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2147g2h-liu-eu.json
+++ b/cameras/hikvision/ds-2cd2147g2h-liu-eu.json
@@ -34,7 +34,8 @@
   "field_of_view_deg": "106 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd2166g2-isu.json
+++ b/cameras/hikvision/ds-2cd2166g2-isu.json
@@ -57,7 +57,8 @@
   "field_of_view_deg": "105 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd2167g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2167g2h-liu.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2185fwd-is.json
+++ b/cameras/hikvision/ds-2cd2185fwd-is.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "103h",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2187g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2187g2h-liu.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd23166g3-i2uy.json
+++ b/cameras/hikvision/ds-2cd23166g3-i2uy.json
@@ -63,7 +63,8 @@
   "field_of_view_deg": "94.5 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd2347g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2347g2h-liu.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "111 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2387g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2387g2h-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd2566g2-is.json
+++ b/cameras/hikvision/ds-2cd2566g2-is.json
@@ -57,7 +57,8 @@
   "field_of_view_deg": "105 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd2686g2-izs.json
+++ b/cameras/hikvision/ds-2cd2686g2-izs.json
@@ -57,7 +57,8 @@
   "field_of_view_deg": "108-46 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2cd2t47g2-l-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g2-l-sl.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g2-lse.json
+++ b/cameras/hikvision/ds-2cd2t47g2-lse.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t47g2h-li.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g3-lis2uy-sl.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g3-liy.json
+++ b/cameras/hikvision/ds-2cd2t47g3-liy.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t87g3-li.json
+++ b/cameras/hikvision/ds-2cd2t87g3-li.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "102 horizontal (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd3056g2-is.json
+++ b/cameras/hikvision/ds-2cd3056g2-is.json
@@ -62,7 +62,8 @@
   "field_of_view_deg": "98 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd3156g2-is-u.json
+++ b/cameras/hikvision/ds-2cd3156g2-is-u.json
@@ -62,7 +62,8 @@
   "field_of_view_deg": "98 horizontal (2.8mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd3746g2-izs.json
+++ b/cameras/hikvision/ds-2cd3746g2-izs.json
@@ -62,7 +62,8 @@
   "field_of_view_deg": "107.6-32.9 horizontal (2.7-13.5mm), 28.7-10.5 (7-35mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2cd3766g2t-izs-y.json
+++ b/cameras/hikvision/ds-2cd3766g2t-izs-y.json
@@ -62,7 +62,8 @@
   "field_of_view_deg": "106-35.6 horizontal (2.7-13.5mm), 34.4-12.5 (7-35mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2ce16d9t-airazh.json
+++ b/cameras/hikvision/ds-2ce16d9t-airazh.json
@@ -14,7 +14,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 120
+    "range_m": 120,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12 VDC / 24 VAC (heater)"

--- a/cameras/hikvision/ds-2ce19u8t-ait3z.json
+++ b/cameras/hikvision/ds-2ce19u8t-ait3z.json
@@ -14,7 +14,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12 VDC / 24 VAC"

--- a/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.json
+++ b/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.json
@@ -62,7 +62,8 @@
   "field_of_view_deg": "114.5-41.8 horizontal (2.8-12mm), 42.5-15.1 (8-32mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE+ (IEEE 802.3at, Class 4) / DC 12V",

--- a/cameras/i-pro/wv-s2236l.json
+++ b/cameras/i-pro/wv-s2236l.json
@@ -31,7 +31,8 @@
   "field_of_view_deg": "100-31 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/kedacom/ipc2231-fn-s.json
+++ b/cameras/kedacom/ipc2231-fn-s.json
@@ -10,7 +10,7 @@
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": { "focal_length_mm": "2.8-12 (varifocal); 2.2 / 2.0 (fixed)", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "108-35 (varifocal); 126 (2.2mm); 151 (2mm)",
-  "night_vision": { "type": "none" },
+  "night_vision": { "type": "none", "min_lux_color": 0.001 },
   "power": { "method": "PoE (IEEE802.3af) / 24V AC / 12V DC", "consumption_w": 11, "voltage": "24V AC / 12V DC" },
   "storage": { "onboard": true, "max_microsd_gb": 128 },
   "protocols": ["onvif", "rtsp", "http"],

--- a/cameras/kedacom/ipc2440-hn-sir30.json
+++ b/cameras/kedacom/ipc2440-hn-sir30.json
@@ -50,7 +50,8 @@
   "field_of_view_deg": "53.4-101.2",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.05
   },
   "power": {
     "method": "PoE (IEEE802.3af) / 12V DC",

--- a/cameras/kedacom/lc2110-an.json
+++ b/cameras/kedacom/lc2110-an.json
@@ -18,7 +18,7 @@
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "2.8/3.6/6/8/12", "varifocal": false },
   "field_of_view_deg": "23-96.3",
-  "night_vision": { "type": "ir", "range_m": 30 },
+  "night_vision": { "type": "ir", "range_m": 30, "min_lux_color": 0.01 },
   "power": { "method": "PoE (IEEE802.3af) / 12V DC", "consumption_w": 10, "voltage": "12V DC", "poe_class": 3 },
   "storage": { "onboard": true, "max_microsd_gb": 128 },
   "protocols": ["onvif", "rtsp", "http"],

--- a/cameras/lorex/e871ab.json
+++ b/cameras/lorex/e871ab.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "180 panoramic",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"

--- a/cameras/lorex/e872sb.json
+++ b/cameras/lorex/e872sb.json
@@ -24,7 +24,8 @@
   "field_of_view_deg": "180 panoramic",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"

--- a/cameras/lorex/x5-bullet.json
+++ b/cameras/lorex/x5-bullet.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.8 diagonal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "12V DC / PoE (IEEE 802.3af); max 7.1W (DC) / 8.9W (PoE)"

--- a/cameras/lorex/x5-turret.json
+++ b/cameras/lorex/x5-turret.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.5 diagonal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "12V DC / PoE (IEEE 802.3af); max 8W (DC) / 10.5W (PoE)"

--- a/cameras/lts/lts-ptzip688x36.json
+++ b/cameras/lts/lts-ptzip688x36.json
@@ -35,7 +35,8 @@
     "varifocal": true
   },
   "night_vision": {
-    "type": "ir"
+    "type": "ir",
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -703,8 +703,8 @@ camius-boltx-4k,Camius,Boltx 4K,bullet,4K UHD,8,"1/2.8"" CMOS",,ir,IP67,,false,2
 camius-boltx-5mp,Camius,Boltx 5MP,bullet,5MP Super HD,5,"1/2.7"" CMOS",,ir,IP67,,false,2022
 camius-iris-4k,Camius,Iris 4K,dome,4K UHD,8,"1/2.8"" CMOS",,ir,IP67,,false,2023
 camius-iris-5mp,Camius,IRIS528R,turret,2K (2880x1620),5,"1/2.7"" Progressive CMOS",110 (2.8mm),hybrid,IP67,,false,2022
-canon-vb-h47,Canon,VB-H47,ptz,1080p/2MP,2,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),,,,true,2022
-canon-vb-m46,Canon,VB-M46,ptz,1.3MP,1.3,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),,,,true,2022
+canon-vb-h47,Canon,VB-H47,ptz,1080p/2MP,2,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),none,,,true,2022
+canon-vb-m46,Canon,VB-M46,ptz,1.3MP,1.3,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),none,,,true,2022
 canon-vb-r13ve,Canon,VB-R13VE,ptz,1080p HD,2,"1/2.3"" CMOS",64.5-2.2 horizontal,none,IP66,IK10,false,2022
 canon-vb-s805d-mk2,Canon,VB-S805D Mk II,dome,1080p HD,2,"1/2.9"" CMOS",123 horizontal,none,IP40,,false,2022
 costar-av02cid-200,Costar,AV02CID-200,dome,1080p,2.1,,,ir,,,true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -2226,7 +2226,8 @@
     "field_of_view_deg": "109 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (IEEE 802.3af) / 12V DC"
@@ -6033,7 +6034,8 @@
     "field_of_view_deg": "95 horizontal",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (IEEE 802.3af) or 12V DC"
@@ -33886,7 +33888,8 @@
     "field_of_view_deg": "104 horizontal (123 diagonal)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34073,7 +34076,8 @@
     "field_of_view_deg": "102 horizontal (134 diagonal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -34179,7 +34183,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34387,7 +34392,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34681,7 +34687,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34783,7 +34790,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34888,7 +34896,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34993,7 +35002,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -35204,7 +35214,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35308,7 +35319,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35411,7 +35423,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35515,7 +35528,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35818,7 +35832,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"
@@ -36019,7 +36034,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "Hi-PoE / 24VAC (max 42W)"
@@ -36122,7 +36138,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36222,7 +36239,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36323,7 +36341,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36420,7 +36439,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -36517,7 +36537,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37288,7 +37309,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -37390,7 +37412,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -37481,7 +37504,8 @@
     "field_of_view_deg": "102h",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -37587,7 +37611,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37689,7 +37714,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37789,7 +37815,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (802.3at, max 24W) / DC 12V"
@@ -37889,7 +37916,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE"
@@ -41824,7 +41852,8 @@
     "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.18
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1",
@@ -44084,7 +44113,8 @@
     "field_of_view_deg": "114-46 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.06
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1",
@@ -64921,7 +64951,8 @@
     },
     "field_of_view_deg": "58.5 (H) x 31.3 (V)",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.1
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1, Class 3",
@@ -65145,7 +65176,8 @@
     },
     "field_of_view_deg": "101",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.15
     },
     "power": {
       "method": "PoE (IEEE 802.3af/802.3at Type 1)",
@@ -65818,7 +65850,8 @@
     },
     "field_of_view_deg": "131",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.15
     },
     "power": {
       "method": "PoE (IEEE 802.3af/802.3at Type 1, Class 3)",
@@ -66537,7 +66570,8 @@
     "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (IEEE 802.3af) / DC 12V"
@@ -66632,6 +66666,10 @@
       "varifocal": true
     },
     "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.02
+    },
     "power": {
       "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
     },
@@ -66732,6 +66770,10 @@
       "varifocal": true
     },
     "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.02
+    },
     "power": {
       "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
     },
@@ -70558,7 +70600,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "ptz": {
       "autotracking": true
@@ -71340,7 +71383,8 @@
     "field_of_view_deg": "89.5",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "video": {
       "max_fps": 30
@@ -75659,7 +75703,8 @@
     "field_of_view_deg": "92",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -76111,7 +76156,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -76315,7 +76361,8 @@
     "field_of_view_deg": "110 (2.8mm) / 93 (3.6mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "video": {
       "codecs": [
@@ -81642,7 +81689,8 @@
     "field_of_view_deg": "93 (3.6mm) / 57 (6mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0004
     },
     "video": {
       "codecs": [
@@ -84242,7 +84290,8 @@
     "field_of_view_deg": "110-30h",
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -107253,7 +107302,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -108268,7 +108318,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "ptz": {
       "autotracking": true
@@ -109996,7 +110047,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE"
@@ -110608,7 +110660,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -110952,7 +111005,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -111122,7 +111176,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -111378,7 +111433,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V"
@@ -112496,7 +112552,8 @@
       "label": "1080p"
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC"
@@ -112553,7 +112610,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC / PoC"
@@ -115509,7 +115567,8 @@
     "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -115807,7 +115866,8 @@
     "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -115906,7 +115966,8 @@
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -116852,7 +116913,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -117123,7 +117185,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -117809,7 +117872,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -118366,7 +118430,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -118869,7 +118934,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -118966,7 +119032,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -120164,7 +120231,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -120440,7 +120508,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -121898,7 +121967,8 @@
     "field_of_view_deg": "111 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -122098,7 +122168,8 @@
     "field_of_view_deg": "106 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -122485,7 +122556,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -122684,7 +122756,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -123039,7 +123112,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -123624,7 +123698,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -123844,7 +123919,8 @@
     "field_of_view_deg": "94.5 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -125346,7 +125422,8 @@
     "field_of_view_deg": "111 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -127084,7 +127161,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -128878,7 +128956,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -130462,7 +130541,8 @@
     "field_of_view_deg": "108-46 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -136032,7 +136112,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136121,7 +136202,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -136296,7 +136378,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136669,7 +136752,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -136860,7 +136944,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -138625,7 +138710,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -139037,7 +139123,8 @@
     "field_of_view_deg": "98 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -139381,7 +139468,8 @@
     "field_of_view_deg": "98 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -140073,7 +140161,8 @@
     "field_of_view_deg": "107.6-32.9 horizontal (2.7-13.5mm), 28.7-10.5 (7-35mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -140210,7 +140299,8 @@
     "field_of_view_deg": "106-35.6 horizontal (2.7-13.5mm), 34.4-12.5 (7-35mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -141678,7 +141768,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 120
+      "range_m": 120,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC (heater)"
@@ -142419,7 +142510,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC"
@@ -148261,7 +148353,8 @@
     "field_of_view_deg": "114.5-41.8 horizontal (2.8-12mm), 42.5-15.1 (8-32mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (IEEE 802.3at, Class 4) / DC 12V",
@@ -150733,7 +150826,8 @@
     "field_of_view_deg": "100-31 horizontal",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159504,7 +159598,8 @@
     },
     "field_of_view_deg": "108-35 (varifocal); 126 (2.2mm); 151 (2mm)",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 24V AC / 12V DC",
@@ -161308,7 +161403,8 @@
     "field_of_view_deg": "53.4-101.2",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.05
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 12V DC",
@@ -163084,7 +163180,8 @@
     "field_of_view_deg": "23-96.3",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 12V DC",
@@ -164238,7 +164335,8 @@
     "field_of_view_deg": "180 panoramic",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"
@@ -164304,7 +164402,8 @@
     "field_of_view_deg": "180 panoramic",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"
@@ -167009,7 +167108,8 @@
     "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.8 diagonal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12V DC / PoE (IEEE 802.3af); max 7.1W (DC) / 8.9W (PoE)"
@@ -167110,7 +167210,8 @@
     "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.5 diagonal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12V DC / PoE (IEEE 802.3af); max 8W (DC) / 10.5W (PoE)"
@@ -167575,7 +167676,8 @@
       "varifocal": true
     },
     "night_vision": {
-      "type": "ir"
+      "type": "ir",
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -2226,7 +2226,8 @@
     "field_of_view_deg": "109 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (IEEE 802.3af) / 12V DC"
@@ -6033,7 +6034,8 @@
     "field_of_view_deg": "95 horizontal",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (IEEE 802.3af) or 12V DC"
@@ -33886,7 +33888,8 @@
     "field_of_view_deg": "104 horizontal (123 diagonal)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34073,7 +34076,8 @@
     "field_of_view_deg": "102 horizontal (134 diagonal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -34179,7 +34183,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34387,7 +34392,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -34681,7 +34687,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34783,7 +34790,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34888,7 +34896,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -34993,7 +35002,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -35204,7 +35214,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35308,7 +35319,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35411,7 +35423,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35515,7 +35528,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -35818,7 +35832,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, Class 3, max 12.9W) / DC 12V"
@@ -36019,7 +36034,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "Hi-PoE / 24VAC (max 42W)"
@@ -36122,7 +36138,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36222,7 +36239,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36323,7 +36341,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af, max 11.5W) / DC 12V"
@@ -36420,7 +36439,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -36517,7 +36537,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37288,7 +37309,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -37390,7 +37412,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af, max 6.5W) / DC 12V"
@@ -37481,7 +37504,8 @@
     "field_of_view_deg": "102h",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -37587,7 +37611,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37689,7 +37714,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af, max 10.5W) / DC 12V"
@@ -37789,7 +37815,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (802.3at, max 24W) / DC 12V"
@@ -37889,7 +37916,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE"
@@ -41824,7 +41852,8 @@
     "field_of_view_deg": "130 H / 71 V (16:9); 109 H / 81 V (4:3)",
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.18
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1",
@@ -44084,7 +44113,8 @@
     "field_of_view_deg": "114-46 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.06
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1",
@@ -64921,7 +64951,8 @@
     },
     "field_of_view_deg": "58.5 (H) x 31.3 (V)",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.1
     },
     "power": {
       "method": "PoE IEEE 802.3af/802.3at Type 1, Class 3",
@@ -65145,7 +65176,8 @@
     },
     "field_of_view_deg": "101",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.15
     },
     "power": {
       "method": "PoE (IEEE 802.3af/802.3at Type 1)",
@@ -65818,7 +65850,8 @@
     },
     "field_of_view_deg": "131",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.15
     },
     "power": {
       "method": "PoE (IEEE 802.3af/802.3at Type 1, Class 3)",
@@ -66537,7 +66570,8 @@
     "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (IEEE 802.3af) / DC 12V"
@@ -66632,6 +66666,10 @@
       "varifocal": true
     },
     "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.02
+    },
     "power": {
       "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
     },
@@ -66732,6 +66770,10 @@
       "varifocal": true
     },
     "field_of_view_deg": "62.4-3.3 horizontal (20x optical zoom)",
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.02
+    },
     "power": {
       "method": "PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18)"
     },
@@ -70558,7 +70600,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "ptz": {
       "autotracking": true
@@ -71340,7 +71383,8 @@
     "field_of_view_deg": "89.5",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "video": {
       "max_fps": 30
@@ -75659,7 +75703,8 @@
     "field_of_view_deg": "92",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -76111,7 +76156,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -76315,7 +76361,8 @@
     "field_of_view_deg": "110 (2.8mm) / 93 (3.6mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "video": {
       "codecs": [
@@ -81642,7 +81689,8 @@
     "field_of_view_deg": "93 (3.6mm) / 57 (6mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0004
     },
     "video": {
       "codecs": [
@@ -84242,7 +84290,8 @@
     "field_of_view_deg": "110-30h",
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -107253,7 +107302,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -108268,7 +108318,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "ptz": {
       "autotracking": true
@@ -109996,7 +110047,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE"
@@ -110608,7 +110660,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -110952,7 +111005,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.02
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -111122,7 +111176,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -111378,7 +111433,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V"
@@ -112496,7 +112552,8 @@
       "label": "1080p"
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC"
@@ -112553,7 +112610,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC / PoC"
@@ -115509,7 +115567,8 @@
     "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -115807,7 +115866,8 @@
     "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -115906,7 +115966,8 @@
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -116852,7 +116913,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -117123,7 +117185,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -117809,7 +117872,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -118366,7 +118430,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -118869,7 +118934,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -118966,7 +119032,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -120164,7 +120231,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -120440,7 +120508,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -121898,7 +121967,8 @@
     "field_of_view_deg": "111 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -122098,7 +122168,8 @@
     "field_of_view_deg": "106 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -122485,7 +122556,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -122684,7 +122756,8 @@
     "field_of_view_deg": "103 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -123039,7 +123112,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -123624,7 +123698,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -123844,7 +123919,8 @@
     "field_of_view_deg": "94.5 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -125346,7 +125422,8 @@
     "field_of_view_deg": "111 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -127084,7 +127161,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -128878,7 +128956,8 @@
     "field_of_view_deg": "105 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -130462,7 +130541,8 @@
     "field_of_view_deg": "108-46 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -136032,7 +136112,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136121,7 +136202,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -136296,7 +136378,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -136669,7 +136752,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -136860,7 +136944,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -138625,7 +138710,8 @@
     "field_of_view_deg": "102 horizontal (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -139037,7 +139123,8 @@
     "field_of_view_deg": "98 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -139381,7 +139468,8 @@
     "field_of_view_deg": "98 horizontal (2.8mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3af, Class 3) / DC 12V",
@@ -140073,7 +140161,8 @@
     "field_of_view_deg": "107.6-32.9 horizontal (2.7-13.5mm), 28.7-10.5 (7-35mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -140210,7 +140299,8 @@
     "field_of_view_deg": "106-35.6 horizontal (2.7-13.5mm), 34.4-12.5 (7-35mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (IEEE 802.3at, Class 4) / DC 12V",
@@ -141678,7 +141768,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 120
+      "range_m": 120,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC (heater)"
@@ -142419,7 +142510,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12 VDC / 24 VAC"
@@ -148261,7 +148353,8 @@
     "field_of_view_deg": "114.5-41.8 horizontal (2.8-12mm), 42.5-15.1 (8-32mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (IEEE 802.3at, Class 4) / DC 12V",
@@ -150733,7 +150826,8 @@
     "field_of_view_deg": "100-31 horizontal",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159504,7 +159598,8 @@
     },
     "field_of_view_deg": "108-35 (varifocal); 126 (2.2mm); 151 (2mm)",
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 24V AC / 12V DC",
@@ -161308,7 +161403,8 @@
     "field_of_view_deg": "53.4-101.2",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.05
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 12V DC",
@@ -163084,7 +163180,8 @@
     "field_of_view_deg": "23-96.3",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (IEEE802.3af) / 12V DC",
@@ -164238,7 +164335,8 @@
     "field_of_view_deg": "180 panoramic",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"
@@ -164304,7 +164402,8 @@
     "field_of_view_deg": "180 panoramic",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE)"
@@ -167009,7 +167108,8 @@
     "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.8 diagonal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12V DC / PoE (IEEE 802.3af); max 7.1W (DC) / 8.9W (PoE)"
@@ -167110,7 +167210,8 @@
     "field_of_view_deg": "109.4 horizontal / 59.5 vertical / 113.5 diagonal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12V DC / PoE (IEEE 802.3af); max 8W (DC) / 10.5W (PoE)"
@@ -167575,7 +167676,8 @@
       "varifocal": true
     },
     "night_vision": {
-      "type": "ir"
+      "type": "ir",
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true

--- a/docs/cameras/abus/ipcb44510a.md
+++ b/docs/cameras/abus/ipcb44510a.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.5" Progressive Scan CMOS |
 | Lens | 1× 2.8mm |
 | Field of view | 109 horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.008 lux color |
 | Power | PoE (IEEE 802.3af) / 12V DC |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/abus/ipcs64511b.md
+++ b/docs/cameras/abus/ipcs64511b.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 4mm F1.0 |
 | Field of view | 95 horizontal° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0005 lux color |
 | Power | PoE (IEEE 802.3af) or 12V DC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/annke/ac400-i81hq.md
+++ b/docs/cameras/annke/ac400-i81hq.md
@@ -12,7 +12,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm |
 | Field of view | 104 horizontal (123 diagonal)° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/ac800.md
+++ b/docs/cameras/annke/ac800.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" BSI CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 102 horizontal (134 diagonal)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.003 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c1200-i91dd.md
+++ b/docs/cameras/annke/c1200-i91dd.md
@@ -11,7 +11,7 @@
 | Resolution | 12MP (12MP, 4096×3072) |
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.01 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c1200d-i91dg.md
+++ b/docs/cameras/annke/c1200d-i91dg.md
@@ -11,7 +11,7 @@
 | Resolution | 12MP (12MP, 4096×3072) |
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.01 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91bd.md
+++ b/docs/cameras/annke/c800-i91bd.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.5" Progressive Scan CMOS |
 | Lens | 1× 2.8mm F1.2 |
 | Field of view | 102 horizontal / 123 diagonal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 128GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91bl.md
+++ b/docs/cameras/annke/c800-i91bl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.5" Progressive Scan CMOS |
 | Lens | 1× 2.8mm F2.0 |
 | Field of view | 102 horizontal / 123 diagonal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91bm.md
+++ b/docs/cameras/annke/c800-i91bm.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.5" Progressive Scan CMOS |
 | Lens | 1× 2.8mm F2.0 |
 | Field of view | 102 horizontal / 123 diagonal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91bn.md
+++ b/docs/cameras/annke/c800-i91bn.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.5" Progressive Scan CMOS |
 | Lens | 1× 2.8mm F2.0 |
 | Field of view | 102 horizontal / 123 diagonal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91df.md
+++ b/docs/cameras/annke/c800-i91df.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 4 (fixed)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91dl.md
+++ b/docs/cameras/annke/c800-i91dl.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 4 (fixed)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91dm-28mm.md
+++ b/docs/cameras/annke/c800-i91dm-28mm.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 105 horizontal / 127 diagonal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/c800-i91dm-40mm.md
+++ b/docs/cameras/annke/c800-i91dm-40mm.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 4.0mm F1.6 |
 | Field of view | 78 horizontal / 96 diagonal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/cz804-i91de.md
+++ b/docs/cameras/annke/cz804-i91de.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8-12 (4x optical zoom)mm F1.6 |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.005 lux color |
 | Power | PoE (802.3af, Class 3, max 12.9W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/cz825x-i91bw.md
+++ b/docs/cameras/annke/cz825x-i91bw.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 5.9-147.5 (25x optical zoom, 16x digital)mm F1.5 |
-| Night vision | hybrid (200m) |
+| Night vision | hybrid (200m), 0.001 lux color |
 | Power | Hi-PoE / 24VAC (max 42W) |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/fcd600-i51fs.md
+++ b/docs/cameras/annke/fcd600-i51fs.md
@@ -11,7 +11,7 @@
 | Resolution | 6MP panoramic (3632x1632) (6MP, 3632×1632) |
 | Sensor | 2x 1/2.5" Progressive Scan CMOS |
 | Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 11.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/fcd800-i91et.md
+++ b/docs/cameras/annke/fcd800-i91et.md
@@ -11,7 +11,7 @@
 | Resolution | 4096x1860 panoramic (8MP, 4096×1860) |
 | Sensor | 2x 1/2.4" Progressive Scan CMOS |
 | Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 11.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/fcd800-i91ev.md
+++ b/docs/cameras/annke/fcd800-i91ev.md
@@ -11,7 +11,7 @@
 | Resolution | 4096x1860 panoramic (8MP, 4096×1860) |
 | Sensor | 2x 1/2.4" Progressive Scan CMOS |
 | Lens | 2× 2.8 (fixed, dual lens)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af, max 11.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/i51dx.md
+++ b/docs/cameras/annke/i51dx.md
@@ -11,7 +11,7 @@
 | Resolution | 6MP panoramic (3632x1632) (6MP, 3632×1632) |
 | Sensor | 2x 1/2.5" Progressive Scan CMOS |
 | Lens | 2× 2.8 (fixed, dual lens)mm F1.2 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/i51ex.md
+++ b/docs/cameras/annke/i51ex.md
@@ -11,7 +11,7 @@
 | Resolution | 3K (3072x1728) (5MP, 3072×1728) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.01 lux color |
 | Power | PoE (802.3af, max 10.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/nc500-i81hd.md
+++ b/docs/cameras/annke/nc500-i81hd.md
@@ -11,7 +11,7 @@
 | Resolution | 3K (3072x1728) (5MP, 3072×1728) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.001 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/nc500-i81he.md
+++ b/docs/cameras/annke/nc500-i81he.md
@@ -11,7 +11,7 @@
 | Resolution | 3K (3072x1728) (5MP, 3072×1728) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.001 lux color |
 | Power | PoE (802.3af, max 6.5W) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/nc800-i91hj.md
+++ b/docs/cameras/annke/nc800-i91hj.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" BSI CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 102h° |
-| Night vision | color (40m) |
+| Night vision | color (40m), 0.0005 lux color |
 | Power | PoE (802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/ncbr800-i91dj.md
+++ b/docs/cameras/annke/ncbr800-i91dj.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0008 lux color |
 | Power | PoE (802.3af, max 10.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/ncbr800-i91du.md
+++ b/docs/cameras/annke/ncbr800-i91du.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0008 lux color |
 | Power | PoE (802.3af, max 10.5W) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/nct425-i81el.md
+++ b/docs/cameras/annke/nct425-i81el.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP per channel (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/3" (fixed bullet) + 1/2.8" (PTZ) Progressive Scan CMOS |
 | Lens | 2× bullet 2.8 (F1.0) + PTZ 4.8-120 (25x optical zoom)mm |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.0005 lux color |
 | Power | PoE+ (802.3at, max 24W) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/annke/slpr400-i81hy.md
+++ b/docs/cameras/annke/slpr400-i81hy.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.7-13.5 (5x optical zoom)mm F1.4 |
-| Night vision | ir (60m) |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE |
 | Storage | NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/axis/m2036-le.md
+++ b/docs/cameras/axis/m2036-le.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" progressive scan RGB CMOS |
 | Lens | 1× 2.4mm F2.1 |
 | Field of view | 130 H / 71 V (16:9); 109 H / 81 V (4:3)° |
-| Night vision | ir (20m) |
+| Night vision | ir (20m), 0.18 lux color |
 | Power | PoE IEEE 802.3af/802.3at Type 1 |
 | Storage | NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/axis/p1488-le.md
+++ b/docs/cameras/axis/p1488-le.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 5.9-13.8 (2.35x optical zoom)mm |
 | Field of view | 114-46 horizontal° |
-| Night vision | ir (50m) |
+| Night vision | ir (50m), 0.06 lux color |
 | Power | PoE IEEE 802.3af/802.3at Type 1 |
 | Storage | NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/bosch/nue-3702-f06.md
+++ b/docs/cameras/bosch/nue-3702-f06.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8 inch CMOS |
 | Lens | 1× 6mm F1.9 |
 | Field of view | 58.5 (H) x 31.3 (V)° |
-| Night vision | none |
+| Night vision | none, 0.1 lux color |
 | Power | PoE IEEE 802.3af/802.3at Type 1, Class 3 |
 | Storage | microSD ≤ 2000GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/bosch/nue-3703-f04.md
+++ b/docs/cameras/bosch/nue-3703-f04.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7 inch CMOS |
 | Lens | 1× 3.2mm f/1.6 |
 | Field of view | 101° |
-| Night vision | none |
+| Night vision | none, 0.15 lux color |
 | Power | PoE (IEEE 802.3af/802.3at Type 1) |
 | Storage | NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/bosch/nuv-3703-f02.md
+++ b/docs/cameras/bosch/nuv-3703-f02.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7-inch CMOS |
 | Lens | 1× 2.49mm f1.7 |
 | Field of view | 131° |
-| Night vision | none |
+| Night vision | none, 0.15 lux color |
 | Power | PoE (IEEE 802.3af/802.3at Type 1, Class 3) |
 | Storage | microSD ≤ 2048GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/camius/iris-5mp.md
+++ b/docs/cameras/camius/iris-5mp.md
@@ -11,7 +11,7 @@
 | Resolution | 2K (2880x1620) (5MP, 2880×1620) |
 | Sensor | 1/2.7" Progressive CMOS |
 | Field of view | 110 (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (IEEE 802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/canon/vb-h47.md
+++ b/docs/cameras/canon/vb-h47.md
@@ -10,6 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.7-94mm F1.6-3.5 |
 | Field of view | 62.4-3.3 horizontal (20x optical zoom)° |
+| Night vision | none, 0.02 lux color |
 | Power | PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18) |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/canon/vb-m46.md
+++ b/docs/cameras/canon/vb-m46.md
@@ -10,6 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.7-94mm F1.6-3.5 |
 | Field of view | 62.4-3.3 horizontal (20x optical zoom)° |
+| Night vision | none, 0.02 lux color |
 | Power | PoE (IEEE 802.3at Type1) / 12V DC / AC adapter (PA-V18) |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.md
+++ b/docs/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.md
@@ -10,7 +10,7 @@
 | Sensor | 2x 1/2.8" CMOS (panoramic + PTZ) |
 | Lens | 2× panoramic: 2.8 fixed / PTZ: 4.8-120 (25x optical)mm F1.0 (panoramic) / F1.6-3.6 (PTZ) |
 | Field of view | 180 horizontal (panoramic) / 55.8-2.4 (PTZ)° |
-| Night vision | hybrid (150m) |
+| Night vision | hybrid (150m), 0.001 lux color |
 | Power | DC 36V/2.23A (±25%) |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/hac-hfw2249e-a-led.md
+++ b/docs/cameras/dahua/hac-hfw2249e-a-led.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 3.6 (fixed)mm F1.0 |
 | Field of view | 89.5° |
-| Night vision | color (40m) |
+| Night vision | color (40m), 0.001 lux color |
 | Power | 12 VDC HDCVI coaxial |
 | Storage | NVR |
 | Protocols | hdcvi |

--- a/docs/cameras/dahua/ipc-hdw2649t-s-pro.md
+++ b/docs/cameras/dahua/ipc-hdw2649t-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8/3.6mm F1.0 |
 | Field of view | 92° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2849h-s-prox.md
+++ b/docs/cameras/dahua/ipc-hdw2849h-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 105° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2849t-s-pro.md
+++ b/docs/cameras/dahua/ipc-hdw2849t-s-pro.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm F1.0 |
 | Field of view | 110 (2.8mm) / 93 (3.6mm)° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hfw2849m-s-b-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2849m-s-b-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 3.6/6mm F1.0 |
 | Field of view | 93 (3.6mm) / 57 (6mm)° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0004 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw5442e-ze-s3.md
+++ b/docs/cameras/dahua/ipc-hfw5442e-ze-s3.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 110-30h° |
-| Night vision | ir (60m) |
+| Night vision | ir (60m), 0.0003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hc-ipc-di3212dvzk-n5-o.md
+++ b/docs/cameras/hi-focus/hc-ipc-di3212dvzk-n5-o.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Sony Starvis CMOS |
 | Lens | 1× 2.7-13.5mm |
 | Field of view | 98.3-32.2° |
-| Night vision | ir (50m) |
+| Night vision | ir (50m), 0.002 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hc-ipc-sdq53320s.md
+++ b/docs/cameras/hi-focus/hc-ipc-sdq53320s.md
@@ -9,7 +9,7 @@
 | Resolution | 2MP (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.5-148.5mm |
-| Night vision | ir (150m) |
+| Night vision | ir (150m), 0.001 lux color |
 | Power | DC / PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hipc-d3022e-i2.md
+++ b/docs/cameras/hi-focus/hipc-d3022e-i2.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Sony Starvis CMOS |
 | Lens | 1× 4 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.02 lux color |
 | Power | PoE |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hipc-d3315-dls-i2.md
+++ b/docs/cameras/hi-focus/hipc-d3315-dls-i2.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" Sony CMOS |
 | Lens | 1× 2.8 (fixed)mm |
 | Field of view | 102.9° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.02 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hipc-t4024-dl-i2.md
+++ b/docs/cameras/hi-focus/hipc-t4024-dl-i2.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 4 (fixed)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.02 lux color |
 | Power | PoE / DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hipc-t4404-dl-r1.md
+++ b/docs/cameras/hi-focus/hipc-t4404-dl-r1.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/3" CMOS |
 | Lens | 1× 4 / 6 (fixed)mm |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.001 lux color |
 | Power | PoE / DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hi-focus/hipc-t4512-adls-i2.md
+++ b/docs/cameras/hi-focus/hipc-t4512-adls-i2.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/3" CMOS |
 | Lens | 1× 4 / 6 (fixed)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cc12d9t-a.md
+++ b/docs/cameras/hikvision/ds-2cc12d9t-a.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/3" 2MP ultra-low-light CMOS |
 | Lens | 1× |
-| Night vision | none |
+| Night vision | none, 0.003 lux color |
 | Power | 12 VDC / 24 VAC |
 | Storage | NVR |
 | Two-way audio | No |

--- a/docs/cameras/hikvision/ds-2cc12d9t-ait3ze.md
+++ b/docs/cameras/hikvision/ds-2cc12d9t-ait3ze.md
@@ -10,7 +10,7 @@
 | Sensor | 2MP ultra-low-light CMOS |
 | Lens | 1× 2.8-12 (motorized)mm |
 | Field of view | 32.1-98° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | 12 VDC / 24 VAC / PoC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2cd1327g2h-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1327g2h-liuf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 106 (2.8mm)/88 (4mm) horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1347g2h-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1347g2h-liuf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 96 (2.8mm)/80 (4mm) horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1367g2h-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1367g2h-liuf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 115 (2.8mm)/94 (4mm) horizontal° |
-| Night vision | hybrid (20m) |
+| Night vision | hybrid (20m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2025fwd-i.md
+++ b/docs/cameras/hikvision/ds-2cd2025fwd-i.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 1080p HD (2MP) |
 | Field of view | 103h° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2027g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2027g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 103 horizontal (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2046g2-iu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2046g2-iu-sl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.4 |
 | Field of view | 103 horizontal (2.8mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2047g2h-li.md
+++ b/docs/cameras/hikvision/ds-2cd2047g2h-li.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 103 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2066g2-iu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2066g2-iu-sl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.6 |
 | Field of view | 105 horizontal (2.8mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2067g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2067g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.7" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 103 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2087g2h-li.md
+++ b/docs/cameras/hikvision/ds-2cd2087g2h-li.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2087g3-li2uy-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2087g3-li2uy-sl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2147g2h-li-su.md
+++ b/docs/cameras/hikvision/ds-2cd2147g2h-li-su.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.0 |
 | Field of view | 111 horizontal (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2147g2h-liu-eu.md
+++ b/docs/cameras/hikvision/ds-2cd2147g2h-liu-eu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed super-confocal)mm F1.0 |
 | Field of view | 106 horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2166g2-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2166g2-isu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.6 |
 | Field of view | 105 horizontal (2.8mm)° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2167g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2167g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.7" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 103 horizontal (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2185fwd-is.md
+++ b/docs/cameras/hikvision/ds-2cd2185fwd-is.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP) |
 | Field of view | 103h° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2187g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2187g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd23166g3-i2uy.md
+++ b/docs/cameras/hikvision/ds-2cd23166g3-i2uy.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.6 |
 | Field of view | 94.5 horizontal (2.8mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2347g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2347g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.0 |
 | Field of view | 111 horizontal (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2387g2h-liu.md
+++ b/docs/cameras/hikvision/ds-2cd2387g2h-liu.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8 / 4 (fixed super-confocal)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2566g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2566g2-is.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed, M12)mm F1.6 |
 | Field of view | 105 horizontal (2.8mm)° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2686g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2686g2-izs.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12 (motorized)mm F1.4 |
 | Field of view | 108-46 horizontal° |
-| Night vision | ir (60m) |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (IEEE 802.3at, Class 4) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd2t47g2-l-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g2-l-sl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 / 4 / 6 / 8 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | color (60m) |
+| Night vision | color (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t47g2-lse.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g2-lse.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | color (60m) |
+| Night vision | color (60m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t47g2h-li.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g2h-li.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t47g3-lis2uy-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g3-lis2uy-sl.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0001 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t47g3-liy.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g3-liy.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t87g3-li.md
+++ b/docs/cameras/hikvision/ds-2cd2t87g3-li.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.0 |
 | Field of view | 102 horizontal (2.8mm)° |
-| Night vision | hybrid (80m) |
+| Night vision | hybrid (80m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd3056g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd3056g2-is.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.4 |
 | Field of view | 98 horizontal (2.8mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd3156g2-is-u.md
+++ b/docs/cameras/hikvision/ds-2cd3156g2-is-u.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 / 6 (fixed)mm F1.4 |
 | Field of view | 98 horizontal (2.8mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3af, Class 3) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd3746g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd3746g2-izs.md
@@ -12,7 +12,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.7-13.5 or 7-35 (motorized)mm F1.4 (2.7-13.5mm) / F1.6 (7-35mm) |
 | Field of view | 107.6-32.9 horizontal (2.7-13.5mm), 28.7-10.5 (7-35mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3at, Class 4) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd3766g2t-izs-y.md
+++ b/docs/cameras/hikvision/ds-2cd3766g2t-izs-y.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.4" Progressive Scan CMOS |
 | Lens | 1× 2.7-13.5 or 7-35 (motorized)mm F1.6 |
 | Field of view | 106-35.6 horizontal (2.7-13.5mm), 34.4-12.5 (7-35mm)° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (IEEE 802.3at, Class 4) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2ce16d9t-airazh.md
+++ b/docs/cameras/hikvision/ds-2ce16d9t-airazh.md
@@ -10,7 +10,7 @@
 | Sensor | 2MP ultra-low-light CMOS |
 | Lens | 1× 5-50 (motorized)mm |
 | Field of view | 6-59° |
-| Night vision | ir (120m) |
+| Night vision | ir (120m), 0.003 lux color |
 | Power | 12 VDC / 24 VAC (heater) |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce19u8t-ait3z.md
+++ b/docs/cameras/hikvision/ds-2ce19u8t-ait3z.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP progressive-scan CMOS |
 | Lens | 1× 2.8-12 (motorized)mm |
 | Field of view | 45.6-108.1° |
-| Night vision | ir (80m) |
+| Night vision | ir (80m), 0.003 lux color |
 | Power | 12 VDC / 24 VAC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.md
+++ b/docs/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12 or 8-32 (motorized, P-iris)mm F1.2-F2.5 (2.8-12mm) / F1.7 (8-32mm) |
 | Field of view | 114.5-41.8 horizontal (2.8-12mm), 42.5-15.1 (8-32mm)° |
-| Night vision | ir (50m) |
+| Night vision | ir (50m), 0.0005 lux color |
 | Power | PoE+ (IEEE 802.3at, Class 4) / DC 12V |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/i-pro/wv-s2236l.md
+++ b/docs/cameras/i-pro/wv-s2236l.md
@@ -12,7 +12,7 @@
 | Sensor | 1/3" CMOS |
 | Lens | 1× 2.9-9 (3.1x motorized varifocal)mm F1.6 |
 | Field of view | 100-31 horizontal° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/kedacom/ipc2231-fn-s.md
+++ b/docs/cameras/kedacom/ipc2231-fn-s.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 2.8-12 (varifocal); 2.2 / 2.0 (fixed)mm F1.4 |
 | Field of view | 108-35 (varifocal); 126 (2.2mm); 151 (2mm)° |
-| Night vision | none |
+| Night vision | none, 0.001 lux color |
 | Power | PoE (IEEE802.3af) / 24V AC / 12V DC |
 | Storage | microSD ≤ 128GB |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/kedacom/ipc2440-hn-sir30.md
+++ b/docs/cameras/kedacom/ipc2440-hn-sir30.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" progressive scan CMOS |
 | Lens | 1× 2.8/3.6/6mm |
 | Field of view | 53.4-101.2° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.05 lux color |
 | Power | PoE (IEEE802.3af) / 12V DC |
 | Protocols | onvif, rtsp, http |
 | IP rating | IP67 |

--- a/docs/cameras/kedacom/lc2110-an.md
+++ b/docs/cameras/kedacom/lc2110-an.md
@@ -12,7 +12,7 @@
 | Sensor | 1/3" progressive scan CMOS |
 | Lens | 1× 2.8/3.6/6/8/12mm |
 | Field of view | 23-96.3° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (IEEE802.3af) / 12V DC |
 | Storage | microSD ≤ 128GB |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/lorex/e871ab.md
+++ b/docs/cameras/lorex/e871ab.md
@@ -11,7 +11,7 @@
 | Resolution | 4K dual-lens 180deg panoramic (8MP, 4096×1856) |
 | Lens | 2× 2.1 (fixed, both lenses)mm F1.6 |
 | Field of view | 180 panoramic° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE) |
 | IP rating | IP67 |
 | Two-way audio | Yes |

--- a/docs/cameras/lorex/e872sb.md
+++ b/docs/cameras/lorex/e872sb.md
@@ -11,7 +11,7 @@
 | Resolution | 4K dual-lens 180deg panoramic (8MP, 4096×1856) |
 | Lens | 2× 2.1 (fixed, both lenses)mm F1.6 |
 | Field of view | 180 panoramic° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af Class) / 12V DC; max 8.2W (DC) / 9.1W (PoE) |
 | IP rating | IP67 |
 | Two-way audio | Yes |

--- a/docs/cameras/lorex/x5-bullet.md
+++ b/docs/cameras/lorex/x5-bullet.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 109.4 horizontal / 59.5 vertical / 113.8 diagonal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | 12V DC / PoE (IEEE 802.3af); max 7.1W (DC) / 8.9W (PoE) |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/lorex/x5-turret.md
+++ b/docs/cameras/lorex/x5-turret.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 109.4 horizontal / 59.5 vertical / 113.5 diagonal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | 12V DC / PoE (IEEE 802.3af); max 8W (DC) / 10.5W (PoE) |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/lts/lts-ptzip688x36.md
+++ b/docs/cameras/lts/lts-ptzip688x36.md
@@ -11,7 +11,7 @@
 | Resolution | 4K/8MP (8MP, 4096×2160) |
 | Sensor | 2/3" Progressive Scan CMOS |
 | Lens | 1× 7.5-270mm F1.5 |
-| Night vision | ir |
+| Night vision | ir, 0.005 lux color |
 | Power | 24V AC or High PoE, up to 50W |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -613,6 +613,7 @@ function flat(cam) {
     megapixels: cam.resolution?.megapixels ?? 0,
     nv_type:    cam.night_vision?.type ?? 'unknown',
     nv_range:   cam.night_vision?.range_m ?? 0,
+    nv_lux:     cam.night_vision?.min_lux_color ?? null,
     two_way:    cam.audio?.two_way ?? false,
     msrp:       cam.msrp_usd ?? cam.msrp_eur ?? cam.msrp_gbp ?? cam.msrp_aud ?? cam.msrp_inr ?? null,
   };
@@ -658,7 +659,7 @@ function fmt(cam, key) {
 
 function nvBadgeClass(nv) { return { ir:'badge-ir', color:'badge-color', hybrid:'badge-hybrid', none:'badge-none' }[nv] ?? 'badge-ir'; }
 function ipBadgeClass(ip) { if (!ip) return 'badge-ip-other'; if (ip.includes('67')) return 'badge-ip67'; if (ip.includes('66')) return 'badge-ip66'; return 'badge-ip-other'; }
-function ikBadgeClass(ik) { if (!ik) return 'xxx'; if (ik === '—') return 'badge-ik-none'; if (ik === 'IK11') return 'badge-ik11'; if (ik === 'IK10') return 'badge-ik10'; return 'badge-ik-other'; }
+function ikBadgeClass(ik) { if (!ik) return 'badge-ik-none'; if (ik === '—') return 'badge-ik-none'; if (ik === 'IK11') return 'badge-ik11'; if (ik === 'IK10') return 'badge-ik10'; return 'badge-ik-other'; }
 function connBadgeClass(c) { return { wifi:'badge-wifi', ethernet:'badge-ethernet', '4g':'badge-4g-conn', coax:'badge-coax' }[c] ?? 'badge-ip-other'; }
 function connLabel(c) { return { wifi:'WiFi', ethernet:'Ethernet', '4g':'4G', coax:'Coax' }[c] ?? c; }
 function powerBadgeClass(p) { return { poe:'badge-poe', dc:'badge-dc', usb:'badge-usb', battery:'badge-battery', solar:'badge-solar', 'ac-mains':'badge-mains' }[p] ?? 'badge-ip-other'; }
@@ -1130,7 +1131,7 @@ function openCompare() {
     ['Sensor',       c => c.sensor ?? '—'],
     ['Lens',         c => c.lens?.focal_length_mm ?? '—'],
     ['FOV',          c => c.field_of_view_deg ?? '—'],
-    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '')],
+    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '') + (c.nv_lux ? ' · ' + c.nv_lux + ' lux color' : '')],
     ['Connectivity', c => (c.connectivity ?? []).join(', ') || '—'],
     ['Power',        c => (c.power_source ?? []).map(powerLabel).join(', ') || '—'],
     ['IP rating',    c => c.ip_rating ?? '—'],
@@ -1261,7 +1262,11 @@ function openDrawer(cam) {
       ${row('Sensor', cam.sensor)}
       ${row('Lens', cam.lens?.focal_length_mm ? cam.lens.focal_length_mm + (cam.lens.aperture ? ' ' + cam.lens.aperture : '') + (cam.lens.varifocal ? ' varifocal' : '') : null)}
       ${row('Field of view', cam.field_of_view_deg)}
-      ${row('Night vision', cam.night_vision?.type ? cam.night_vision.type + (cam.night_vision.range_m ? ' · ' + cam.night_vision.range_m + 'm' : '') : null)}
+      ${row('Night vision', cam.night_vision?.type ? cam.night_vision.type + 
+      		(cam.night_vision.range_m ? ' · ' + cam.night_vision.range_m + 'm' : '')  +
+		(cam.night_vision.min_lux_color ? ' · ' + cam.night_vision.min_lux_color + ' lux color' : '')
+		: null)
+	}
       ${row('IP rating', cam.ip_rating)}
       ${row('IK rating', cam.ik_rating)}
       ${row('Power', cam.power?.method)}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -10,7 +10,7 @@ Quick reference for terms used across camera entries.
 
 **IR night vision** — Infrared LEDs illuminate the scene invisibly; image is black & white. `range_m` is the rated effective distance.
 
-**Color night vision** — Uses a low-light sensor plus a white spotlight to keep footage in color at night.
+**Color night vision** — Uses a low-light sensor plus a white spotlight to keep footage in color at night. The low-light sensitivity is specified as the minimum illumination required for color, defined in lux (lx).
 
 **WDR (Wide Dynamic Range)** — Balances very bright and very dark areas in one frame. Measured in dB; 120 dB is strong.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.44.2",
+  "version": "1.45.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -181,7 +181,8 @@
         },
         "min_lux_color": {
           "type": "number",
-	  "description": "Minimum illumination (lux) required for color image."
+          "minimum": 0,
+          "description": "Minimum illumination (lux) required for color image."
         }
       }
     },

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -178,6 +178,10 @@
         },
         "range_m": {
           "type": "integer"
+        },
+        "min_lux_color": {
+          "type": "number",
+	  "description": "Minimum illumination (lux) required for color image."
         }
       }
     },

--- a/scripts/add-camera.js
+++ b/scripts/add-camera.js
@@ -92,7 +92,13 @@ async function run() {
   const nvType = await askList('\nNight vision type :', ['ir','color','hybrid','none']);
   if (nvType !== 'none') {
     const rangeRaw = await ask('Night vision range in metres (e.g. 30) : ');
-    cam.night_vision = { type: nvType, range_m: parseInt(rangeRaw) || 20 };
+    const minluxRaw = await ask('Minimum illumination (lux) required for color image (e.g. 0.005) : ');
+    cam.night_vision = { type: nvType, range_m: parseInt(rangeRaw) || 20};
+
+    const minluxParsed = parseFloat(minluxRaw);
+    if (!isNaN(minluxParsed)) {
+      cam.night_vision.min_lux_color = minluxParsed;
+    }
   } else {
     cam.night_vision = { type: 'none', range_m: 0 };
   }

--- a/scripts/gen-docs.js
+++ b/scripts/gen-docs.js
@@ -37,7 +37,7 @@ function render(c) {
   md += row("Sensor", c.sensor);
   md += row("Lens", c.lens && [c.lens.count ? `${c.lens.count}×` : "", c.lens.focal_length_mm ? `${c.lens.focal_length_mm}mm` : "", c.lens.aperture].filter(Boolean).join(" "));
   md += row("Field of view", c.field_of_view_deg && `${c.field_of_view_deg}°`);
-  md += row("Night vision", c.night_vision && `${c.night_vision.type}${c.night_vision.range_m ? ` (${c.night_vision.range_m}m)` : ""}`);
+  md += row("Night vision", c.night_vision && `${c.night_vision.type}${c.night_vision.range_m ? ` (${c.night_vision.range_m}m)` : ""}${c.night_vision.min_lux_color ? `, ${c.night_vision.min_lux_color} lux color` : ""}`);
   md += row("Power", c.power?.method);
   md += row("Storage", c.storage && [c.storage.max_microsd_gb ? `microSD ≤ ${c.storage.max_microsd_gb}GB` : "", c.storage.nvr_compatible ? "NVR" : ""].filter(Boolean).join(", "));
   md += row("Protocols", c.protocols?.join(", "));


### PR DESCRIPTION
## What does this PR do?

This PR extends the schema with a new property to specify the "Night Vision" low-light sensitivity by capturing the minimum illumination level (in lux) required to render a usable color image. 

---

## Checklist

### For schema / tooling changes
- [X] Existing cameras still validate (`npm run build`)
- [X] Updated `docs/glossary.md` if new fields were added

---

## Notes

Different vendors are using various marketing terms for the low-light color capability of the camera: Color Night Vision, Starlight, Darkfighter, ColorVu, NightChroma etc. 

To be able to compare/assess the advertised/documented low light capabilities, a new attribute *min_lux_color* has been added in the *night_vision* to capture the minimum illumination (defined in lux) required to render a usable color image.

This PR includes 
- changes to the camera schema
- glossary.md update
- updates of the ad-camera and gen-docs scripts
- updates of the demo.html web viewer
- data migration of existing camera data -- where the low-light capabilities have been documented in the notes
