### PR TITLE
Extend the schema with a generic min_lux attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.46.0] — 2026-07-26
+
+**New field: `night_vision.min_lux`** (#147 — thanks @fvdpol!). A generic minimum-illumination figure (lux) for datasheets that state a low-light sensitivity **without** specifying whether the resulting image is colour or black-and-white — complementing `min_lux_color` (#143), which is specifically the colour threshold. `gen-docs` and the `docs/demo.html` viewer render both. Adds a "Minimum Illumination" glossary entry (with the IRE-level caveat on how vendors measure it). (Maintainer follow-up: fixed a missing `+` in the demo.html table renderer that would have thrown on the Night-vision column.)
+
 ## [1.45.1] — 2026-07-25
 
 **Verified Frigate configs for 5 Annke models** (#142 — thanks @fvdpol!). Real-world-tested Frigate 0.17.2 configuration for `C800 I91BL`, `C800 I91BN`, `C800 I91DM (28mm)`, `C800 I91DM (40mm)` and `FCD800 I91ET`: detect FPS corrected 5→4, plus `recommended_stream_type`, per-camera `notes` (H.265 sub-stream resolution/codec guidance) and `verified` / `tested_version` / `tested_by` provenance flags.

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -613,7 +613,8 @@ function flat(cam) {
     megapixels: cam.resolution?.megapixels ?? 0,
     nv_type:    cam.night_vision?.type ?? 'unknown',
     nv_range:   cam.night_vision?.range_m ?? 0,
-    nv_lux:     cam.night_vision?.min_lux_color ?? null,
+    nv_lux:     cam.night_vision?.min_lux ?? null,
+    nv_lux_color:     cam.night_vision?.min_lux_color ?? null,
     two_way:    cam.audio?.two_way ?? false,
     msrp:       cam.msrp_usd ?? cam.msrp_eur ?? cam.msrp_gbp ?? cam.msrp_aud ?? cam.msrp_inr ?? null,
   };
@@ -1131,7 +1132,7 @@ function openCompare() {
     ['Sensor',       c => c.sensor ?? '—'],
     ['Lens',         c => c.lens?.focal_length_mm ?? '—'],
     ['FOV',          c => c.field_of_view_deg ?? '—'],
-    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '') + (c.nv_lux ? ' · ' + c.nv_lux + ' lux color' : '')],
+    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '') + (c.nv_lux ? ' · ' + c.nv_lux + ' lux' : '')(c.nv_lux_color ? ' · ' + c.nv_lux_color + ' lux color' : '')],
     ['Connectivity', c => (c.connectivity ?? []).join(', ') || '—'],
     ['Power',        c => (c.power_source ?? []).map(powerLabel).join(', ') || '—'],
     ['IP rating',    c => c.ip_rating ?? '—'],
@@ -1264,6 +1265,7 @@ function openDrawer(cam) {
       ${row('Field of view', cam.field_of_view_deg)}
       ${row('Night vision', cam.night_vision?.type ? cam.night_vision.type + 
       		(cam.night_vision.range_m ? ' · ' + cam.night_vision.range_m + 'm' : '')  +
+		(cam.night_vision.min_lux ? ' · ' + cam.night_vision.min_lux + ' lux' : '') +
 		(cam.night_vision.min_lux_color ? ' · ' + cam.night_vision.min_lux_color + ' lux color' : '')
 		: null)
 	}

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1132,7 +1132,7 @@ function openCompare() {
     ['Sensor',       c => c.sensor ?? '—'],
     ['Lens',         c => c.lens?.focal_length_mm ?? '—'],
     ['FOV',          c => c.field_of_view_deg ?? '—'],
-    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '') + (c.nv_lux ? ' · ' + c.nv_lux + ' lux' : '')(c.nv_lux_color ? ' · ' + c.nv_lux_color + ' lux color' : '')],
+    ['Night vision', c => c.nv_type + (c.nv_range ? ' · ' + c.nv_range + 'm' : '') + (c.nv_lux ? ' · ' + c.nv_lux + ' lux' : '') + (c.nv_lux_color ? ' · ' + c.nv_lux_color + ' lux color' : '')],
     ['Connectivity', c => (c.connectivity ?? []).join(', ') || '—'],
     ['Power',        c => (c.power_source ?? []).map(powerLabel).join(', ') || '—'],
     ['IP rating',    c => c.ip_rating ?? '—'],

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -12,6 +12,8 @@ Quick reference for terms used across camera entries.
 
 **Color night vision** — Uses a low-light sensor plus a white spotlight to keep footage in color at night. The low-light sensitivity is specified as the minimum illumination required for color, defined in lux (lx).
 
