### PR TITLE
Resolve autotracking review for 16 non-PTZ cameras (#126)

### DIFF
--- a/cameras/amcrest/ip2m-841b.json
+++ b/cameras/amcrest/ip2m-841b.json
@@ -2,7 +2,10 @@
   "id": "amcrest-ip2m-841b",
   "brand": "Amcrest",
   "model": "IP2M-841B 1080p WiFi Bullet",
-  "type": "box",
+  "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi"
   ],

--- a/cameras/bosch/nti-50022-a3.json
+++ b/cameras/bosch/nti-50022-a3.json
@@ -54,8 +54,7 @@
     "IVA Pro",
     "Starlight low-light",
     "IntelliVision deep learning",
-    "IK10",
-    "auto-tracking"
+    "IK10"
   ],
   "sources": [
     "https://assets.catalog.boschbuildingtechnologies.com/public/documents/NTI_5000_A3_Data_sheet_enUS_9007220087116299.pdf"

--- a/cameras/eufy/floodlight-cam-e30.json
+++ b/cameras/eufy/floodlight-cam-e30.json
@@ -7,6 +7,9 @@
     "T8426121"
   ],
   "type": "floodlight",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi"
   ],
@@ -47,7 +50,7 @@
     "two_way": true
   },
   "features": [
-    "dual-lens 360 pan & tilt with auto-tracking",
+    "dual-lens 355° pan & tilt with auto-tracking",
     "3x optical / 8x digital zoom",
     "2000-lumen motion-activated LED floodlight (4000K)",
     "AI human/vehicle detection, out-of-view detection",

--- a/cameras/hikvision/ds-2sf8c442mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c442mxg1-elw.json
@@ -3,6 +3,9 @@
   "brand": "Hikvision",
   "model": "DS-2SF8C442MXG1-ELW",
   "type": "panoramic",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/hikvision/ds-2sf8c848mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c848mxg1-elw.json
@@ -3,6 +3,9 @@
   "brand": "Hikvision",
   "model": "DS-2SF8C848MXG1-ELW",
   "type": "panoramic",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/lorex/w452asd.json
+++ b/cameras/lorex/w452asd.json
@@ -51,7 +51,7 @@
     "smart motion detection (person/vehicle/animal)",
     "adjustable LED color temperature",
     "built-in siren",
-    "auto-tracking",
+    "auto-framing (digital, live view only)",
     "32GB microSD included",
     "no monthly fees",
     "Alexa / Google",

--- a/cameras/lorex/w482cad.json
+++ b/cameras/lorex/w482cad.json
@@ -60,7 +60,6 @@
     "2K WiFi outdoor smart deterrence (spotlight + siren)",
     "color night vision",
     "person/vehicle/animal/package detection",
-    "auto-tracking",
     "32GB local storage included",
     "no monthly fees",
     "Lorex Home app",

--- a/cameras/ubiquiti/ai-pro-white.json
+++ b/cameras/ubiquiti/ai-pro-white.json
@@ -56,7 +56,6 @@
     "on-device AI analytics",
     "license plate recognition",
     "face detection",
-    "auto-tracking",
     "UniFi Protect ecosystem",
     "two-way audio"
   ],

--- a/cameras/ubiquiti/ai-pro.json
+++ b/cameras/ubiquiti/ai-pro.json
@@ -55,7 +55,6 @@
     "on-device AI analytics",
     "license plate recognition",
     "face detection",
-    "auto-tracking",
     "UniFi Protect ecosystem",
     "two-way audio"
   ],

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -359,7 +359,7 @@ ajax-turretcam-8mp-28mm,Ajax,TurretCam (8 MP/2.8 mm),turret,4K/8MP,8,"1/2.8"" CM
 ajax-turretcam-8mp-4mm,Ajax,TurretCam (8 MP/4 mm),turret,4K/8MP,8,"1/2.8"" CMOS",75-85 H / 40-50 V / 105-115 D,ir,IP65,IK08,false,
 amcrest-ad410-doorbell,Amcrest,AD410 2K Video Doorbell,doorbell,2K QHD,4,,163 diagonal (head-to-toe),ir,IP65,,true,2022
 amcrest-ash42-w,Amcrest,ASH42-W,bullet,2K QHD,4,,101 horizontal,ir,IP66,,false,2023
-amcrest-ip2m-841b,Amcrest,IP2M-841B 1080p WiFi Bullet,box,1080p HD,2,,90,ir,,,true,2019
+amcrest-ip2m-841b,Amcrest,IP2M-841B 1080p WiFi Bullet,ptz,1080p HD,2,,90,ir,,,true,2019
 amcrest-ip4m-1041w,Amcrest,IP4M-1041W,box,4MP,4,,90,ir,,,true,2022
 amcrest-ip4m-1051ew,Amcrest,IP4M-1051E 4MP WiFi Dome,dome,4MP,4,,120,ir,IP20,,true,2022
 amcrest-ip5m-b1186ew,Amcrest,IP5M-B1186EW,bullet,5MP,5,,132,ir,IP67,,false,2023

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -32703,7 +32703,10 @@
     "id": "amcrest-ip2m-841b",
     "brand": "Amcrest",
     "model": "IP2M-841B 1080p WiFi Bullet",
-    "type": "box",
+    "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -64590,8 +64593,7 @@
       "IVA Pro",
       "Starlight low-light",
       "IntelliVision deep learning",
-      "IK10",
-      "auto-tracking"
+      "IK10"
     ],
     "sources": [
       "https://assets.catalog.boschbuildingtechnologies.com/public/documents/NTI_5000_A3_Data_sheet_enUS_9007220087116299.pdf"
@@ -88456,6 +88458,9 @@
       "T8426121"
     ],
     "type": "floodlight",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -88496,7 +88501,7 @@
       "two_way": true
     },
     "features": [
-      "dual-lens 360 pan & tilt with auto-tracking",
+      "dual-lens 355° pan & tilt with auto-tracking",
       "3x optical / 8x digital zoom",
       "2000-lumen motion-activated LED floodlight (4000K)",
       "AI human/vehicle detection, out-of-view detection",
@@ -148064,6 +148069,9 @@
     "brand": "Hikvision",
     "model": "DS-2SF8C442MXG1-ELW",
     "type": "panoramic",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -148153,6 +148161,9 @@
     "brand": "Hikvision",
     "model": "DS-2SF8C848MXG1-ELW",
     "type": "panoramic",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -166314,7 +166325,7 @@
       "smart motion detection (person/vehicle/animal)",
       "adjustable LED color temperature",
       "built-in siren",
-      "auto-tracking",
+      "auto-framing (digital, live view only)",
       "32GB microSD included",
       "no monthly fees",
       "Alexa / Google",
@@ -166554,7 +166565,6 @@
       "2K WiFi outdoor smart deterrence (spotlight + siren)",
       "color night vision",
       "person/vehicle/animal/package detection",
-      "auto-tracking",
       "32GB local storage included",
       "no monthly fees",
       "Lorex Home app",
@@ -199631,7 +199641,6 @@
       "on-device AI analytics",
       "license plate recognition",
       "face detection",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "two-way audio"
     ],
@@ -199721,7 +199730,6 @@
       "on-device AI analytics",
       "license plate recognition",
       "face detection",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "two-way audio"
     ],

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -32703,7 +32703,10 @@
     "id": "amcrest-ip2m-841b",
     "brand": "Amcrest",
     "model": "IP2M-841B 1080p WiFi Bullet",
-    "type": "box",
+    "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -64590,8 +64593,7 @@
       "IVA Pro",
       "Starlight low-light",
       "IntelliVision deep learning",
-      "IK10",
-      "auto-tracking"
+      "IK10"
     ],
     "sources": [
       "https://assets.catalog.boschbuildingtechnologies.com/public/documents/NTI_5000_A3_Data_sheet_enUS_9007220087116299.pdf"
@@ -88456,6 +88458,9 @@
       "T8426121"
     ],
     "type": "floodlight",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -88496,7 +88501,7 @@
       "two_way": true
     },
     "features": [
-      "dual-lens 360 pan & tilt with auto-tracking",
+      "dual-lens 355° pan & tilt with auto-tracking",
       "3x optical / 8x digital zoom",
       "2000-lumen motion-activated LED floodlight (4000K)",
       "AI human/vehicle detection, out-of-view detection",
@@ -148064,6 +148069,9 @@
     "brand": "Hikvision",
     "model": "DS-2SF8C442MXG1-ELW",
     "type": "panoramic",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -148153,6 +148161,9 @@
     "brand": "Hikvision",
     "model": "DS-2SF8C848MXG1-ELW",
     "type": "panoramic",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -166314,7 +166325,7 @@
       "smart motion detection (person/vehicle/animal)",
       "adjustable LED color temperature",
       "built-in siren",
-      "auto-tracking",
+      "auto-framing (digital, live view only)",
       "32GB microSD included",
       "no monthly fees",
       "Alexa / Google",
@@ -166554,7 +166565,6 @@
       "2K WiFi outdoor smart deterrence (spotlight + siren)",
       "color night vision",
       "person/vehicle/animal/package detection",
-      "auto-tracking",
       "32GB local storage included",
       "no monthly fees",
       "Lorex Home app",
@@ -199631,7 +199641,6 @@
       "on-device AI analytics",
       "license plate recognition",
       "face detection",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "two-way audio"
     ],
@@ -199721,7 +199730,6 @@
       "on-device AI analytics",
       "license plate recognition",
       "face detection",
-      "auto-tracking",
       "UniFi Protect ecosystem",
       "two-way audio"
     ],

--- a/docs/cameras/amcrest/ip2m-841b.md
+++ b/docs/cameras/amcrest/ip2m-841b.md
@@ -4,7 +4,7 @@
 |-------|------|
 | Brand | Amcrest |
 | Model | IP2M-841B 1080p WiFi Bullet |