+**Minimum Illumination** -- This is the lowest light level, measured in lux (lx) at which a security camera produces a usable, recognizable video image. A complete definition requires an IRE (Institute of Radio Engineers) video signal level (usually 30% to 50%, or 50 IRE). Note that different vendors may use different standards regarding the required minimum image quality/contrast/noise/blur or an 10% IRE to inflate the low-light sensitivity numbers.
+
 **WDR (Wide Dynamic Range)** — Balances very bright and very dark areas in one frame. Measured in dB; 120 dB is strong.
 
 **IP rating** — Ingress protection. First digit = dust, second = water. `IP66` = dust-tight + strong water jets; `IP67` = dust-tight + temporary immersion.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -179,6 +179,11 @@
         "range_m": {
           "type": "integer"
         },
+        "min_lux": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum illumination (lux) required for usable image."
+        },
         "min_lux_color": {
           "type": "number",
           "minimum": 0,

--- a/scripts/gen-docs.js
+++ b/scripts/gen-docs.js
@@ -37,7 +37,7 @@ function render(c) {
   md += row("Sensor", c.sensor);
   md += row("Lens", c.lens && [c.lens.count ? `${c.lens.count}×` : "", c.lens.focal_length_mm ? `${c.lens.focal_length_mm}mm` : "", c.lens.aperture].filter(Boolean).join(" "));
   md += row("Field of view", c.field_of_view_deg && `${c.field_of_view_deg}°`);
-  md += row("Night vision", c.night_vision && `${c.night_vision.type}${c.night_vision.range_m ? ` (${c.night_vision.range_m}m)` : ""}${c.night_vision.min_lux_color ? `, ${c.night_vision.min_lux_color} lux color` : ""}`);
+  md += row("Night vision", c.night_vision && `${c.night_vision.type}${c.night_vision.range_m ? ` (${c.night_vision.range_m}m)` : ""}${c.night_vision.min_lux ? `, ${c.night_vision.min_lux} lux` : ""}${c.night_vision.min_lux_color ? `, ${c.night_vision.min_lux_color} lux color` : ""}`);
   md += row("Power", c.power?.method);
   md += row("Storage", c.storage && [c.storage.max_microsd_gb ? `microSD ≤ ${c.storage.max_microsd_gb}GB` : "", c.storage.nvr_compatible ? "NVR" : ""].filter(Boolean).join(", "));
   md += row("Protocols", c.protocols?.join(", "));


### PR DESCRIPTION

## What does this PR do?

Extend the schema with a generic min_lux attribute to cover camera that do not specify if the minimum illumination provides a color image or black and white

---

## Checklist

### For schema / tooling changes
- [X] Existing cameras still validate (`npm run build`)
- [X] Updated `docs/glossary.md` if new fields were added

---

## Notes

During data collection to back-fill the minimum illumination level I found that some data sheets did not specify if the listed minimum illumination level would give an usable color image, or if this would be a black and white image (which requires less light). To allow to stay true to the manufacturer data a 2nd attribute was introduced to keep this distinction clear.

this PR contains:

- schema change
- documentation update
- update of the gen-docs.js
- update of the demo.html web application