-| Type | box |
+| Type | ptz |
 | Connectivity | wifi |
 | Resolution | 1080p HD (2MP) |
 | Field of view | 90° |

--- a/docs/cameras/bosch/nti-50022-a3.md
+++ b/docs/cameras/bosch/nti-50022-a3.md
@@ -30,7 +30,6 @@
 - Starlight low-light
 - IntelliVision deep learning
 - IK10
-- auto-tracking
 
 ## Sources
 

--- a/docs/cameras/eufy/floodlight-cam-e30.md
+++ b/docs/cameras/eufy/floodlight-cam-e30.md
@@ -21,7 +21,7 @@
 
 ## Features
 
-- dual-lens 360 pan & tilt with auto-tracking
+- dual-lens 355° pan & tilt with auto-tracking
 - 3x optical / 8x digital zoom
 - 2000-lumen motion-activated LED floodlight (4000K)
 - AI human/vehicle detection, out-of-view detection

--- a/docs/cameras/lorex/w452asd.md
+++ b/docs/cameras/lorex/w452asd.md
@@ -25,7 +25,7 @@
 - smart motion detection (person/vehicle/animal)
 - adjustable LED color temperature
 - built-in siren
-- auto-tracking
+- auto-framing (digital, live view only)
 - 32GB microSD included
 - no monthly fees
 - Alexa / Google

--- a/docs/cameras/lorex/w482cad.md
+++ b/docs/cameras/lorex/w482cad.md
@@ -25,7 +25,6 @@
 - 2K WiFi outdoor smart deterrence (spotlight + siren)
 - color night vision
 - person/vehicle/animal/package detection
-- auto-tracking
 - 32GB local storage included
 - no monthly fees
 - Lorex Home app

--- a/docs/cameras/ubiquiti/ai-pro-white.md
+++ b/docs/cameras/ubiquiti/ai-pro-white.md
@@ -31,7 +31,6 @@
 - on-device AI analytics
 - license plate recognition
 - face detection
-- auto-tracking
 - UniFi Protect ecosystem
 - two-way audio
 

--- a/docs/cameras/ubiquiti/ai-pro.md
+++ b/docs/cameras/ubiquiti/ai-pro.md
@@ -30,7 +30,6 @@
 - on-device AI analytics
 - license plate recognition
 - face detection
-- auto-tracking
 - UniFi Protect ecosystem
 - two-way audio
 


### PR DESCRIPTION
Closes #126.

Each of the 16 cameras tagged `autotracking` in `features[]` but not typed `ptz`/`dual-lens` was verified against its **official source** and given a per-camera call.

### Mechanical PTZ / PT → `ptz.autotracking: true`
| Camera | Evidence |
|---|---|
| `hikvision-ds-2sf8c442mxg1-elw` | TandemVu **Speed Dome**, 42× optical, 360° endless pan, "auto-tracking 3.0" drives the motorized PTZ channel (datasheet) |
| `hikvision-ds-2sf8c848mxg1-elw` | TandemVu **Speed Dome**, 48× optical, 360° endless pan (datasheet) |
| `eufy-floodlight-cam-e30` | Motorized PT, "automatic panning and tilting" (official page); also corrected feature **360° → 355°** per spec |
| `amcrest-ip2m-841b` | Motorized 355°/90° PT, auto-tracking pans/tilts to follow motion; **type `box` → `ptz`** (was mistyped) |

### Digital tracking → reworded, no mechanical flag
- `lorex-w452asd`: fixed lens; "auto-tracking" is digital auto-framing (live-view only) → reworded to **`auto-framing (digital, live view only)`**

### Unsupported by source → `auto-tracking` feature removed
- `lorex-w482cad` (fixed bullet, no tracking in spec), `ubiquiti-ai-pro` + `ubiquiti-ai-pro-white` (fixed bullets; it's Smart Detections, not tracking), `bosch-nti-50022-a3` (fixed IR bullet — datasheet never mentions tracking; only E-PTZ crop + MOTION+)

### Confirmed digital / e-PTZ → left as-is
Already carry a `digital`/`e-PTZ` qualifier in `features` (the distinct signal the issue asked about), correctly without `ptz.autotracking`: `hanwha-xnv-8080r`, `hanwha-pnd-9080r`, `acti-b76a`, `acti-b511a`, `hikvision-ds-2cd3746g2-izs`. (`reolink-omvi-3i-wifi`/`-poe` already had the flag.)

**On the issue's open question** ("does digital/e-PTZ tracking deserve its own signal?"): the existing free-text `features` qualifier already distinguishes it from mechanical `ptz.autotracking`, so no schema change was needed.

_Also noticed out of scope: `amcrest-ip4m-1041w` shares the same `box` mistype — worth a follow-up._

---

## Checklist

### For schema / tooling changes
- [X] Existing cameras still validate (`npm run build`)
- [X] Updated `docs/glossary.md` if new fields were added
