### PR TITLE
Add 57 ABUS + 7 Tapo cameras (+64); correct abus-tvip83900

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.47.0] — 2026-07-26
+
+**ABUS + Tapo expansion (+64).** Added **57 ABUS** cameras across the professional IP range — IPCA (18), IPCB bullets (24), IPCS domes/turrets (11) and PPIC pan/floodlight (4) series — and **7 Tapo** models (`C217`, `C245D`, `C250`, `C403`, `C410`, `C545D`, `C710`). Also corrected `abus-tvip83900` (SPECIAL-line 3 MPx fisheye): fixed resolution (3→3.1 MP), IR range (5→15 m) and sensor naming, marked it **discontinued**, and removed an incorrect "Hikvision-OEM" claim — its RTSP/integration guidance now points to Generic ONVIF (Profile S) per the official ABUS catalog. Net: 2,330 → **2,394**.
+
+> **Note on sources:** several of the added ABUS models are discontinued / end-of-life and no longer have live pages on abus.com. Where no official manufacturer source was available, specs were taken from the official **ABUS Video IP catalog** and reputable retailer/distributor listings instead. These are flagged for a future re-source if official archived datasheets surface.
+
 ## [1.46.0] — 2026-07-26
 
 **New field: `night_vision.min_lux`** (#147 — thanks @fvdpol!). A generic minimum-illumination figure (lux) for datasheets that state a low-light sensitivity **without** specifying whether the resulting image is colour or black-and-white — complementing `min_lux_color` (#143), which is specifically the colour threshold. `gen-docs` and the `docs/demo.html` viewer render both. Adds a "Minimum Illumination" glossary entry (with the IRE-level caveat on how vendors measure it). (Maintainer follow-up: fixed a missing `+` in the demo.html table renderer that would have thrown on the Night-vision column.)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An open, structured database of 2,330 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
-[![cameras](https://img.shields.io/badge/cameras-2%2C330-blue)](data/cameras.json)
+[![cameras](https://img.shields.io/badge/cameras-2%2C394-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-72-green)](cameras/)
 [![license](https://img.shields.io/badge/license-CC0-lightgrey)](LICENSE)
 
@@ -60,11 +60,11 @@ cctv-camera-database/
 │   ├── acti/             # 248 cameras
 │   ├── dahua/            # 189 cameras
 │   ├── bosch/            # 153 cameras
+│   ├── abus/             # 142 cameras
 │   ├── reolink/          # 127 cameras
-│   ├── ezviz/            #  87 cameras
 │   └── …66 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,330 cameras as one array
+│   ├── cameras.json      # all 2,394 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -125,7 +125,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,330** |
+| Total cameras | **2,394** |
 | Brands | **72** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,669 |
@@ -145,14 +145,14 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | ACTi | 248 | Enterprise IP + analog, NDAA, TW/global |
 | Dahua | 189 | Enterprise + consumer, global |
 | Bosch | 153 | Enterprise + thermal, EU/global |
+| ABUS | 142 | Consumer + professional, GDPR-first, DE/AT/CH |
 | Reolink | 127 | Prosumer, no-subscription, global |
 | EZVIZ (Hikvision) | 87 | Consumer, global |
-| ABUS | 85 | Consumer + professional, GDPR-first, DE/AT/CH |
 | Axis | 72 | Enterprise premium, global |
 | Hi-Focus | 60 | Made-in-India, BIS certified, IN |
 | Kedacom | 58 | Enterprise, CN/global |
 | IMOU (Dahua) | 56 | Consumer + prosumer, global |
-| Tapo (TP-Link) | 47 | Consumer budget, global |
+| Tapo (TP-Link) | 54 | Consumer budget, global |
 | Eufy (Anker) | 46 | Consumer no-subscription, global |
 | Hanwha | 45 | Enterprise AI, Korea/global |
 | Annke | 43 | Prosumer, global |

--- a/cameras/abus/ipca32500.json
+++ b/cameras/abus/ipca32500.json
@@ -1,0 +1,86 @@
+{
+  "id": "abus-ipca32500",
+  "brand": "ABUS",
+  "model": "IPCA32500",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.0 to 9.0",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP24",
+  "power": {
+    "method": "PoE"
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "two_way": true
+  },
+  "features": [
+    "Sony STARVIS sensor with Tamron 3-9 mm lens",
+    "True WDR",
+    "IR LEDs",
+    "16 GB internal memory for edge recording",
+    "ONVIF"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line (2017 generation) indoor IP dome 2 MPx — predecessor platform of the IPCA72510. Specs from the RS Components (authorized distributor) product listing: Sony STARVIS + Tamron 3-9 mm, 1080p @ 30 fps, IP24 indoor, PoE, audio, 16 GB internal memory, 141 mm width. Single-distributor sourced and flagged accordingly — aperture, FOV, IR range, full dimensions, and temperature omitted pending an official datasheet. Sibling IPCA22500 (official 2017 manual exists on abus.com) remains excluded: identity and resolution unconfirmed.",
+  "sources": [
+    "https://uk.rs-online.com/web/p/cctv-cameras/1774399"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca33500.json
+++ b/cameras/abus/ipca33500.json
@@ -1,0 +1,74 @@
+{
+  "id": "abus-ipca33500",
+  "brand": "ABUS",
+  "model": "IPCA33500",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "3MP",
+    "max_width": 2048,
+    "max_height": 1536,
+    "megapixels": 3.1
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Indoor IP dome 3 MPx — sibling of the 1080p IPCA32500. Max 50/60 fps with WDR off, 25 fps with WDR.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca52000.json
+++ b/cameras/abus/ipca52000.json
@@ -1,0 +1,72 @@
+{
+  "id": "abus-ipca52000",
+  "brand": "ABUS",
+  "model": "IPCA52000",
+  "type": "box",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "outdoor boxtype",
+    "120 dB WDR",
+    "16 GB internal memory for recording on network failure",
+    "Sony Xarina DSP"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Aussen IP Boxtype 1080p (2017 Advanced generation, predecessor of the IPCA52010). Platform data (1920x1080 @ 25 fps, Sony Exmor sensor + Xarina DSP, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018, covering IPCA22500/32500/52000/62500/62505/72500); 'Aussen IP Boxtype 1080p' designation from the official ABUS Katalog accessory compatibility matrices. Lens, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources.",
+  "sources": [
+    "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca52010.json
+++ b/cameras/abus/ipca52010.json
@@ -1,35 +1,33 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca52010",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA52010",
+  "type": "box",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
     "varifocal": false
   },
-  "field_of_view_deg": "180/360",
   "night_vision": {
-    "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "type": "none",
+    "min_lux_color": 0.001
   },
   "storage": {
     "onboard": true,
@@ -40,31 +38,34 @@
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP20",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "0 to 50",
+  "dimensions_mm": "65 x 65 x 120",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "CS-mount box camera (lens sold separately, e.g. TVAC65502 2.8-10 mm)",
+    "150 dB DOL WDR (3x shutter)",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "indoor (IP20), outdoor via TVAC70200 heated housing"
   ],
   "environment": [
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line IP boxtype 2 MPx — interchangeable-lens body; the lens field is intentionally minimal (CS mount, no bundled lens). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca53000.json
+++ b/cameras/abus/ipca53000.json
@@ -1,0 +1,73 @@
+{
+  "id": "abus-ipca53000",
+  "brand": "ABUS",
+  "model": "IPCA53000",
+  "type": "box",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "3MP",
+    "max_width": 2048,
+    "max_height": 1536,
+    "megapixels": 3.1
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "Universal boxtype with interchangeable lens (lens sold separately)",
+    "120 dB True WDR",
+    "ABF integrated auto back focus",
+    "RS-485 interface (unique in the IPCA series)",
+    "outdoor use via optional heated housing"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Universal IP Boxtype 3 MPx (2016 Advanced generation, predecessor of the IPCA52010). Identity and hardware from the official ABUS hardware manual (20160425-IPCA53000_BDA_Hardware); 2048x1536 @ 25 fps, 120 dB True WDR, and ABF auto back focus cross-corroborated by dealer PIM republications; RS-485 confirmed by the official IPCA-series software manual. Interchangeable-lens body: lens field intentionally minimal. Sensor, power, IP rating, dimensions omitted: not confirmed from recovered official sources.",
+  "sources": [
+    "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/17/20160425-IPCA53000_BDA_Hardware_DE_UK.pdf",
+    "https://www.sicher24.de/ueberwachungskameras/abus-universal-ip-boxtype-3-mpx-ipca53000.html",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca62510.json
+++ b/cameras/abus/ipca62510.json
@@ -1,70 +1,81 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca62510",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA62510",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "3.0 to 9.0",
+    "aperture": "F1.3 - F2.2 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "35 to 90 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP67",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "89 x 87 x 287",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "3x optical zoom (Tamron motor zoom)",
+    "150 dB DOL WDR (3x shutter)",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca62515.json
+++ b/cameras/abus/ipca62515.json
@@ -1,35 +1,37 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca62515",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA62515",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "5.0 to 50.0",
+    "aperture": "F1.6 - F1.8 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "9 to 70 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 30,
+    "min_lux_color": 0.02
   },
   "storage": {
     "onboard": true,
@@ -40,31 +42,40 @@
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP67",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "89 x 84 x 287",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "10x optical zoom",
+    "150 dB DOL WDR (3x shutter)",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca62520.json
+++ b/cameras/abus/ipca62520.json
@@ -1,0 +1,76 @@
+{
+  "id": "abus-ipca62520",
+  "brand": "ABUS",
+  "model": "IPCA62520",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 1080p — successor of the IPCA62500. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA63500/66500.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf",
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca63500.json
+++ b/cameras/abus/ipca63500.json
@@ -1,0 +1,76 @@
+{
+  "id": "abus-ipca63500",
+  "brand": "ABUS",
+  "model": "IPCA63500",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "3MP",
+    "max_width": 2048,
+    "max_height": 1536,
+    "megapixels": 3.1
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 3 MPx. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA62520/66500.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf",
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca66500.json
+++ b/cameras/abus/ipca66500.json
@@ -1,0 +1,77 @@
+{
+  "id": "abus-ipca66500",
+  "brand": "ABUS",
+  "model": "IPCA66500",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "6MP",
+    "max_width": 3072,
+    "max_height": 2048,
+    "megapixels": 6.3
+  },
+  "video": {
+    "max_fps": 24,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 6 MPx. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual. Official joint hardware manual with IPCA62520/63500.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf",
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf",
+    "https://www.libble.eu/abus-ipca66500/online-manual-964589/"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca68500.json
+++ b/cameras/abus/ipca68500.json
@@ -1,35 +1,37 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca68500",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA68500",
+  "type": "bullet",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "8MP",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8.3
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "4.3 to 8.6",
+    "aperture": "F1.5 - F2.4 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "48 to 95 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "storage": {
     "onboard": true,
@@ -40,31 +42,40 @@
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP67",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "89 x 84 x 287",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "2x optical zoom",
+    "120 dB WDR",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca72500.json
+++ b/cameras/abus/ipca72500.json
@@ -1,0 +1,78 @@
+{
+  "id": "abus-ipca72500",
+  "brand": "ABUS",
+  "model": "IPCA72500",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.0 to 9.0",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "Tamron 3-9 mm motor vario zoom",
+    "120 dB WDR",
+    "16 GB internal memory for recording on network failure",
+    "Sony Xarina DSP",
+    "outdoor dome (TVAC31311 wall mount)"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced outdoor IP dome 1080p (2017 generation, predecessor of the IPCA72510). Platform data (1920x1080 @ 25 fps, Sony Exmor + Xarina DSP, Tamron 3.0-9.0 mm motor vario, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018); dome form factor confirmed by the official Katalog 19 mount compatibility (TVAC31311 wall mount: IPCA72500, IPCA72510, IPCA72515, IPCA78500). IR range, IP rating, power, and dimensions omitted pending the official datasheet. Note: IPCA22500 from the same manual remains excluded — its form factor is still unconfirmed.",
+  "sources": [
+    "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca72510.json
+++ b/cameras/abus/ipca72510.json
@@ -1,70 +1,81 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca72510",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA72510",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "3.0 to 9.0",
+    "aperture": "F1.3 - F2.2 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "35 to 90 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 20,
+    "min_lux_color": 0.001
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "111 x 140 x 140",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "3x optical zoom",
+    "150 dB DOL WDR (3x shutter)",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca72515.json
+++ b/cameras/abus/ipca72515.json
@@ -1,70 +1,81 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca72515",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA72515",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "5.0 to 50.0",
+    "aperture": "F1.6 - F1.8 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "9 to 70 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 20,
+    "min_lux_color": 0.02
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "111 x 140 x 140",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "10x optical zoom",
+    "150 dB DOL WDR (3x shutter)",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipca72520.json
+++ b/cameras/abus/ipca72520.json
@@ -1,0 +1,75 @@
+{
+  "id": "abus-ipca72520",
+  "brand": "ABUS",
+  "model": "IPCA72520",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP dome 1080p — successor of the IPCA72500. Max 50/60 fps with WDR off.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca73500.json
+++ b/cameras/abus/ipca73500.json
@@ -1,0 +1,76 @@
+{
+  "id": "abus-ipca73500",
+  "brand": "ABUS",
+  "model": "IPCA73500",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "3MP",
+    "max_width": 2048,
+    "max_height": 1536,
+    "megapixels": 3.1
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 3 MPx per the dealer PIM designation. Max 50/60 fps with WDR off.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf",
+    "https://www.wilkon-sicherheitstechnik.de/epages/wilko1.sf/de_DE/?ObjectPath=/Shops/wilko1/Products/VICM_AS_IPCA73500"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca76500.json
+++ b/cameras/abus/ipca76500.json
@@ -1,0 +1,76 @@
+{
+  "id": "abus-ipca76500",
+  "brand": "ABUS",
+  "model": "IPCA76500",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "6MP",
+    "max_width": 3072,
+    "max_height": 2048,
+    "megapixels": 6.3
+  },
+  "video": {
+    "max_fps": 24,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "motor zoom with remote zoom/focus",
+    "WDR",
+    "SD-card edge recording with in-browser playback",
+    "master/installer user model"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 6 MPx per the dealer PIM designation. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual.",
+  "sources": [
+    "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+    "https://assets.abus.com/dam/132269_originalFile.pdf",
+    "https://www.wilkon-sicherheitstechnik.de/ABUS-Aussen-IP-Dome-IR-6MPx-IPCA76500"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipca78500.json
+++ b/cameras/abus/ipca78500.json
@@ -1,70 +1,81 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipca78500",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCA78500",
+  "type": "dome",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "8MP",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8.3
   },
   "video": {
-    "max_fps": 25,
+    "max_fps": 30,
     "codecs": [
       "H.264",
+      "H.265",
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "4.3 to 8.6",
+    "aperture": "F1.5 - F2.4 (W-T)",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "48 to 95 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 20,
+    "min_lux_color": 0.01
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "dc",
+    "ac-mains"
   ],
   "audio": {
+    "microphone": false,
+    "speaker": false,
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-25 to 55",
+  "dimensions_mm": "111 x 140 x 140",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
+    "2x optical zoom",
+    "120 dB WDR",
+    "Ultra Low-Light",
+    "Tripwire, intrusion, human detection, object counting VCA",
+    "IK10 vandal resistance",
+    "full-duplex 2-way audio",
     "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "microUSB service port",
+    "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+    "modular housing design"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipcb42510a.json
+++ b/cameras/abus/ipcb42510a.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb42510a",
+  "brand": "ABUS",
+  "model": "IPCB42510A",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "dimensions_mm": "100 x 97 x 53",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+  "sources": [
+    "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+    "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "108 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb42510b.json
+++ b/cameras/abus/ipcb42510b.json
@@ -1,0 +1,119 @@
+{
+  "id": "abus-ipcb42510b",
+  "brand": "ABUS",
+  "model": "IPCB42510B",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "dimensions_mm": "100 x 97 x 53",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+  "sources": [
+    "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Innendome/IP-Mini-Dome-2-MPx-1080p-4-mm",
+    "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+    "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "87 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb42510c.json
+++ b/cameras/abus/ipcb42510c.json
@@ -1,0 +1,119 @@
+{
+  "id": "abus-ipcb42510c",
+  "brand": "ABUS",
+  "model": "IPCB42510C",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "6",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "dimensions_mm": "100 x 97 x 53",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-Mini-Dome-2-MPx-1080p-6-mm",
+    "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+    "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "53 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb42515a.json
+++ b/cameras/abus/ipcb42515a.json
@@ -1,0 +1,128 @@
+{
+  "id": "abus-ipcb42515a",
+  "brand": "ABUS",
+  "model": "IPCB42515A",
+  "type": "dome",
+  "connectivity": [
+    "ethernet",
+    "wifi"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "108 horizontal / 59 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK08",
+  "audio": {
+    "microphone": true
+  },
+  "features": [
+    "WiFi 802.11 b/g/n + wired RJ45",
+    "built-in microphone + audio output",
+    "1x alarm input / 1x alarm output",
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G/T",
+    "flat 5 cm profile",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "97 x 100 x 53",
+  "weight_g": 400,
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL WLAN variant of the Basic-line 2 MPx mini dome — the only radio (RED-directive) model in the IPCB fixed-lens family; the 6x515/7x515 siblings are wired. All specs from the official ABUS datasheet.",
+  "sources": [
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf",
+    "https://www.abus.com/de/Archiv/IP-Mini-Dome-WLAN-2-MPx-1080p-2.8-mm",
+    "https://www.zajadacz.de/ABUS-IP-Mini-Dome-WLAN-2-MPx-IPCB42515A.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb44510b.json
+++ b/cameras/abus/ipcb44510b.json
@@ -1,0 +1,101 @@
+{
+  "id": "abus-ipcb44510b",
+  "brand": "ABUS",
+  "model": "IPCB44510B",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2688,
+    "max_height": 1520,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "88 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.008
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK08",
+  "features": [
+    "IK08 vandal-resistant housing",
+    "120 dB WDR",
+    "Ultra low-light performance",
+    "ONVIF Profile S/G",
+    "M12 fixed lens mount",
+    "Min. illumination 0.008 lux color / 0 lux IR",
+    "ABUS Link Station App support"
+  ],
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "100 x 97 x 53",
+  "weight_g": 400,
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "release_notes": "4 mm middle lens variant of the IPCB44510 mini dome family (A = 2.8 mm / 109°, B = 4 mm / 88°, C = 6 mm / 53°). Lens and FOV from the official ABUS archive product page; all shared-platform specs match the family datasheet.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-Mini-Dome-4-MPx-4-mm",
+    "https://c1.abus.com/uk/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-4-mm",
+    "https://www.expert-security.de/abus-ipcb44510b-ip-dome-1080p-t-n-ir-poe-ip66-ik08.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb62510a.json
+++ b/cameras/abus/ipcb62510a.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb62510a",
+  "brand": "ABUS",
+  "model": "IPCB62510A",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+  "sources": [
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+    "https://www.zajadacz.de/ABUS-IP-Mini-Tube-2-MPx-IPCB62510A.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "108 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "weight_g": 500,
+  "operating_temp_c": "-30 to 60",
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ]
+}

--- a/cameras/abus/ipcb62510b.json
+++ b/cameras/abus/ipcb62510b.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb62510b",
+  "brand": "ABUS",
+  "model": "IPCB62510B",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+  "sources": [
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+    "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-4-mm"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "87 horizontal / 45 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "weight_g": 500,
+  "operating_temp_c": "-30 to 60",
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ]
+}

--- a/cameras/abus/ipcb62510c.json
+++ b/cameras/abus/ipcb62510c.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb62510c",
+  "brand": "ABUS",
+  "model": "IPCB62510C",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "1920x1080",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "6",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+  "sources": [
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+    "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-6-mm"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "53 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10,
+    "min_lux_color": 0.009
+  },
+  "weight_g": 500,
+  "operating_temp_c": "-30 to 60",
+  "features": [
+    "Ultra low-light performance",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "Tripwire / intrusion detection VCA",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ]
+}

--- a/cameras/abus/ipcb62515a.json
+++ b/cameras/abus/ipcb62515a.json
@@ -1,0 +1,97 @@
+{
+  "id": "abus-ipcb62515a",
+  "brand": "ABUS",
+  "model": "IPCB62515A",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.005
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "120 dB WDR",
+    "motion detection (8 zones)",
+    "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Basic-line IP Tube 2 MPx (fixed 2.8 mm) — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190617-IPCB6x515AB_INST_DE_UK.pdf",
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/23/ABUS-Link-Station-Supported-devices.pdf",
+    "https://endlich-sicher.de/ip-tube-kamera-abus-ipcb62515a",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "108 horizontal",
+  "ip_rating": "IP67",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "160 x 160 x 390",
+  "power": {
+    "method": "12V DC / PoE (IEEE 802.3af)"
+  }
+}

--- a/cameras/abus/ipcb62520.json
+++ b/cameras/abus/ipcb62520.json
@@ -1,0 +1,105 @@
+{
+  "id": "abus-ipcb62520",
+  "brand": "ABUS",
+  "model": "IPCB62520",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.005
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+    "https://myloesch.com/de/smart-home-elektronik/videoueberwachung/"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "field_of_view_deg": "35 to 105 horizontal",
+  "ip_rating": "IP67",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "160 x 160 x 390",
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  }
+}

--- a/cameras/abus/ipcb64515b.json
+++ b/cameras/abus/ipcb64515b.json
@@ -1,0 +1,93 @@
+{
+  "id": "abus-ipcb64515b",
+  "brand": "ABUS",
+  "model": "IPCB64515B",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2688,
+    "max_height": 1520,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.008
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "IR LEDs",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Basic-line IP Tube 4 MPx (fixed 4 mm). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+    "https://www.manualslib.com/manual/2443358/Abus-Ipcb64515b.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "field_of_view_deg": "88 horizontal",
+  "ip_rating": "IP67",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "160 x 160 x 390"
+}

--- a/cameras/abus/ipcb64520.json
+++ b/cameras/abus/ipcb64520.json
@@ -1,0 +1,104 @@
+{
+  "id": "abus-ipcb64520",
+  "brand": "ABUS",
+  "model": "IPCB64520",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "megapixels": 4,
+    "max_width": 2688,
+    "max_height": 1520
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.008
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "field_of_view_deg": "32 to 114 horizontal",
+  "ip_rating": "IP67",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "160 x 160 x 390",
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  }
+}

--- a/cameras/abus/ipcb68510a.json
+++ b/cameras/abus/ipcb68510a.json
@@ -1,0 +1,115 @@
+{
+  "id": "abus-ipcb68510a",
+  "brand": "ABUS",
+  "model": "IPCB68510A",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "8MP (4K)",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "3840x2160",
+        "fps": 20
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+    "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "102 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10
+  },
+  "features": [
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb68510b.json
+++ b/cameras/abus/ipcb68510b.json
@@ -1,0 +1,116 @@
+{
+  "id": "abus-ipcb68510b",
+  "brand": "ABUS",
+  "model": "IPCB68510B",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "8MP (4K)",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "3840x2160",
+        "fps": 20
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+    "https://www.zajadacz.de/ABUS-IP-Mini-Tube-8-MPx-4K-IPCB68510A.html",
+    "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10
+  },
+  "features": [
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "field_of_view_deg": "79 horizontal",
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb68510c.json
+++ b/cameras/abus/ipcb68510c.json
@@ -1,0 +1,115 @@
+{
+  "id": "abus-ipcb68510c",
+  "brand": "ABUS",
+  "model": "IPCB68510C",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "8MP (4K)",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "3840x2160",
+        "fps": 20
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "6",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "dimensions_mm": "155 x 74 x 74",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-6-mm",
+    "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "field_of_view_deg": "50 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10
+  },
+  "features": [
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb68520.json
+++ b/cameras/abus/ipcb68520.json
@@ -1,0 +1,104 @@
+{
+  "id": "abus-ipcb68520",
+  "brand": "ABUS",
+  "model": "IPCB68520",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "8MP",
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.01
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "field_of_view_deg": "35 to 115 horizontal",
+  "ip_rating": "IP67",
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "160 x 160 x 390",
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  }
+}

--- a/cameras/abus/ipcb72515a.json
+++ b/cameras/abus/ipcb72515a.json
@@ -1,0 +1,96 @@
+{
+  "id": "abus-ipcb72515a",
+  "brand": "ABUS",
+  "model": "IPCB72515A",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "2MP (1080p)",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "varifocal": false
+  },
+  "field_of_view_deg": "108 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.005
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "ik_rating": "IK10",
+  "features": [
+    "IK10 vandal-resistant full dome",
+    "120 dB WDR",
+    "motion detection (8 zones)",
+    "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+    "ABUS Link Station App"
+  ],
+  "dimensions_mm": "143 x 143 x 100",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 2 MPx full-size vandal dome (fixed-lens dome family: IPCB72515A 2.8 mm / 108°, IPCB74515B 4 mm / 88°, IPCB78515A 2.8 mm / 102°; FOVs corroborated by the official ABUS Video/IP catalog). Sensor, IR range, weight, and operating temperature omitted: not confirmed from an official source for this variant.",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+    "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb72515a",
+    "https://manuals.plus/m/41e9eecc72014f49518f19ef80f4599ffbfe1827ef54d434bc1c5bf5ee7006d4"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "operating_temp_c": "-30 to 60",
+  "sensor": "1/2.8\" Progressive Scan CMOS"
+}

--- a/cameras/abus/ipcb72520.json
+++ b/cameras/abus/ipcb72520.json
@@ -1,0 +1,105 @@
+{
+  "id": "abus-ipcb72520",
+  "brand": "ABUS",
+  "model": "IPCB72520",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "35 to 105 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30,
+    "min_lux_color": 0.005
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "power": {
+    "method": "12V DC / PoE (IEEE 802.3af)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  },
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "143 x 100 x 143",
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output",
+    "ONVIF Profile S + G"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (2MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb74515b.json
+++ b/cameras/abus/ipcb74515b.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb74515b",
+  "brand": "ABUS",
+  "model": "IPCB74515B",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2688,
+    "max_height": 1520,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "2688x1520",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "88 horizontal / 46 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "ik_rating": "IK10",
+  "features": [
+    "IK10 vandal-resistant full dome",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "143 x 143 x 100",
+  "weight_g": 1100,
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 4 MPx full-size vandal dome; 4 mm / 88° per the official ABUS archive product page and the official Video/IP catalog. Platform table (sensor, F1.6, 143x143x100, 1100 g, streams, -30 to 60 °C) from the ABUS PIM data as republished by distributors; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings.",
+  "sources": [
+    "https://www.abus.com/ch_de/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-4-MPx-4-mm",
+    "https://www.expert-security.de/abus-ipcb74515b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
+    "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb74515b/jl56564"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb74520.json
+++ b/cameras/abus/ipcb74520.json
@@ -1,0 +1,105 @@
+{
+  "id": "abus-ipcb74520",
+  "brand": "ABUS",
+  "model": "IPCB74520",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2688,
+    "max_height": 1520,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "32 to 114 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30,
+    "min_lux_color": 0.008
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "power": {
+    "method": "12V DC / PoE (IEEE 802.3af)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  },
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "143 x 100 x 143",
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output",
+    "ONVIF Profile S + G"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (4MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb74615b.json
+++ b/cameras/abus/ipcb74615b.json
@@ -1,0 +1,85 @@
+{
+  "id": "abus-ipcb74615b",
+  "brand": "ABUS",
+  "model": "IPCB74615B",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "2.8-12 mm motor zoom",
+    "3-axis gimbal (pan/tilt/rotation)",
+    "IR LEDs",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+  "sources": [
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb78515a.json
+++ b/cameras/abus/ipcb78515a.json
@@ -1,0 +1,118 @@
+{
+  "id": "abus-ipcb78515a",
+  "brand": "ABUS",
+  "model": "IPCB78515A",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "8MP (4K)",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "3840x2160",
+        "fps": 20
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "field_of_view_deg": "102 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "ik_rating": "IK10",
+  "features": [
+    "IK10 vandal-resistant full dome",
+    "120 dB WDR",
+    "3D-DNR",
+    "motion detection (8 zones)",
+    "ONVIF Profile S/G",
+    "compatible with ABUS Secvest / wAppLoxx",
+    "ABUS Link Station App"
+  ],
+  "dimensions_mm": "143 x 143 x 100",
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line 8 MPx (4K) full-size vandal dome; 2.8 mm / 102° per the official ABUS archive product page and datasheet. Sensor, F2.0, dimensions, and streams from the official ABUS datasheet; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings. Weight and operating temperature omitted: not captured from the official sources reviewed.",
+  "sources": [
+    "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-8-MPx-4K-2.8-mm",
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002246401DS00/datablad-2246401-abus-ipcb78515a-lan-ip-overvagningskamera-3840-x-2160-pix.pdf",
+    "https://www.elektroshopwagner.de/product_info.php/info/p266293_ABUS-IPCB78515A-IP-Dome-8-MPx--4K--2-8-mm-.html",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "operating_temp_c": "-30 to 60"
+}

--- a/cameras/abus/ipcb78520.json
+++ b/cameras/abus/ipcb78520.json
@@ -1,0 +1,105 @@
+{
+  "id": "abus-ipcb78520",
+  "brand": "ABUS",
+  "model": "IPCB78520",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "8MP",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8.3
+  },
+  "video": {
+    "max_fps": 20,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "aperture": "F1.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "35 to 115 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30,
+    "min_lux_color": 0.01
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "power": {
+    "method": "12V DC / PoE (IEEE 802.3af)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  },
+  "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "143 x 100 x 143",
+  "features": [
+    "2.8-12 mm motor zoom (4.2x optical)",
+    "Ultra Low Light",
+    "120 dB WDR",
+    "IK10 vandal resistance",
+    "Tripwire / intrusion detection VCA",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output",
+    "ONVIF Profile S + G"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (8MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcb78615a.json
+++ b/cameras/abus/ipcb78615a.json
@@ -1,0 +1,87 @@
+{
+  "id": "abus-ipcb78615a",
+  "brand": "ABUS",
+  "model": "IPCB78615A",
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "8MP",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8.3
+  },
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "12V DC / PoE"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "features": [
+    "2.8-12 mm motor zoom",
+    "3-axis gimbal (pan/tilt/rotation)",
+    "IR LEDs",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+  "sources": [
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcs29511.json
+++ b/cameras/abus/ipcs29511.json
@@ -1,0 +1,114 @@
+{
+  "id": "abus-ipcs29511",
+  "brand": "ABUS",
+  "model": "IPCS29511",
+  "type": "fisheye",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "12MP",
+    "max_width": 4000,
+    "max_height": 3000,
+    "megapixels": 12
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Main (Fisheye)",
+        "resolution": "4000x3000",
+        "fps": 20
+      },
+      {
+        "name": "Main (Panorama)",
+        "resolution": "3072x2304",
+        "fps": 15
+      },
+      {
+        "name": "Sub",
+        "resolution": "704x576",
+        "fps": 15
+      }
+    ]
+  },
+  "field_of_view_deg": "360 horizontal",
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "hemispheric 360/180 degree panorama views",
+    "in-camera dewarping (hardware + up to 14 software view modes)",
+    "ePTZ with up to 255 presets and 32 tours",
+    "replaces up to 4 cameras (up to 4 video channels)",
+    "DWDR",
+    "people counting",
+    "heat map",
+    "intersection analysis",
+    "Tripwire / intrusion / region entry-exit / unattended baggage / object removal VCA",
+    "audio exception detection",
+    "1x alarm input / 1x alarm output",
+    "audio in/out (2-way audio)",
+    "8 privacy zones",
+    "NAS recording",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL 12 MPx Hemispheric IP fisheye — predecessor of the IPCS29512 (which added deep-learning people counting v2). All fields from the official ABUS user manual (20230425-IPCS29511_BDA_INT): 4000x3000 @ 20 fps fisheye main stream (2560x2560 @ 25/30 fps mode), panorama and multi-ePTZ view modes, IP66, mic + speaker with 2-way audio, alarm I/O, PoE/12V DC, microSD + NAS recording, DWDR, full smart-event suite. Sensor, lens, IR range, IK rating, microSD max size, dimensions, and weight omitted: the manual defers the spec table to the product page, and no official datasheet was recovered.",
+  "sources": [
+    "https://c1.abus.com/asc-pim-assets-01/medias/docus/28/20230425-IPCS29511_BDA_INT.pdf",
+    "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  }
+}

--- a/cameras/abus/ipcs62120.json
+++ b/cameras/abus/ipcs62120.json
@@ -1,0 +1,100 @@
+{
+  "id": "abus-ipcs62120",
+  "brand": "ABUS",
+  "model": "IPCS62120",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 60,
+    "codecs": [
+      "H.264",
+      "MPEG-4",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/1.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 to 12",
+    "varifocal": true
+  },
+  "field_of_view_deg": "32 to 92 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50,
+    "min_lux_color": 0.003
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "two_way": true
+  },
+  "dimensions_mm": "390 x 160",
+  "features": [
+    "ANPR license plate recognition (Europe, up to 70 km/h, 2048-plate allow/deny list)",
+    "1080p @ 50/60 fps",
+    "2.8-12 mm motor zoom (4.2x)",
+    "120 dB WDR",
+    "EIS electronic image stabilization, distortion correction",
+    "2-way audio (browser/CMS)",
+    "1 alarm input / 1 alarm output",
+    "analog video output"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL SPECIAL-line ANPR tube on the Basic Hikvision-OEM platform. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "sources": [
+    "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcs64511a.json
+++ b/cameras/abus/ipcs64511a.json
@@ -1,0 +1,121 @@
+{
+  "id": "abus-ipcs64511a",
+  "brand": "ABUS",
+  "model": "IPCS64511A",
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2688,
+    "max_height": 1520,
+    "megapixels": 4
+  },
+  "video": {
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "640x480",
+        "fps": 25,
+        "codec": "H.264"
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.264"
+      }
+    ]
+  },
+  "sensor": "1/1.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8",
+    "aperture": "F1.0",
+    "varifocal": false
+  },
+  "field_of_view_deg": "108 horizontal",
+  "night_vision": {
+    "type": "color",
+    "min_lux_color": 0.0005
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) or 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP67",
+  "features": [
+    "WDR 120 dB",
+    "full-color night vision",
+    "white light LEDs",
+    "person/vehicle detection",
+    "motion detection (up to 8 zones)",
+    "minimum illumination 0.0005 lux (color)",
+    "compatible with ABUS Secvest / Secoris / wAppLoxx Pro",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-25 to 60",
+  "dimensions_mm": "282 x 105 x 105",
+  "weight_g": 1000,
+  "release_year": 2023,
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "release_notes": "2.8 mm wide-angle variant of the Gecko IP Tube 4 MPx WL (A = 2.8 mm / 108°, B = 4 mm / 95°) per the official ABUS product pages. White-light LED range omitted: not stated per-variant in the official sources reviewed (retailer figures conflict with the B variant's documented 50 m).",
+  "sources": [
+    "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-mm-WL",
+    "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-2.8-mm-WL",
+    "https://www.zajadacz.de/ABUS-IP-Tube-4-MPx-2-8-mm-IPCS64511A.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcs82500.json
+++ b/cameras/abus/ipcs82500.json
@@ -1,16 +1,16 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipcs82500",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCS82500",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
     "max_fps": 25,
@@ -19,52 +19,58 @@
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "4.7 to 94",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "3.2 to 58.3 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 150,
+    "min_lux_color": 0.05
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "24V AC / High-PoE (IEEE 802.3bt)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "ac-mains"
   ],
   "audio": {
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-30 to 65",
+  "dimensions_mm": "185 x 330 x 185",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
-    "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "20x optical zoom",
+    "16x digital zoom",
+    "360 degree pan / -15 to 90 tilt",
+    "EIS electronic image stabilization",
+    "Defog",
+    "WDR, BLC, HLC",
+    "2 alarm inputs / 1 alarm output",
+    "RS485",
+    "analog video output",
+    "2-way audio (browser/CMS)"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (20x) — predecessor generation of the IPCS84550/84551 slot. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipcs82520.json
+++ b/cameras/abus/ipcs82520.json
@@ -1,16 +1,16 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipcs82520",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCS82520",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
     "max_fps": 25,
@@ -19,52 +19,59 @@
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/1.9\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "5.9 to 135.7",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "3.0 to 59.8 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 200,
+    "min_lux_color": 0.02
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "24V AC / High-PoE (IEEE 802.3bt)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "ac-mains"
   ],
   "audio": {
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-40 to 60",
+  "dimensions_mm": "266 x 365 x 266",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
-    "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "23x optical zoom",
+    "16x digital zoom",
+    "Ultra Low-Light (large 1/1.9 inch sensor)",
+    "120 dB True WDR",
+    "EIS electronic image stabilization",
+    "ROI, Defog",
+    "7 alarm inputs / 2 alarm outputs",
+    "RS485",
+    "analog video output",
+    "IK10 vandal resistance",
+    "2-way audio (browser/CMS)"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (23x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipcs82530.json
+++ b/cameras/abus/ipcs82530.json
@@ -1,16 +1,16 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipcs82530",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCS82530",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
   "resolution": {
-    "label": "3MP",
-    "max_width": 2048,
-    "max_height": 1536,
-    "megapixels": 3.1
+    "label": "2MP",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
   },
   "video": {
     "max_fps": 25,
@@ -19,52 +19,59 @@
       "MJPEG"
     ]
   },
-  "sensor": "1/3\" Progressive Scan CMOS",
+  "sensor": "1/1.9\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "5.7 to 205",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "2.0 to 59.0 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 200,
+    "min_lux_color": 0.02
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "24V AC / High-PoE (IEEE 802.3bt)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "ac-mains"
   ],
   "audio": {
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-40 to 60",
+  "dimensions_mm": "266 x 365 x 266",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
-    "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "36x optical zoom",
+    "16x digital zoom",
+    "Ultra Low-Light (large 1/1.9 inch sensor)",
+    "120 dB True WDR",
+    "EIS electronic image stabilization",
+    "ROI, Defog",
+    "7 alarm inputs / 2 alarm outputs",
+    "RS485",
+    "analog video output",
+    "IK10 vandal resistance",
+    "2-way audio (browser/CMS)"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (36x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipcs83500.json
+++ b/cameras/abus/ipcs83500.json
@@ -1,8 +1,8 @@
 {
-  "id": "abus-tvip83900",
+  "id": "abus-ipcs83500",
   "brand": "ABUS",
-  "model": "TVIP83900",
-  "type": "fisheye",
+  "model": "IPCS83500",
+  "type": "ptz",
   "connectivity": [
     "ethernet"
   ],
@@ -22,49 +22,54 @@
   "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "1.27",
-    "varifocal": false
+    "focal_length_mm": "4.5 to 162",
+    "varifocal": true
   },
-  "field_of_view_deg": "180/360",
+  "field_of_view_deg": "3.7 to 61.0 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 15,
-    "min_lux_color": 0.28
+    "range_m": 200,
+    "min_lux_color": 0.05
   },
   "storage": {
     "onboard": true,
-    "max_microsd_gb": 128,
+    "max_microsd_gb": 256,
     "nvr_compatible": true
   },
   "protocols": [
     "onvif",
     "rtsp"
   ],
-  "ip_rating": "IP24",
+  "ip_rating": "IP66",
   "power": {
-    "method": "12V DC / PoE (IEEE 802.3af)"
+    "method": "24V AC / High-PoE (IEEE 802.3bt)"
   },
   "power_source": [
     "poe",
-    "dc"
+    "ac-mains"
   ],
   "audio": {
     "two_way": true
   },
-  "operating_temp_c": "10 to 50",
-  "dimensions_mm": "164 x 44 x 153",
+  "operating_temp_c": "-40 to 60",
+  "dimensions_mm": "266 x 365 x 266",
   "features": [
-    "hemispheric 360/180 degree panorama views",
-    "ePTZ (360/80 degrees) with configurable tours",
-    "WDR, 3D DNR, BLC",
-    "1 alarm input / 1 alarm output",
-    "audio in/out"
+    "36x optical zoom",
+    "16x digital zoom",
+    "120 dB WDR",
+    "ROI, Defog",
+    "7 alarm inputs / 2 alarm outputs",
+    "RS485",
+    "analog video output",
+    "IK10 vandal resistance",
+    "2-way audio (browser/CMS)"
   ],
   "environment": [
+    "outdoor",
     "indoor"
   ],
   "status": "discontinued",
-  "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+  "release_notes": "Archived/EOL SPECIAL-line IP PTZ 3 MPx (36x). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
   "sources": [
     "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
   ],

--- a/cameras/abus/ipcs84510.json
+++ b/cameras/abus/ipcs84510.json
@@ -1,0 +1,127 @@
+{
+  "id": "abus-ipcs84510",
+  "brand": "ABUS",
+  "model": "IPCS84510",
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.264",
+      "H.265",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "2560x1440",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "704x576",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1280x720",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/3\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.8 - 12.0",
+    "aperture": "F1.6 - F2.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "31.6 to 96.7 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20,
+    "min_lux_color": 0.005
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) / 12V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "two_way": true
+  },
+  "features": [
+    "PTZ 355 pan / 0-90 tilt (100°/s)",
+    "4x optical zoom",
+    "16x digital zoom",
+    "120dB WDR",
+    "electronic image stabilization (EIS)",
+    "3D-DNR",
+    "IK10 vandal resistance",
+    "300 presets",
+    "Tripwire / intrusion detection VCA",
+    "Motion detection",
+    "2 relay outputs",
+    "Pelco D / Pelco P",
+    "ABUS Link Station App"
+  ],
+  "operating_temp_c": "-20 to 60",
+  "dimensions_mm": "131 x 131 x 102",
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "release_notes": "Predecessor of the IPCS84511 mini PTZ on the same Ø13 cm body; still supported by current mounts (TVAC31215/31285) on abus.com. Specs from the official ABUS datasheet. Power recorded from the datasheet spec table (12V DC / PoE 802.3af); the same datasheet's bullet list states '24 V AC & PoE' and recommends a High-PoE 60W injector for wall mounting — discrepancy left unresolved rather than guessed.",
+  "sources": [
+    "https://asset.conrad.com/media10/add/160267/c1/-/de/002237147DS00/datablad-2237147-abus-ipcs84510-ip-bewakingscamera-lan-2560-x-1440-pix.pdf",
+    "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Ceiling-Mount-for-IPCS84510",
+    "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcs84530.json
+++ b/cameras/abus/ipcs84530.json
@@ -1,0 +1,122 @@
+{
+  "id": "abus-ipcs84530",
+  "brand": "ABUS",
+  "model": "IPCS84530",
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "2560x1440",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "704x576",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "2560x1440",
+        "fps": 25
+      }
+    ]
+  },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.8 to 120",
+    "aperture": "F1.6 - F3.5",
+    "varifocal": true
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "max_microsd_gb": 256
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "features": [
+    "25x optical autofocus motor zoom (4.8-120 mm)",
+    "360 degree pan",
+    "300 presets / 8 tours (automated guard tours)",
+    "Ultra Low Light",
+    "WDR",
+    "2-way audio",
+    "1080p @ 50 fps mode",
+    "compact form factor for flush ceiling mount",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL IP PTZ 4 MPx (25x) — predecessor of the IPCS84531/IPCS84532 on the same 169 mm body (note: 1/2.5\" sensor vs 1/2.8\" in the successors). Full platform table (sensor, 4.8-120 mm F1.6-F3.5, FOV 2.5-57.6°, streams, 2-way audio, 12V DC / PoE+ 802.3at) from the official ABUS partner portal product data; IR 50 m, IP66, 360° pan, and ULL from the official ABUS archive product page. Weight and operating temperature omitted: not captured from official sources.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-25x",
+    "https://partner-ch.abus.com/de/silver.econtent/catalog/Produkte/Elektronische-Sicherheit/Professional-Sortiment/Videoueberwachung/Netzwerk/Kameras/SPECIAL/IP-PTZ-4-MPx-25x",
+    "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "sensor": "1/2.5\" Progressive Scan CMOS",
+  "field_of_view_deg": "2.5 to 57.6 horizontal",
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "dimensions_mm": "169 diameter x 161"
+}

--- a/cameras/abus/ipcs84531.json
+++ b/cameras/abus/ipcs84531.json
@@ -1,0 +1,100 @@
+{
+  "id": "abus-ipcs84531",
+  "brand": "ABUS",
+  "model": "IPCS84531",
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 25,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.8 to 120",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.5 to 53 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 50
+  },
+  "power": {
+    "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "features": [
+    "25x optical autofocus motor zoom",
+    "16x digital zoom",
+    "360 degree pan",
+    "300 presets / automated guard tours",
+    "Ultra Low Light",
+    "WDR",
+    "compact form factor for flush ceiling mount (TVAC31275/31375)",
+    "ABUS Link Station App"
+  ],
+  "dimensions_mm": "169 diameter x 161",
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "markets": [
+    "EU"
+  ],
+  "release_notes": "Predecessor of the IPCS84532 (same 169x161 mm body; the 84532 adds AI human/vehicle detection). Shares the official installation manual with IPCS84511 (220504-IPCS84511_84531_TVIP82561_BDA_INT). Still supported by current mounts (TVAC31205/31275) on abus.com. Audio, IK rating, weight, and operating temperature omitted: not confirmed from official sources for this variant.",
+  "sources": [
+    "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
+    "https://c1.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/PTZ/IP-PTZ-4-MPx-25x",
+    "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84531"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/abus/ipcs84550.json
+++ b/cameras/abus/ipcs84550.json
@@ -1,0 +1,119 @@
+{
+  "id": "abus-ipcs84550",
+  "brand": "ABUS",
+  "model": "IPCS84550",
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "label": "4MP",
+    "max_width": 2560,
+    "max_height": 1440,
+    "megapixels": 4
+  },
+  "video": {
+    "max_fps": 50,
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "Stream 1",
+        "resolution": "2560x1440",
+        "fps": 25
+      },
+      {
+        "name": "Stream 2",
+        "resolution": "704x576",
+        "fps": 25
+      },
+      {
+        "name": "Stream 3",
+        "resolution": "1920x1080",
+        "fps": 25
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.8 to 153",
+    "aperture": "F1.2 - F4.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.0 to 54.3 horizontal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 150
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "32x optical zoom",
+    "16x digital zoom",
+    "120 dB WDR",
+    "Ultra Low Light",
+    "Smart Tracking",
+    "Tripwire / intrusion detection VCA",
+    "300 presets / 8 tours",
+    "2 alarm inputs / 1 alarm output",
+    "1080p @ 50 fps mode",
+    "ABUS Link Station App"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "status": "discontinued",
+  "release_notes": "Archived/EOL IP PTZ 4 MPx (32x) — predecessor of the IPCS84551 (which moved to a 1/1.8\" sensor, 5.9-189 mm lens, and 200 m IR). Platform table (sensor, 4.8-153 mm F1.2-F4.4, FOV, streams, audio, alarm I/O, Smart Tracking) from the ABUS PIM data as republished by distributors, alongside the official archive product page and the official joint IPCS84530/IPCS84550 manual. IR 150 m from a distributor spec listing (single secondary source — flagged for verification against the official datasheet). Power method (PoE class), weight, and dimensions omitted: unconfirmed.",
+  "sources": [
+    "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-32x",
+    "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf",
+    "https://www.abus-alarmanlagen.ch/video/netzwerkkameras/abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66/",
+    "https://www.aesag.ch/en/network-cameras/2778-abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66-ipcs84550.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "recommended_stream_type": "go2rtc",
+      "verified": false,
+      "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+    },
+    "home_assistant": {
+      "integration": "onvif",
+      "connection_type": "local_push",
+      "onvif_events": true,
+      "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+    },
+    "blue_iris": {
+      "profile": "Hikvision",
+      "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "power_source": [
+    "poe",
+    "dc"
+  ]
+}

--- a/cameras/abus/ppic42520b.json
+++ b/cameras/abus/ppic42520b.json
@@ -1,0 +1,91 @@
+{
+  "id": "abus-ppic42520b",
+  "brand": "ABUS",
+  "model": "PPIC42520B",
+  "aliases": [
+    "ABUS Wireless Pan/Tilt Outdoor Camera (black)"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "markets": [
+    "AT",
+    "CH",
+    "DE",
+    "EU"
+  ],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "Full HD (1080p)"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.1",
+    "aperture": "F2.0",
+    "varifocal": false,
+    "count": 1
+  },
+  "field_of_view_deg": "355 pan / 90 tilt",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "DC 5V"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": false,
+    "cloud": false
+  },
+  "protocols": [],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "ABUS App2Cam Plus outdoor pan/tilt",
+    "355deg pan / 90deg tilt",
+    "3MP 2K",
+    "person/animal/vehicle detection",
+    "two-way audio",
+    "GDPR-compliant local storage",
+    "IP66",
+    "German brand"
+  ],
+  "sources": [
+    "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wireless-Pan-Tilt-Outdoor-Camera",
+    "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-WiFi-Pan-Tilt-Outdoor-Camera"
+  ],
+  "power_source": [
+    "dc"
+  ],
+  "video": {
+    "codecs": [
+      "H.264"
+    ],
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "dimensions_mm": "210 x 120 x 160",
+  "weight_g": 650,
+  "operating_temp_c": "-10 to 50",
+  "last_verified": "2026-07-26",
+  "release_notes": "Black housing variant of the PPIC42520 WiFi Pan/Tilt Outdoor Camera. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs."
+}

--- a/cameras/abus/ppic46520w.json
+++ b/cameras/abus/ppic46520w.json
@@ -1,0 +1,82 @@
+{
+  "id": "abus-ppic46520w",
+  "brand": "ABUS",
+  "model": "PPIC46520W",
+  "aliases": [
+    "ABUS Wi-Fi Light Outdoor Camera (white)"
+  ],
+  "type": "floodlight",
+  "connectivity": [
+    "wifi"
+  ],
+  "markets": [
+    "DE",
+    "AT",
+    "CH",
+    "EU"
+  ],
+  "resolution": {
+    "megapixels": 2,
+    "label": "2K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4",
+    "aperture": "F2.0",
+    "varifocal": false,
+    "count": 1
+  },
+  "field_of_view_deg": "110 horizontal",
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 8
+  },
+  "power": {
+    "method": "AC 90-260V"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": false,
+    "cloud": false
+  },
+  "protocols": [],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "replaces outdoor light fitting (like Netatmo Presence)",
+    "1000-lumen LED outdoor light",
+    "person/animal/vehicle/car AI detection",
+    "PIR sensor",
+    "two-way audio",
+    "App2Cam Plus",
+    "GDPR-compliant local microSD",
+    "no mandatory subscription",
+    "German brand"
+  ],
+  "sources": [
+    "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wi-Fi-Light-Outdoor-Camera2",
+    "https://security.abus.com/Videoueberwachung/ABUS-WLAN-Licht-Aussen-Kamera.html"
+  ],
+  "power_source": [
+    "ac-mains"
+  ],
+  "video": {
+    "codecs": [
+      "H.264"
+    ],
+    "max_fps": 20
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "dimensions_mm": "75 x 155 x 180",
+  "weight_g": 985,
+  "operating_temp_c": "-20 to 50",
+  "last_verified": "2026-07-26",
+  "release_notes": "White housing variant of the PPIC46520 Wi-Fi Light Outdoor Camera, listed as new on abus.com (07/2026). Shares the official user guide with the base model (guide covers PPIC46520 / PPIC46520W); only the housing color differs."
+}

--- a/cameras/abus/ppic52520b.json
+++ b/cameras/abus/ppic52520b.json
@@ -1,0 +1,87 @@
+{
+  "id": "abus-ppic52520b",
+  "brand": "ABUS",
+  "model": "PPIC52520B",
+  "aliases": [
+    "ABUS SmartLook Pan & Tilt (black)"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "wifi",
+    "ethernet"
+  ],
+  "markets": [
+    "DE",
+    "EU"
+  ],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "2 MP (4K-interpolated recording)"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4",
+    "aperture": "F2.0",
+    "varifocal": false,
+    "count": 1
+  },
+  "field_of_view_deg": "85 horizontal / 45 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "DC 5V"
+  },
+  "power_source": [
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256,
+    "nvr_compatible": false,
+    "cloud": false
+  },
+  "protocols": [],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "video": {
+    "codecs": [
+      "H.264",
+      "H.264+"
+    ],
+    "max_fps": 15
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "dimensions_mm": "210 x 120 x 160",
+  "weight_g": 650,
+  "operating_temp_c": "-10 to 50",
+  "features": [
+    "4K-interpolated recording (native 2 MP sensor)",
+    "outdoor pan/tilt (270° pan / 80° tilt)",
+    "person/animal/vehicle detection",
+    "two-way audio",
+    "siren",
+    "privacy zones",
+    "5s pre-recording",
+    "local microSD (256GB, no cloud)",
+    "App2Cam Plus",
+    "WiFi 2.4/5 GHz",
+    "German brand"
+  ],
+  "sources": [
+    "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook-pan-tilt2",
+    "https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html",
+    "https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE"
+  ],
+  "last_verified": "2026-07-26",
+  "release_notes": "Black housing variant of the PPIC52520 SmartLook Pan & Tilt. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs."
+}

--- a/cameras/abus/ppic54520b.json
+++ b/cameras/abus/ppic54520b.json
@@ -1,0 +1,85 @@
+{
+  "id": "abus-ppic54520b",
+  "brand": "ABUS",
+  "model": "PPIC54520B",
+  "aliases": [
+    "ABUS SmartLook (black)"
+  ],
+  "type": "box",
+  "connectivity": [
+    "wifi",
+    "ethernet"
+  ],
+  "markets": [
+    "DE",
+    "AT",
+    "CH",
+    "EU"
+  ],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "2 MP (4K-interpolated recording)"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4",
+    "aperture": "F2.0",
+    "varifocal": false,
+    "count": 1
+  },
+  "field_of_view_deg": "85 horizontal / 45 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 10
+  },
+  "power": {
+    "method": "DC 5V"
+  },
+  "power_source": [
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 128,
+    "nvr_compatible": false,
+    "cloud": false
+  },
+  "protocols": [],
+  "ip_rating": "IP66",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "video": {
+    "codecs": [
+      "H.264",
+      "H.264+"
+    ],
+    "max_fps": 15
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "dimensions_mm": "167 x 48 x 80",
+  "weight_g": 433,
+  "operating_temp_c": "-10 to 50",
+  "features": [
+    "4K-interpolated recording (native 2 MP sensor)",
+    "App2Cam Plus",
+    "person/animal/vehicle detection",
+    "5s pre-recording",
+    "privacy masking",
+    "dual-band WiFi (2.4/5 GHz)",
+    "local microSD (no cloud)",
+    "German brand"
+  ],
+  "sources": [
+    "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook2",
+    "https://security.abus.com/Videoueberwachung/SmartLook-abus.html"
+  ],
+  "last_verified": "2026-07-26",
+  "release_notes": "Black housing variant of the PPIC54520 SmartLook. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs."
+}

--- a/cameras/tapo/c217.json
+++ b/cameras/tapo/c217.json
@@ -1,0 +1,103 @@
+{
+  "id": "tapo-c217",
+  "brand": "Tapo",
+  "model": "Tapo C217",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "resolution": {
+    "label": "2K 3MP",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 2.99
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "field_of_view_deg": "98 diagonal / 83 horizontal / 47 vertical",
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 12
+  },
+  "power": {
+    "method": "DC power adapter with 2 m USB adapter cable"
+  },
+  "power_source": [
+    "dc"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP65",
+  "features": [
+    "HybridCam 360 indoor/outdoor pan/tilt",
+    "360 degree horizontal pan / 152 degree vertical tilt",
+    "full-color night vision with built-in spotlights",
+    "IR night vision",
+    "smart motion tracking",
+    "person detection",
+    "baby cry detection",
+    "customizable activity and privacy zones",
+    "sound and light alarm",
+    "two-way audio",
+    "Tapo H500 hub storage (up to 16 TB)",
+    "Alexa / Google Assistant / Samsung SmartThings",
+    "no subscription required"
+  ],
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "release_notes": "Indoor/outdoor 2K pan/tilt camera (HybridCam 360 line). Sensor, 4 mm F2.0 lens (both stated with +/-5% tolerance officially), full FOV triplet, IP65, and 512 GB microSD limit from the official Tapo product page specification table and the official TP-Link C217 datasheet; 30 fps, 360/152 degree pan-tilt range, and ONVIF compliance from the authorized-distributor product description. Dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c217/",
+    "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c217/",
+    "https://manuals.plus/m/b590be04aaf9c900dd1085af215325e8cefa5da5b6de0fdff19cd1f50b7fdaec",
+    "https://www.bhphotovideo.com/c/product/1922982-REG/tp_link_tapo_c217_indoor_outdoor_home.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "verified": false,
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+    },
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/tapo/c245d.json
+++ b/cameras/tapo/c245d.json
@@ -1,0 +1,108 @@
+{
+  "id": "tapo-c245d",
+  "brand": "Tapo",
+  "model": "Tapo C245D",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "resolution": {
+    "label": "2K (3MP per lens)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 2.99
+  },
+  "video": {
+    "codecs": [
+      "H.264"
+    ],
+    "streams": [
+      {
+        "name": "Wide-angle lens",
+        "resolution": "2304x1296"
+      },
+      {
+        "name": "Telephoto pan/tilt lens",
+        "resolution": "2304x1296"
+      }
+    ]
+  },
+  "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "3.1 (wide-angle) / 6.0 (telephoto pan-tilt)",
+    "aperture": "F1.6 (wide-angle)",
+    "varifocal": false
+  },
+  "field_of_view_deg": "121.8 diagonal / 104.3 horizontal / 57.9 vertical (wide-angle lens)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 12
+  },
+  "power": {
+    "method": "DC power adapter"
+  },
+  "power_source": [
+    "dc"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "dual 2K 3MP lenses (wide-angle + telephoto)",
+    "Synchronized Smart Tracking (fixed lens detects, pan/tilt lens follows)",
+    "One-Tap Smart Focus",
+    "10.8x digital zoom on telephoto lens",
+    "motorized pan/tilt on telephoto lens",
+    "wide-angle lens manually adjustable -15 to 15 degrees vertically",
+    "AI person / pet / vehicle / motion detection",
+    "baby cry detection",
+    "two-way audio",
+    "Alexa / Google Home / Samsung SmartThings",
+    "Tapo H200 / H500 hub unified storage",
+    "no subscription required for AI detection"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "release_notes": "Indoor dual-lens pan/tilt camera (2026) — the indoor counterpart of the indoor/outdoor C246D and the outdoor C545D. Sensor, both focal lengths, wide-angle aperture and full wide-angle FOV triplet, dual 2304x1296 resolution, 10.8x digital zoom, and 512 GB microSD from the official Tapo product page specification table as republished verbatim by distributors. Night vision stated officially as 40 ft (approx. 12 m), IR black-and-white. Telephoto aperture, telephoto FOV, frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source.",
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c245d/",
+    "https://www.tp-link.com/en/home-networking/cloud-camera/tapo-c245d/",
+    "https://pcworx.ph/products/tapo-c245d-dual-lens-pan-tilt-security-camera"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "verified": false,
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+    },
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/tapo/c250.json
+++ b/cameras/tapo/c250.json
@@ -1,0 +1,98 @@
+{
+  "id": "tapo-c250",
+  "brand": "Tapo",
+  "model": "Tapo C250",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "resolution": {
+    "label": "4K 8MP",
+    "max_width": 3840,
+    "max_height": 2160,
+    "megapixels": 8.3
+  },
+  "video": {
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "1/2.7\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0",
+    "aperture": "F1.6",
+    "varifocal": false
+  },
+  "field_of_view_deg": "105.4 diagonal / 88 horizontal / 46 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 12
+  },
+  "power": {
+    "method": "DC power adapter"
+  },
+  "power_source": [
+    "dc"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "4K 8MP resolution",
+    "360 degree horizontal pan / 116 degree vertical tilt",
+    "AI Auto-Zoom Tracking",
+    "motion / person / pet / vehicle detection",
+    "line-crossing detection",
+    "lens tamper detection",
+    "baby cry detection",
+    "abnormal sound detection (glass breaking, meow, bark)",
+    "customizable block/privacy zones",
+    "two-way audio with noise cancellation",
+    "Alexa / Google Assistant",
+    "free AI detection (no subscription)"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "release_notes": "Indoor 4K pan/tilt AI camera. Sensor, 4 mm F1.6 lens, full FOV triplet, 4K 8MP resolution, 360/116 degree pan-tilt range, 512 GB microSD limit, and the full AI detection list from the official Tapo product page specification table (Tapo C250_V1 Datasheet), cross-checked against distributor republications of the same table. Frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c250/",
+    "https://www.tp-link.com/sg/home-networking/cloud-camera/tapo-c250/",
+    "https://www.pbtech.com/pacific/product/CCTTPL8250/TP-Link-Tapo-C250-8MP4K-Indoor-PT-Wi-Fi-Camera-AI"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "verified": false,
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+    },
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/tapo/c403.json
+++ b/cameras/tapo/c403.json
@@ -1,0 +1,86 @@
+{
+  "brand": "Tapo",
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.17",
+    "aperture": "F1.65",
+    "varifocal": false
+  },
+  "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 9
+  },
+  "power": {
+    "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+  },
+  "power_source": [
+    "battery",
+    "solar"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP65",
+  "operating_temp_c": "-20 to 45",
+  "dimensions_mm": "60 diameter x 89",
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "configs": {
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "id": "tapo-c403",
+  "model": "Tapo C403",
+  "resolution": {
+    "label": "1080p Full HD",
+    "max_width": 1920,
+    "max_height": 1080,
+    "megapixels": 2
+  },
+  "video": {
+    "max_fps": 15,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "features": [
+    "100% wire-free battery-powered",
+    "up to 180-day battery life",
+    "full-color night vision with 2x spotlights",
+    "850 nm IR LED night vision",
+    "smart person detection",
+    "activity zones",
+    "94 dB siren",
+    "3DNR and WDR image enhancement",
+    "PIR motion sensor (110 deg, 10 sensitivity levels)",
+    "ambient light sensor",
+    "two-way audio with noise cancellation",
+    "Tapo H200 hub unified local storage support",
+    "Alexa / Google Assistant",
+    "no subscription required"
+  ],
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c403/"
+  ],
+  "release_notes": "Battery-powered indoor/outdoor camera — the 1080p sibling of the 2K C410 on an identical optical and mechanical platform (same 1/2.8\" starlight sensor, 3.17 mm F1.65 lens, 125 deg diagonal FOV, 60 x 89 mm body, IP65, 180-day battery). All specs from the official Tapo product page specification table. No RTSP/ONVIF on the battery/solar line, so no Frigate or Blue Iris config is provided. Solar-powered kit variant is the Tapo C403 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer."
+}

--- a/cameras/tapo/c410.json
+++ b/cameras/tapo/c410.json
@@ -1,0 +1,88 @@
+{
+  "brand": "Tapo",
+  "type": "bullet",
+  "connectivity": [
+    "wifi"
+  ],
+  "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.17",
+    "aperture": "F1.65",
+    "varifocal": false
+  },
+  "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 9
+  },
+  "power": {
+    "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+  },
+  "power_source": [
+    "battery",
+    "solar"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP65",
+  "operating_temp_c": "-20 to 45",
+  "dimensions_mm": "60 diameter x 89",
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "configs": {
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26",
+  "id": "tapo-c410",
+  "model": "Tapo C410",
+  "resolution": {
+    "label": "2K 3MP",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 3
+  },
+  "video": {
+    "max_fps": 15,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "features": [
+    "100% wire-free battery-powered",
+    "up to 180-day battery life",
+    "full-color night vision with 2x spotlights",
+    "850 nm IR LED night vision",
+    "smart person detection",
+    "activity zones",
+    "94 dB siren",
+    "3DNR and WDR image enhancement",
+    "PIR motion sensor (110 deg, 10 sensitivity levels)",
+    "ambient light sensor",
+    "two-way audio with noise cancellation",
+    "Tapo H200 hub unified local storage support",
+    "Alexa / Google Assistant",
+    "no subscription required"
+  ],
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c410/",
+    "https://www.tapo.com/en/document/50810/",
+    "https://www.tapo.com/en/document/51028/"
+  ],
+  "release_notes": "Battery-powered outdoor camera (V2 hardware). All specs from the official Tapo product page specification table. No RTSP/ONVIF: TP-Link's battery/solar camera line exposes no local stream, so no Frigate or Blue Iris config is provided rather than a fabricated RTSP path — consistent with the C400/C402/C420/C425 entries. Solar-powered kit variant is the Tapo C410 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer."
+}

--- a/cameras/tapo/c545d.json
+++ b/cameras/tapo/c545d.json
@@ -1,0 +1,96 @@
+{
+  "id": "tapo-c545d",
+  "brand": "Tapo",
+  "model": "Tapo C545D",
+  "type": "ptz",
+  "connectivity": [
+    "wifi"
+  ],
+  "resolution": {
+    "label": "2K (3MP per lens)",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 2.99
+  },
+  "video": {
+    "codecs": [
+      "H.264"
+    ],
+    "streams": [
+      {
+        "name": "Wide-angle lens",
+        "resolution": "2304x1296"
+      },
+      {
+        "name": "Telephoto pan/tilt lens",
+        "resolution": "2304x1296"
+      }
+    ]
+  },
+  "lens": {
+    "count": 2,
+    "varifocal": false
+  },
+  "field_of_view_deg": "121 diagonal / 95 horizontal / 57.3 vertical (wide-angle lens); 31.7 vertical (telephoto lens)",
+  "night_vision": {
+    "type": "hybrid"
+  },
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power_source": [
+    "dc"
+  ],
+  "features": [
+    "dual 2K 3MP lenses (wide-angle + telephoto)",
+    "synchronized smart detection and tracking",
+    "color night vision",
+    "motorized pan/tilt on telephoto lens",
+    "wide-angle lens manual pan 270 degrees, tilt -30 to -10 degrees",
+    "wall, ceiling or rod mounting",
+    "Alexa / Google Assistant / Samsung SmartThings",
+    "Tapo Care cloud or local microSD storage"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "release_notes": "Outdoor dual-lens pan/tilt camera — the outdoor counterpart of the indoor C245D and indoor/outdoor C246D. Dual 2K 3MP resolution, both lens FOV figures, the wide-angle manual pan/tilt ranges, motorized telephoto control, colour night vision, and 512 GB microSD from the official TP-Link C545D datasheet. Sensor, focal lengths, apertures, IR range, IP rating, power method, dimensions, and weight omitted: not present in the recovered datasheet text.",
+  "sources": [
+    "https://www.tapo.com/en/product/smart-camera/tapo-c545d/",
+    "https://manuals.plus/m/25fd9cf1ca4000dcfcba1ecd9b383147b3fd481b4ac5735e94f324b76441574d"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "verified": false,
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+    },
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/cameras/tapo/c710.json
+++ b/cameras/tapo/c710.json
@@ -1,0 +1,102 @@
+{
+  "id": "tapo-c710",
+  "brand": "Tapo",
+  "model": "Tapo C710",
+  "type": "floodlight",
+  "connectivity": [
+    "wifi"
+  ],
+  "resolution": {
+    "label": "2K 3MP",
+    "max_width": 2304,
+    "max_height": 1296,
+    "megapixels": 2.99
+  },
+  "video": {
+    "max_fps": 30,
+    "codecs": [
+      "H.264"
+    ]
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0",
+    "aperture": "F2.0",
+    "varifocal": false
+  },
+  "field_of_view_deg": "98.1 diagonal / 82.8 horizontal / 44.5 vertical",
+  "night_vision": {
+    "type": "hybrid",
+    "range_m": 30
+  },
+  "power": {
+    "method": "Hardwired mains (mounts over a standard wall junction box; neutral + line wires)"
+  },
+  "power_source": [
+    "ac-mains"
+  ],
+  "storage": {
+    "onboard": false,
+    "max_microsd_gb": 512,
+    "nvr_compatible": false,
+    "cloud": true
+  },
+  "protocols": [
+    "rtsp",
+    "onvif"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP65",
+  "features": [
+    "1500-lumen dimmable floodlight (4000K, motion-activated, app-controlled)",
+    "pan mechanical 338 degrees (360 coverage) / tilt 97 degrees (140 coverage)",
+    "dedicated PIR sensor on floodlight (165 degrees, 25 ft) independent of camera direction",
+    "360-degree AI motion tracking",
+    "person / pet / vehicle detection",
+    "scheduled 360-degree panoramic scans and patrol mode",
+    "24/7 continuous recording (hardwired)",
+    "10.8x digital zoom",
+    "3D DNR, BLC, WDR",
+    "full-color night vision + IR",
+    "sound and light alarm (customizable)",
+    "two-way audio with noise cancellation",
+    "Alexa / Google Assistant",
+    "no subscription required"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "release_notes": "Hardwired pan/tilt floodlight camera (US launch February 2026). Complete specification from the official Tapo product page spec table: sensor, 4.0 mm F2.0 lens, full FOV triplet, IR 98 ft / 30 m plus full-color night vision, 1500 lm 4000K floodlight, mechanical pan/tilt ranges, PIR coverage, 30 fps, 10.8x digital zoom, 512 GB microSD, IP65. RTSP/ONVIF listed per the mains-powered Tapo pattern with verified:false — confirm on hardware, as floodlight models occasionally differ.",
+  "sources": [
+    "https://www.tapo.com/us/product/smart-camera/tapo-c710/",
+    "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c710/",
+    "https://www.notebookcheck.net/Tapo-releases-new-security-camera-with-bright-floodlight.1225415.0.html"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "verified": false,
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 main, /stream2 sub. Not bench-verified on the C710 specifically."
+    },
+    "home_assistant": {
+      "integration": "tapo",
+      "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+    },
+    "blue_iris": {
+      "profile": "Generic/ONVIF",
+      "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Enable the Camera Account in the Tapo app first."
+    }
+  },
+  "last_verified": "2026-07-26"
+}

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -2,24 +2,47 @@ id,brand,model,type,resolution_label,megapixels,sensor,field_of_view_deg,night_v
 abus-hdcc35512,ABUS,HDCC35512,bullet,5MP,5,"1/2.8"" Progressive Scan CMOS","112 horizontal, 60 vertical",hybrid,IP67,,false,
 abus-hdcc52512,ABUS,HDCC52512,dome,1080p,2,"1/2.8"" Progressive Scan CMOS","105 horizontal, 56 vertical",hybrid,IP67,,true,
 abus-hdcc75550,ABUS,HDCC75550,dome,5MP,5,"1/2.7\"" Progressive Scan CMOS",92 to 29 horizontal,ir,IP67,,,
+abus-ipca32500,ABUS,IPCA32500,dome,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",,ir,IP24,,true,
+abus-ipca33500,ABUS,IPCA33500,dome,3MP,3.1,,,ir,,,,
 abus-ipca34512a,ABUS,IPCA34512A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,,false,
 abus-ipca34512b,ABUS,IPCA34512B,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","89 horizontal, 45 vertical",hybrid,IP67,,false,
 abus-ipca34612a,ABUS,IPCA34612A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,,false,
+abus-ipca52000,ABUS,IPCA52000,box,2MP,2,Sony Exmor CMOS (Sony Xarina DSP),,ir,,,,
+abus-ipca52010,ABUS,IPCA52010,box,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",,none,IP20,,true,
+abus-ipca53000,ABUS,IPCA53000,box,3MP,3.1,,,,,,,
 abus-ipca54512a,ABUS,IPCA54512A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",110 horizontal / 57 vertical,hybrid,IP67,,false,
 abus-ipca54512b,ABUS,IPCA54512B,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",95 horizontal,hybrid,IP67,,false,2023
 abus-ipca54572a,ABUS,IPCA54572A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",110 horizontal,hybrid,IP67,,true,
 abus-ipca54581b,ABUS,IPCA54581B,dual-lens,4MP,4,"1/2.7"" Progressive Scan CMOS","84 horizontal / 43 vertical (optical), 50 horizontal (thermal)",ir,IP66,,true,
 abus-ipca54612a,ABUS,IPCA54612A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS","110 horizontal, 57 vertical",hybrid,IP67,,false,
+abus-ipca62510,ABUS,IPCA62510,bullet,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",35 to 90 horizontal,ir,IP67,,true,
+abus-ipca62515,ABUS,IPCA62515,bullet,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",9 to 70 horizontal,ir,IP67,,true,
+abus-ipca62520,ABUS,IPCA62520,bullet,2MP,2,,,ir,,,,
+abus-ipca63500,ABUS,IPCA63500,bullet,3MP,3.1,,,ir,,,,
 abus-ipca64512a,ABUS,IPCA64512A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,,,
 abus-ipca64512b,ABUS,IPCA64512B,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","89 horizontal, 45 vertical",hybrid,IP67,,false,
 abus-ipca64581d,ABUS,IPCA64581D,dual-lens,4MP,4,"1/2.7"" Progressive Scan CMOS","39.5 horizontal (visible), 18 horizontal (thermal)",ir,IP67,,true,2022
 abus-ipca64612a,ABUS,IPCA64612A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","104 horizontal, 54 vertical",hybrid,IP67,,false,
+abus-ipca66500,ABUS,IPCA66500,bullet,6MP,6.3,,,ir,,,,
+abus-ipca68500,ABUS,IPCA68500,bullet,8MP,8.3,"1/1.8"" Sony Exmor R STARVIS CMOS",48 to 95 horizontal,ir,IP67,,true,
+abus-ipca72500,ABUS,IPCA72500,dome,2MP,2,Sony Exmor CMOS (Sony Xarina DSP),,ir,,,,
+abus-ipca72510,ABUS,IPCA72510,dome,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",35 to 90 horizontal,ir,IP66,,true,
+abus-ipca72515,ABUS,IPCA72515,dome,2MP,2,"1/2.8"" Sony Exmor R STARVIS CMOS",9 to 70 horizontal,ir,IP66,,true,
+abus-ipca72520,ABUS,IPCA72520,dome,2MP,2,,,ir,,,,
+abus-ipca73500,ABUS,IPCA73500,dome,3MP,3.1,,,ir,,,,
+abus-ipca76500,ABUS,IPCA76500,dome,6MP,6.3,,,ir,,,,
+abus-ipca78500,ABUS,IPCA78500,dome,8MP,8.3,"1/1.8"" Sony Exmor R STARVIS CMOS",48 to 95 horizontal,ir,IP66,,true,
 abus-ipcb34511a,ABUS,IPCB34511A,bullet,4MP,4,"1/2.7"" Progressive Scan CMOS",103 horizontal,ir,IP67,,false,
 abus-ipcb34511b,ABUS,IPCB34511B,bullet,4MP,4,"1/2.7"" Progressive Scan CMOS",83 horizontal,ir,IP67,,false,
 abus-ipcb34611a,ABUS,IPCB34611A,bullet,4MP,4.1,"1/2.7"" Progressive Scan CMOS",103 horizontal,ir,IP67,,false,
 abus-ipcb38511a,ABUS,IPCB38511A,bullet,4K,8,"1/1.8"" Progressive Scan CMOS","102 horizontal, 55 vertical",ir,IP67,,false,
 abus-ipcb38511b,ABUS,IPCB38511B,bullet,4K Ultra HD,8,"1/1.8"" Progressive Scan CMOS",78 horizontal,ir,IP67,,false,
+abus-ipcb42510a,ABUS,IPCB42510A,dome,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",108 horizontal,ir,IP66,,,
+abus-ipcb42510b,ABUS,IPCB42510B,dome,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",87 horizontal,ir,IP66,,,
+abus-ipcb42510c,ABUS,IPCB42510C,dome,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",53 horizontal,ir,IP66,,,
+abus-ipcb42515a,ABUS,IPCB42515A,dome,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",108 horizontal / 59 vertical,ir,IP66,IK08,,
 abus-ipcb44510a,ABUS,IPCB44510A,dome,4MP,4,"1/2.5"" Progressive Scan CMOS",109 horizontal,ir,IP66,IK08,,
+abus-ipcb44510b,ABUS,IPCB44510B,dome,4MP,4,"1/2.5"" Progressive Scan CMOS",88 horizontal,ir,IP66,IK08,,
 abus-ipcb44510c,ABUS,IPCB44510C,dome,QHD,4,"1/2.5"" CMOS","53 horizontal, 30 vertical",ir,IP66,IK08,,
 abus-ipcb44511a,ABUS,IPCB44511A,dome,4MP,4,"1/2.7"" Progressive Scan CMOS",103 horizontal,ir,IP67,IK08,false,
 abus-ipcb44511b,ABUS,IPCB44511B,dome,4MP,4,"1/2.7"" Progressive Scan CMOS",83 horizontal,ir,IP67,IK08,,
@@ -32,19 +55,39 @@ abus-ipcb54611b,ABUS,IPCB54611B,dome,4MP,4,"1/2.7"" Progressive Scan CMOS",83 ho
 abus-ipcb58511a,ABUS,IPCB58511A,dome,4K UHD,8,"1/1.8"" Progressive Scan CMOS",102 horizontal,ir,IP67,,false,
 abus-ipcb58511b,ABUS,IPCB58511B,dome,4K,8,"1/1.8"" Progressive Scan CMOS",82 horizontal,ir,IP67,,false,
 abus-ipcb58611a,ABUS,IPCB58611A,dome,4K,8,"1/1.8"" Progressive Scan CMOS",102 horizontal,ir,IP67,,false,2021
+abus-ipcb62510a,ABUS,IPCB62510A,bullet,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",108 horizontal,ir,IP67,,,
+abus-ipcb62510b,ABUS,IPCB62510B,bullet,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",87 horizontal / 45 vertical,ir,IP67,,,
+abus-ipcb62510c,ABUS,IPCB62510C,bullet,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",53 horizontal,ir,IP67,,,
+abus-ipcb62515a,ABUS,IPCB62515A,bullet,2MP,2,"1/2.8"" Progressive Scan CMOS",108 horizontal,ir,IP67,,,
+abus-ipcb62520,ABUS,IPCB62520,bullet,2MP,2,"1/2.8"" Progressive Scan CMOS",35 to 105 horizontal,ir,IP67,,true,
 abus-ipcb64510a,ABUS,IPCB64510A,bullet,4MP,4,,109 H,ir,IP67,,false,
 abus-ipcb64510b,ABUS,IPCB64510B,bullet,4MP,4,,,ir,IP67,,false,
 abus-ipcb64510c,ABUS,IPCB64510C,bullet,4MP,4,,53 H,ir,IP67,,false,
+abus-ipcb64515b,ABUS,IPCB64515B,bullet,4MP,4,"1/2.5"" Progressive Scan CMOS",88 horizontal,ir,IP67,,,
+abus-ipcb64520,ABUS,IPCB64520,bullet,4MP,4,"1/2.5"" Progressive Scan CMOS",32 to 114 horizontal,ir,IP67,,true,
 abus-ipcb64521,ABUS,IPCB64521,bullet,4MP,4,"1/2.7"" Progressive Scan CMOS",30 to 108 horizontal,ir,IP67,IK10,false,
 abus-ipcb64620,ABUS,IPCB64620,bullet,4MP,4,"1/2.5"" progressive CMOS",32-114 H,ir,IP67,IK10,true,
 abus-ipcb64621,ABUS,IPCB64621,bullet,4 MPx,4,"1/2.7"" Progressive Scan CMOS",108 to 30 horizontal,ir,IP67,IK10,true,
+abus-ipcb68510a,ABUS,IPCB68510A,bullet,8MP (4K),8,"1/2.5"" Progressive Scan CMOS",102 horizontal,ir,IP67,,,
+abus-ipcb68510b,ABUS,IPCB68510B,bullet,8MP (4K),8,"1/2.5"" Progressive Scan CMOS",79 horizontal,ir,IP67,,,
+abus-ipcb68510c,ABUS,IPCB68510C,bullet,8MP (4K),8,"1/2.5"" Progressive Scan CMOS",50 horizontal,ir,IP67,,,
 abus-ipcb68515a,ABUS,IPCB68515A,bullet,4K/8MP,8,"1/2.5"" progressive CMOS",102 H,ir,IP67,IK10,false,
+abus-ipcb68520,ABUS,IPCB68520,bullet,8MP,8.3,"1/2.5"" Progressive Scan CMOS",35 to 115 horizontal,ir,IP67,,true,
 abus-ipcb68521,ABUS,IPCB68521,bullet,4K,8,"1/1.8"" CMOS",46-108 horizontal / 26-58 vertical,ir,IP67,IK10,false,
 abus-ipcb68621,ABUS,IPCB68621,bullet,4K Ultra HD,8,"1/1.8"" Progressive Scan CMOS",46 to 108 horizontal,ir,IP67,IK10,true,2021
+abus-ipcb72515a,ABUS,IPCB72515A,dome,2MP (1080p),2,"1/2.8"" Progressive Scan CMOS",108 horizontal,ir,IP67,IK10,,
+abus-ipcb72520,ABUS,IPCB72520,dome,2MP,2,"1/2.8"" Progressive Scan CMOS",35 to 105 horizontal,ir,IP67,,true,
+abus-ipcb74515b,ABUS,IPCB74515B,dome,4MP,4,"1/2.5"" Progressive Scan CMOS",88 horizontal / 46 vertical,ir,IP67,IK10,,
+abus-ipcb74520,ABUS,IPCB74520,dome,4MP,4,"1/2.5"" Progressive Scan CMOS",32 to 114 horizontal,ir,IP67,,true,
 abus-ipcb74521,ABUS,IPCB74521,dome,4MP,4,"1/2.7"" Progressive Scan CMOS",30 to 108 horizontal,ir,IP67,IK10,false,
+abus-ipcb74615b,ABUS,IPCB74615B,dome,4MP,4,,,ir,,,,
+abus-ipcb78515a,ABUS,IPCB78515A,dome,8MP (4K),8,"1/2.5"" Progressive Scan CMOS",102 horizontal,ir,IP67,IK10,,
+abus-ipcb78520,ABUS,IPCB78520,dome,8MP,8.3,"1/2.5"" Progressive Scan CMOS",35 to 115 horizontal,ir,IP67,,true,
 abus-ipcb78521,ABUS,IPCB78521,dome,4K,8,"1/1.8"" Progressive Scan CMOS",35 to 115 horizontal,ir,IP67,IK10,true,
+abus-ipcb78615a,ABUS,IPCB78615A,dome,8MP,8.3,,,ir,,,,
 abus-ipcs24500,ABUS,IPCS24500,fisheye,12MP,12,"1/1.7"" progressive CMOS",360,ir,IP66,IK10,true,
 abus-ipcs28581a,ABUS,IPCS28581A,panoramic,4K,8,"2 x 1/1.8"" Progressive Scan CMOS","180 horizontal, 44 vertical",color,IP67,,true,
+abus-ipcs29511,ABUS,IPCS29511,fisheye,12MP,12,,360 horizontal,,IP66,,true,
 abus-ipcs29512,ABUS,IPCS29512,fisheye,12MP,12.3,"1/1.7"" Progressive Scan CMOS",360 horizontal,ir,IP67,IK10,true,
 abus-ipcs34511a,ABUS,IPCS34511A,bullet,4MP,4,,108 H,color,IP67,,false,
 abus-ipcs34511b,ABUS,IPCS34511B,bullet,4MP,4,,95 H,color,IP67,,false,
@@ -53,20 +96,34 @@ abus-ipcs54511a,ABUS,IPCS54511A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",108 h
 abus-ipcs54511b,ABUS,IPCS54511B,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",95 horizontal,color,IP67,,,
 abus-ipcs54611a,ABUS,IPCS54611A,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",108 horizontal,color,IP67,,,
 abus-ipcs58571a,ABUS,IPCS58571A,dome,4K,8,"1/1.8"" Progressive Scan CMOS",111 horizontal,ir,IP67,,true,
+abus-ipcs62120,ABUS,IPCS62120,bullet,2MP,2,"1/1.8"" Progressive Scan CMOS",32 to 92 horizontal,ir,IP67,,true,
+abus-ipcs64511a,ABUS,IPCS64511A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",108 horizontal,color,IP67,,,2023
 abus-ipcs64511b,ABUS,IPCS64511B,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",95 horizontal,color,IP67,,,2023
 abus-ipcs64531,ABUS,IPCS64531,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",114 to 42 horizontal,ir,IP67,IK10,true,
 abus-ipcs64541,ABUS,IPCS64541,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",2.8 to 56 horizontal,hybrid,IP67,IK10,true,
 abus-ipcs64611a,ABUS,IPCS64611A,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",108 horizontal,color,IP67,,,
 abus-ipcs74511a,ABUS,IPCS74511A,dome,4MP,4,,101 horizontal,ir,IP67,IK10,,2025
+abus-ipcs82500,ABUS,IPCS82500,ptz,2MP,2,"1/2.8"" Progressive Scan CMOS",3.2 to 58.3 horizontal,ir,IP66,,true,
+abus-ipcs82520,ABUS,IPCS82520,ptz,2MP,2,"1/1.9"" Progressive Scan CMOS",3.0 to 59.8 horizontal,ir,IP66,,true,
+abus-ipcs82530,ABUS,IPCS82530,ptz,2MP,2,"1/1.9"" Progressive Scan CMOS",2.0 to 59.0 horizontal,ir,IP66,,true,
+abus-ipcs83500,ABUS,IPCS83500,ptz,3MP,3.1,"1/3"" Progressive Scan CMOS",3.7 to 61.0 horizontal,ir,IP66,,true,
+abus-ipcs84510,ABUS,IPCS84510,ptz,4MP,4,"1/3"" Progressive Scan CMOS",31.6 to 96.7 horizontal,ir,IP66,IK10,true,
 abus-ipcs84511,ABUS,IPCS84511,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",31.6 to 96.7 horizontal,ir,IP66,IK10,true,
+abus-ipcs84530,ABUS,IPCS84530,ptz,4MP,4,"1/2.5"" Progressive Scan CMOS",2.5 to 57.6 horizontal,ir,IP66,,true,
+abus-ipcs84531,ABUS,IPCS84531,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",2.5 to 53 horizontal,ir,IP66,,,
 abus-ipcs84532,ABUS,IPCS84532,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",2.5 to 53 horizontal,ir,IP66,,true,
+abus-ipcs84550,ABUS,IPCS84550,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",2.0 to 54.3 horizontal,ir,IP66,,true,
 abus-ipcs84551,ABUS,IPCS84551,ptz,4MP,4,"1/1.8"" Progressive Scan CMOS",51 to 2.6 horizontal,ir,IP66,IK10,true,
 abus-ppic31020,ABUS,PPIC31020,box,Full HD (1080p),2,"1/2.8"" CMOS",180 horizontal / 100 vertical,ir,,,true,
 abus-ppic42520,ABUS,PPIC42520,ptz,Full HD (1080p),2,"1/2.8"" CMOS",355 pan / 90 tilt,ir,IP66,,true,2023
+abus-ppic42520b,ABUS,PPIC42520B,ptz,Full HD (1080p),2,"1/2.8"" CMOS",355 pan / 90 tilt,ir,IP66,,true,
 abus-ppic44520,ABUS,PPIC44520,bullet,Full HD (1080p),2,"1/2.7"" CMOS",100 horizontal,ir,IP66,,true,2023
 abus-ppic46520,ABUS,PPIC46520,floodlight,2K,2,"1/2.8"" CMOS",110 horizontal,hybrid,IP66,,true,2022
+abus-ppic46520w,ABUS,PPIC46520W,floodlight,2K,2,"1/2.8"" CMOS",110 horizontal,hybrid,IP66,,true,
 abus-ppic52520,ABUS,PPIC52520,ptz,2 MP (4K-interpolated recording),2,"1/2.8"" CMOS",85 horizontal / 45 vertical,ir,IP66,,true,
+abus-ppic52520b,ABUS,PPIC52520B,ptz,2 MP (4K-interpolated recording),2,"1/2.8"" CMOS",85 horizontal / 45 vertical,ir,IP66,,true,
 abus-ppic54520,ABUS,PPIC54520,box,2 MP (4K-interpolated recording),2,"1/2.8"" CMOS",85 horizontal / 45 vertical,ir,IP66,,false,
+abus-ppic54520b,ABUS,PPIC54520B,box,2 MP (4K-interpolated recording),2,"1/2.8"" CMOS",85 horizontal / 45 vertical,ir,IP66,,false,
 abus-ppic90520,ABUS,PPIC90520,bullet,1080p HD,2,"1/2.8"" CMOS (Sony IMX307)",115 horizontal / 75 vertical,color,IP65,,true,2023
 abus-ppic91000,ABUS,PPIC91000,bullet,3 MP,3,,120 horizontal,color,IP65,,true,
 abus-ppic91520,ABUS,PPIC91520,bullet,3MP,3,Sony IMX307,120 H,color,IP65,,true,
@@ -83,7 +140,7 @@ abus-tvip62562,ABUS,TVIP62562,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS","10
 abus-tvip64511,ABUS,TVIP64511,bullet,4MP QHD,4,"1/3"" Progressive Scan CMOS",103 horizontal,ir,IP67,IK10,false,
 abus-tvip68511,ABUS,TVIP68511,bullet,4K,8,"1/2.8"" Progressive Scan CMOS","107 horizontal, 55 vertical",ir,IP67,IK10,,
 abus-tvip82561,ABUS,TVIP82561,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",101 to 33 horizontal,ir,IP66,IK10,,
-abus-tvip83900,ABUS,TVIP83900,fisheye,3MP,3,"1/3"" progressive CMOS",360,ir,IP24,,true,
+abus-tvip83900,ABUS,TVIP83900,fisheye,3MP,3.1,"1/3"" Progressive Scan CMOS",180/360,ir,IP24,,true,
 acti-a213,ACTi,A213,box,5MP,5,"1/2.7"" Progressive Scan CMOS",106 horizontal / 85.9 vertical,,IP66,,true,
 acti-a214,ACTi,A214,box,5MP,5,"1/2.7"" CMOS",62.6 - 1.9 horizontal / 48.8 - 1.4 vertical,,,,true,
 acti-a29,ACTi,A29,box,2MP,2,"1/2.7"" Progressive Scan CMOS",108.6 horizontal / 63.6 vertical,,IP66,,true,
@@ -2147,11 +2204,14 @@ tapo-c200,Tapo,Tapo C200,ptz,1080p,2,"1/3\"" Progressive Scan CMOS","88.3 (Diago
 tapo-c207,Tapo,C207,ptz,1080p,2,"1/3"" Progressive Scan CMOS Starlight Sensor",85 diagonal / 73.5 horizontal / 41 vertical,hybrid,IP65,,true,
 tapo-c210,Tapo,Tapo C210,ptz,2K (3MP),3,"1/2.8"" Progressive Scan CMOS","83 (horizontal), 45 (vertical), 98 (diagonal)",ir,,,true,2021
 tapo-c216,Tapo,Tapo C216,ptz,2K 3MP,3,"1/2.8"" Progressive Scan CMOS Starlight Sensor",360 pan / 152 tilt,color,IP65,,true,2025
+tapo-c217,Tapo,Tapo C217,ptz,2K 3MP,2.99,"1/2.8"" Progressive Scan CMOS Starlight Sensor",98 diagonal / 83 horizontal / 47 vertical,hybrid,IP65,,true,
 tapo-c220,Tapo,Tapo C220,ptz,2K QHD,4,"1/3"" Progressive Scan Non-Starlight Sensor","88 (diagonal), 75 (horizontal), 41 (vertical)",ir,,,,2021
 tapo-c222,Tapo,C222,ptz,2K QHD,4,"1/3"" Progressive Scan CMOS","90 diagonal, 76.2 horizontal, 41.8 vertical",ir,,,true,
 tapo-c225,Tapo,Tapo C225,ptz,2K QHD,4.1,"1/2.9"" Progressive Scan CMOS Starlight Sensor",100 (diagonal) / 83 (horizontal) / 43 (vertical),ir,,,true,2023
 tapo-c230,Tapo,Tapo C230,ptz,3K,5,"1/3"" Progressive Scan CMOS Starlight Sensor","88° diagonal, 75° horizontal, 41° vertical (image FOV; separate from 360° pan / 114° tilt mechanical range)",ir,,,true,2024
+tapo-c245d,Tapo,Tapo C245D,ptz,2K (3MP per lens),2.99,"1/2.8"" Progressive Scan CMOS Starlight Sensor",121.8 diagonal / 104.3 horizontal / 57.9 vertical (wide-angle lens),ir,,,true,
 tapo-c246d,Tapo,Tapo C246D,ptz,2K (3MP per lens),2.99,"1/2.8"" Progressive Scan CMOS Starlight Sensor",125.5 diagonal (fixed lens) / 67.1 diagonal (pan-tilt lens),hybrid,IP65,,true,2025
+tapo-c250,Tapo,Tapo C250,ptz,4K 8MP,8.3,"1/2.7"" CMOS",105.4 diagonal / 88 horizontal / 46 vertical,ir,,,true,
 tapo-c260,Tapo,Tapo C260,ptz,4K (8MP),8,"1/2.7"" Progressive Scan CMOS Starlight Sensor","109.6 (diagonal), 91.5 (horizontal), 46.1 (vertical)",ir,,,true,2025
 tapo-c310,Tapo,Tapo C310,bullet,3MP / 2K (2304x1296),3,"1/2.8"" Progressive Scan CMOS Sensor","100 (diagonal), 84 (horizontal), 46 (vertical)",ir,IP66,,true,2021
 tapo-c320ws,Tapo,Tapo C320WS,bullet,2K QHD,4,"1/3"" Progressive Scan CMOS Starlight Sensor","113 diagonal, 97 horizontal, 54 vertical",hybrid,IP66,,true,2022
@@ -2160,6 +2220,8 @@ tapo-c325wb-ca,Tapo,C325WB (Canada),bullet,2K QHD,3.69,"1/1.88"" Progressive Sca
 tapo-c325wb-india,Tapo,C325WB (India),bullet,2K QHD,4,"1/1.79"" Progressive Scan CMOS Starlight Sensor","131 (Diagonal), 106 (Horizontal), 56 (Vertical)",hybrid,IP66,,true,2023
 tapo-c400-kit,Tapo,C400 Kit,bullet,1080p,2,"1/3"" Progressive Scan CMOS",116.7 diagonal / 99.7 horizontal / 53.8 vertical,hybrid,IP65,,true,
 tapo-c402,Tapo,Tapo C402,bullet,1080p Full HD,2,"1/2.8"" Progressive Scan CMOS Starlight Sensor","125° (Diagonal), 111° (Horizontal), 56° (Vertical)",hybrid,IP65,,,2023
+tapo-c403,Tapo,Tapo C403,bullet,1080p Full HD,2,"1/2.8"" Progressive Scan CMOS Starlight Sensor",125 (diagonal) / 111 (horizontal) / 56 (vertical),ir,IP65,,true,
+tapo-c410,Tapo,Tapo C410,bullet,2K 3MP,3,"1/2.8"" Progressive Scan CMOS Starlight Sensor",125 (diagonal) / 111 (horizontal) / 56 (vertical),ir,IP65,,true,
 tapo-c420,Tapo,C420,bullet,2K QHD,4,"1/3"" Progressive Scan CMOS Starlight Sensor","113 (diagonal), 97 (horizontal), 54 (vertical)",hybrid,IP65,,true,2023
 tapo-c425,Tapo,Tapo C425,bullet,2K QHD,4,"1/3"" Progressive Scan CMOS Starlight Sensor","150 (Diagonal), 134 (Horizontal), 77 (Vertical)",hybrid,IP66,,true,2023
 tapo-c460,Tapo,Tapo C460,bullet,4K 8MP,8,"1/2.7"" Progressive Scan CMOS Starlight Sensor","134° (Diagonal), 113° (Horizontal), 59° (Vertical)",hybrid,IP66,,true,2025
@@ -2168,12 +2230,14 @@ tapo-c500,Tapo,Tapo C500,ptz,1080p,2,"1/3"" Progressive Scan CMOS Sensor","85.5 
 tapo-c510w,Tapo,Tapo C510W,ptz,2K (3MP),3,"1/2.8"" Progressive Scan CMOS","97.23 (diagonal), 82.3 (horizontal), 45.31 (vertical)",hybrid,IP65,,true,2023
 tapo-c520ws,Tapo,Tapo C520WS,ptz,2K QHD (4MP),4,"1/3"" Progressive Scan CMOS Starlight Sensor","112 (Diagonal), 95 (Horizontal), 53 (Vertical)",hybrid,IP66,,true,2023
 tapo-c530ws,Tapo,Tapo C530WS,ptz,3K 5MP,5,"1/2.7"" Progressive Scan CMOS Starlight Sensor","102° (Diagonal), 87° (Horizontal), 45.5° (Vertical)",hybrid,IP66,,true,2024
+tapo-c545d,Tapo,Tapo C545D,ptz,2K (3MP per lens),2.99,,121 diagonal / 95 horizontal / 57.3 vertical (wide-angle lens); 31.7 vertical (telephoto lens),hybrid,,,true,
 tapo-c560ws,Tapo,Tapo C560WS,ptz,4K 8MP,8,"1/2.7"" Progressive Scan CMOS Starlight Sensor","105 (Diagonal), 88 (Horizontal), 45 (Vertical)",hybrid,IP66,,true,2025
 tapo-c566wb,Tapo,C566WB,ptz,4K,8,,360 pan / 140 tilt,color,IP66,,,2025
 tapo-c615f-kit,Tapo,C615F Kit,ptz,2K,3,"1/2.8"" Progressive Scan CMOS",100 diagonal / 84 horizontal / 44 vertical,hybrid,IP65,,true,2025
 tapo-c645d-kit,Tapo,C645D Kit,dual-lens,"2K 3MP (dual-lens, each lens independently 2K)",3,"1/2.8"" Progressive Scan CMOS",Wide-angle lens: 165.1 diagonal / 137.6 horizontal / 73 vertical; Telephoto lens: 65.5 diagonal / 56.5 horizontal / 30.6 vertical,hybrid,IP65,,true,
 tapo-c660-kit,Tapo,C660 KIT,ptz,4K,8,"1/2.7"" Progressive Scan CMOS Starlight Sensor","105 (Diagonal), 88 (Horizontal), 45 (Vertical)",hybrid,IP65,,true,2025
 tapo-c675d-kit,Tapo,C675D Kit,dual-lens,"4K (dual-lens, each lens independently 4K)",8,"1/2.7"" CMOS Starlight Sensor",Fixed lens: 169.7 diagonal / 140.8 horizontal / 74.7 vertical; Pan-tilt lens: 66.5 diagonal / 57.3 horizontal / 31.0 vertical,hybrid,IP65,,true,2026
+tapo-c710,Tapo,Tapo C710,floodlight,2K 3MP,2.99,"1/2.8"" CMOS",98.1 diagonal / 82.8 horizontal / 44.5 vertical,hybrid,IP65,,true,
 tapo-c720,Tapo,Tapo C720,bullet,2K QHD,4,"1/3"" progressive scan CMOS Starlight sensor","153 diagonal, 134 horizontal, 77.6 vertical",hybrid,IP65,,true,2024
 tapo-c840,Tapo,C840,dual-lens,4MP wide + 2MP tele dual lens,4,"1/2.9"" image sensor","144 (wide lens, diagonal) / 55 (tele lens, diagonal)",ir,,,true,2025
 tapo-d130,Tapo,Tapo D130,doorbell,2K (5MP),5,"1/2.7"" Progressive Scan CMOS","180 diagonal, 172 horizontal, 144 vertical",hybrid,IP65,,true,2024

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -217,6 +217,168 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipca32500",
+    "brand": "ABUS",
+    "model": "IPCA32500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP24",
+    "power": {
+      "method": "PoE"
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "features": [
+      "Sony STARVIS sensor with Tamron 3-9 mm lens",
+      "True WDR",
+      "IR LEDs",
+      "16 GB internal memory for edge recording",
+      "ONVIF"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line (2017 generation) indoor IP dome 2 MPx — predecessor platform of the IPCA72510. Specs from the RS Components (authorized distributor) product listing: Sony STARVIS + Tamron 3-9 mm, 1080p @ 30 fps, IP24 indoor, PoE, audio, 16 GB internal memory, 141 mm width. Single-distributor sourced and flagged accordingly — aperture, FOV, IR range, full dimensions, and temperature omitted pending an official datasheet. Sibling IPCA22500 (official 2017 manual exists on abus.com) remains excluded: identity and resolution unconfirmed.",
+    "sources": [
+      "https://uk.rs-online.com/web/p/cctv-cameras/1774399"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca33500",
+    "brand": "ABUS",
+    "model": "IPCA33500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Indoor IP dome 3 MPx — sibling of the 1080p IPCA32500. Max 50/60 fps with WDR off, 25 fps with WDR.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipca34512a",
     "brand": "ABUS",
     "model": "IPCA34512A",
@@ -547,6 +709,249 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipca52000",
+    "brand": "ABUS",
+    "model": "IPCA52000",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "outdoor boxtype",
+      "120 dB WDR",
+      "16 GB internal memory for recording on network failure",
+      "Sony Xarina DSP"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Aussen IP Boxtype 1080p (2017 Advanced generation, predecessor of the IPCA52010). Platform data (1920x1080 @ 25 fps, Sony Exmor sensor + Xarina DSP, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018, covering IPCA22500/32500/52000/62500/62505/72500); 'Aussen IP Boxtype 1080p' designation from the official ABUS Katalog accessory compatibility matrices. Lens, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources.",
+    "sources": [
+      "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca52010",
+    "brand": "ABUS",
+    "model": "IPCA52010",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP20",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "0 to 50",
+    "dimensions_mm": "65 x 65 x 120",
+    "features": [
+      "CS-mount box camera (lens sold separately, e.g. TVAC65502 2.8-10 mm)",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "indoor (IP20), outdoor via TVAC70200 heated housing"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line IP boxtype 2 MPx — interchangeable-lens body; the lens field is intentionally minimal (CS mount, no bundled lens). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca53000",
+    "brand": "ABUS",
+    "model": "IPCA53000",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "Universal boxtype with interchangeable lens (lens sold separately)",
+      "120 dB True WDR",
+      "ABF integrated auto back focus",
+      "RS-485 interface (unique in the IPCA series)",
+      "outdoor use via optional heated housing"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Universal IP Boxtype 3 MPx (2016 Advanced generation, predecessor of the IPCA52010). Identity and hardware from the official ABUS hardware manual (20160425-IPCA53000_BDA_Hardware); 2048x1536 @ 25 fps, 120 dB True WDR, and ABF auto back focus cross-corroborated by dealer PIM republications; RS-485 confirmed by the official IPCA-series software manual. Interchangeable-lens body: lens field intentionally minimal. Sensor, power, IP rating, dimensions omitted: not confirmed from recovered official sources.",
+    "sources": [
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/17/20160425-IPCA53000_BDA_Hardware_DE_UK.pdf",
+      "https://www.sicher24.de/ueberwachungskameras/abus-universal-ip-boxtype-3-mpx-ipca53000.html",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipca54512a",
@@ -1120,6 +1525,372 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipca62510",
+    "brand": "ABUS",
+    "model": "IPCA62510",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "aperture": "F1.3 - F2.2 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 90 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 87 x 287",
+    "features": [
+      "3x optical zoom (Tamron motor zoom)",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca62515",
+    "brand": "ABUS",
+    "model": "IPCA62515",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.0 to 50.0",
+      "aperture": "F1.6 - F1.8 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "9 to 70 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 84 x 287",
+    "features": [
+      "10x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca62520",
+    "brand": "ABUS",
+    "model": "IPCA62520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 1080p — successor of the IPCA62500. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA63500/66500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca63500",
+    "brand": "ABUS",
+    "model": "IPCA63500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 3 MPx. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA62520/66500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipca64512a",
     "brand": "ABUS",
     "model": "IPCA64512A",
@@ -1600,6 +2371,817 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipca66500",
+    "brand": "ABUS",
+    "model": "IPCA66500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "6MP",
+      "max_width": 3072,
+      "max_height": 2048,
+      "megapixels": 6.3
+    },
+    "video": {
+      "max_fps": 24,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 6 MPx. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual. Official joint hardware manual with IPCA62520/63500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf",
+      "https://www.libble.eu/abus-ipca66500/online-manual-964589/"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca68500",
+    "brand": "ABUS",
+    "model": "IPCA68500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3 to 8.6",
+      "aperture": "F1.5 - F2.4 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "48 to 95 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 84 x 287",
+    "features": [
+      "2x optical zoom",
+      "120 dB WDR",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72500",
+    "brand": "ABUS",
+    "model": "IPCA72500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "Tamron 3-9 mm motor vario zoom",
+      "120 dB WDR",
+      "16 GB internal memory for recording on network failure",
+      "Sony Xarina DSP",
+      "outdoor dome (TVAC31311 wall mount)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced outdoor IP dome 1080p (2017 generation, predecessor of the IPCA72510). Platform data (1920x1080 @ 25 fps, Sony Exmor + Xarina DSP, Tamron 3.0-9.0 mm motor vario, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018); dome form factor confirmed by the official Katalog 19 mount compatibility (TVAC31311 wall mount: IPCA72500, IPCA72510, IPCA72515, IPCA78500). IR range, IP rating, power, and dimensions omitted pending the official datasheet. Note: IPCA22500 from the same manual remains excluded — its form factor is still unconfirmed.",
+    "sources": [
+      "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72510",
+    "brand": "ABUS",
+    "model": "IPCA72510",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "aperture": "F1.3 - F2.2 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 90 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "3x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72515",
+    "brand": "ABUS",
+    "model": "IPCA72515",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.0 to 50.0",
+      "aperture": "F1.6 - F1.8 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "9 to 70 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "10x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72520",
+    "brand": "ABUS",
+    "model": "IPCA72520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP dome 1080p — successor of the IPCA72500. Max 50/60 fps with WDR off.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca73500",
+    "brand": "ABUS",
+    "model": "IPCA73500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 3 MPx per the dealer PIM designation. Max 50/60 fps with WDR off.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://www.wilkon-sicherheitstechnik.de/epages/wilko1.sf/de_DE/?ObjectPath=/Shops/wilko1/Products/VICM_AS_IPCA73500"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca76500",
+    "brand": "ABUS",
+    "model": "IPCA76500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "6MP",
+      "max_width": 3072,
+      "max_height": 2048,
+      "megapixels": 6.3
+    },
+    "video": {
+      "max_fps": 24,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 6 MPx per the dealer PIM designation. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://www.wilkon-sicherheitstechnik.de/ABUS-Aussen-IP-Dome-IR-6MPx-IPCA76500"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca78500",
+    "brand": "ABUS",
+    "model": "IPCA78500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3 to 8.6",
+      "aperture": "F1.5 - F2.4 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "48 to 95 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "2x optical zoom",
+      "120 dB WDR",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb34511a",
@@ -2192,6 +3774,494 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb42510a",
+    "brand": "ABUS",
+    "model": "IPCB42510A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42510b",
+    "brand": "ABUS",
+    "model": "IPCB42510B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Innendome/IP-Mini-Dome-2-MPx-1080p-4-mm",
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "87 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42510c",
+    "brand": "ABUS",
+    "model": "IPCB42510C",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-2-MPx-1080p-6-mm",
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42515a",
+    "brand": "ABUS",
+    "model": "IPCB42515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet",
+      "wifi"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal / 59 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "audio": {
+      "microphone": true
+    },
+    "features": [
+      "WiFi 802.11 b/g/n + wired RJ45",
+      "built-in microphone + audio output",
+      "1x alarm input / 1x alarm output",
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G/T",
+      "flat 5 cm profile",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "97 x 100 x 53",
+    "weight_g": 400,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL WLAN variant of the Basic-line 2 MPx mini dome — the only radio (RED-directive) model in the IPCB fixed-lens family; the 6x515/7x515 siblings are wired. All specs from the official ABUS datasheet.",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-WLAN-2-MPx-1080p-2.8-mm",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Dome-WLAN-2-MPx-IPCB42515A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb44510a",
     "brand": "ABUS",
     "model": "IPCB44510A",
@@ -2287,6 +4357,108 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcb44510b",
+    "brand": "ABUS",
+    "model": "IPCB44510B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "88 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.008
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "features": [
+      "IK08 vandal-resistant housing",
+      "120 dB WDR",
+      "Ultra low-light performance",
+      "ONVIF Profile S/G",
+      "M12 fixed lens mount",
+      "Min. illumination 0.008 lux color / 0 lux IR",
+      "ABUS Link Station App support"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "100 x 97 x 53",
+    "weight_g": 400,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "4 mm middle lens variant of the IPCB44510 mini dome family (A = 2.8 mm / 109°, B = 4 mm / 88°, C = 6 mm / 53°). Lens and FOV from the official ABUS archive product page; all shared-platform specs match the family datasheet.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-4-MPx-4-mm",
+      "https://c1.abus.com/uk/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-4-mm",
+      "https://www.expert-security.de/abus-ipcb44510b-ip-dome-1080p-t-n-ir-poe-ip66-ik08.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb44510c",
@@ -3661,6 +5833,567 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb62510a",
+    "brand": "ABUS",
+    "model": "IPCB62510A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Tube-2-MPx-IPCB62510A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62510b",
+    "brand": "ABUS",
+    "model": "IPCB62510B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-4-mm"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "87 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62510c",
+    "brand": "ABUS",
+    "model": "IPCB62510C",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-6-mm"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62515a",
+    "brand": "ABUS",
+    "model": "IPCB62515A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "120 dB WDR",
+      "motion detection (8 zones)",
+      "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube 2 MPx (fixed 2.8 mm) — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190617-IPCB6x515AB_INST_DE_UK.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/23/ABUS-Link-Station-Supported-devices.pdf",
+      "https://endlich-sicher.de/ip-tube-kamera-abus-ipcb62515a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62520",
+    "brand": "ABUS",
+    "model": "IPCB62520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://myloesch.com/de/smart-home-elektronik/videoueberwachung/"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "field_of_view_deg": "35 to 105 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb64510a",
     "brand": "ABUS",
     "model": "IPCB64510A",
@@ -3943,6 +6676,205 @@
       }
     },
     "added": "2026-07-05"
+  },
+  {
+    "id": "abus-ipcb64515b",
+    "brand": "ABUS",
+    "model": "IPCB64515B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube 4 MPx (fixed 4 mm). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://www.manualslib.com/manual/2443358/Abus-Ipcb64515b.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "88 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb64520",
+    "brand": "ABUS",
+    "model": "IPCB64520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "megapixels": 4,
+      "max_width": 2688,
+      "max_height": 1520
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "32 to 114 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb64521",
@@ -4278,6 +7210,355 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb68510a",
+    "brand": "ABUS",
+    "model": "IPCB68510A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "102 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb68510b",
+    "brand": "ABUS",
+    "model": "IPCB68510B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Tube-8-MPx-4K-IPCB68510A.html",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "field_of_view_deg": "79 horizontal",
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb68510c",
+    "brand": "ABUS",
+    "model": "IPCB68510C",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-6-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "50 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb68515a",
     "brand": "ABUS",
     "model": "IPCB68515A",
@@ -4374,6 +7655,111 @@
       }
     },
     "added": "2026-07-05"
+  },
+  {
+    "id": "abus-ipcb68520",
+    "brand": "ABUS",
+    "model": "IPCB68520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "35 to 115 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb68521",
@@ -4616,6 +8002,434 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb72515a",
+    "brand": "ABUS",
+    "model": "IPCB72515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "motion detection (8 zones)",
+      "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "143 x 143 x 100",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx full-size vandal dome (fixed-lens dome family: IPCB72515A 2.8 mm / 108°, IPCB74515B 4 mm / 88°, IPCB78515A 2.8 mm / 102°; FOVs corroborated by the official ABUS Video/IP catalog). Sensor, IR range, weight, and operating temperature omitted: not confirmed from an official source for this variant.",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb72515a",
+      "https://manuals.plus/m/41e9eecc72014f49518f19ef80f4599ffbfe1827ef54d434bc1c5bf5ee7006d4"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "operating_temp_c": "-30 to 60",
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb72520",
+    "brand": "ABUS",
+    "model": "IPCB72520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 105 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (2MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb74515b",
+    "brand": "ABUS",
+    "model": "IPCB74515B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2688x1520",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "88 horizontal / 46 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 143 x 100",
+    "weight_g": 1100,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 4 MPx full-size vandal dome; 4 mm / 88° per the official ABUS archive product page and the official Video/IP catalog. Platform table (sensor, F1.6, 143x143x100, 1100 g, streams, -30 to 60 °C) from the ABUS PIM data as republished by distributors; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings.",
+    "sources": [
+      "https://www.abus.com/ch_de/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-4-MPx-4-mm",
+      "https://www.expert-security.de/abus-ipcb74515b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
+      "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb74515b/jl56564"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb74520",
+    "brand": "ABUS",
+    "model": "IPCB74520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "32 to 114 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (4MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb74521",
     "brand": "ABUS",
     "model": "IPCB74521",
@@ -4747,6 +8561,317 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb74615b",
+    "brand": "ABUS",
+    "model": "IPCB74615B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom",
+      "3-axis gimbal (pan/tilt/rotation)",
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb78515a",
+    "brand": "ABUS",
+    "model": "IPCB78515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "102 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "143 x 143 x 100",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) full-size vandal dome; 2.8 mm / 102° per the official ABUS archive product page and datasheet. Sensor, F2.0, dimensions, and streams from the official ABUS datasheet; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings. Weight and operating temperature omitted: not captured from the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-8-MPx-4K-2.8-mm",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002246401DS00/datablad-2246401-abus-ipcb78515a-lan-ip-overvagningskamera-3840-x-2160-pix.pdf",
+      "https://www.elektroshopwagner.de/product_info.php/info/p266293_ABUS-IPCB78515A-IP-Dome-8-MPx--4K--2-8-mm-.html",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb78520",
+    "brand": "ABUS",
+    "model": "IPCB78520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 115 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (8MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb78521",
     "brand": "ABUS",
     "model": "IPCB78521",
@@ -4855,6 +8980,94 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcb78615a",
+    "brand": "ABUS",
+    "model": "IPCB78615A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom",
+      "3-axis gimbal (pan/tilt/rotation)",
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs24500",
@@ -5069,6 +9282,121 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcs29511",
+    "brand": "ABUS",
+    "model": "IPCS29511",
+    "type": "fisheye",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "12MP",
+      "max_width": 4000,
+      "max_height": 3000,
+      "megapixels": 12
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Main (Fisheye)",
+          "resolution": "4000x3000",
+          "fps": 20
+        },
+        {
+          "name": "Main (Panorama)",
+          "resolution": "3072x2304",
+          "fps": 15
+        },
+        {
+          "name": "Sub",
+          "resolution": "704x576",
+          "fps": 15
+        }
+      ]
+    },
+    "field_of_view_deg": "360 horizontal",
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "hemispheric 360/180 degree panorama views",
+      "in-camera dewarping (hardware + up to 14 software view modes)",
+      "ePTZ with up to 255 presets and 32 tours",
+      "replaces up to 4 cameras (up to 4 video channels)",
+      "DWDR",
+      "people counting",
+      "heat map",
+      "intersection analysis",
+      "Tripwire / intrusion / region entry-exit / unattended baggage / object removal VCA",
+      "audio exception detection",
+      "1x alarm input / 1x alarm output",
+      "audio in/out (2-way audio)",
+      "8 privacy zones",
+      "NAS recording",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL 12 MPx Hemispheric IP fisheye — predecessor of the IPCS29512 (which added deep-learning people counting v2). All fields from the official ABUS user manual (20230425-IPCS29511_BDA_INT): 4000x3000 @ 20 fps fisheye main stream (2560x2560 @ 25/30 fps mode), panorama and multi-ePTZ view modes, IP66, mic + speaker with 2-way audio, alarm I/O, PoE/12V DC, microSD + NAS recording, DWDR, full smart-event suite. Sensor, lens, IR range, IK rating, microSD max size, dimensions, and weight omitted: the manual defers the spec table to the product page, and no official datasheet was recovered.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/28/20230425-IPCS29511_BDA_INT.pdf",
+      "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs29512",
@@ -5979,6 +10307,229 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs62120",
+    "brand": "ABUS",
+    "model": "IPCS62120",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 60,
+      "codecs": [
+        "H.264",
+        "MPEG-4",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "field_of_view_deg": "32 to 92 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.003
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "dimensions_mm": "390 x 160",
+    "features": [
+      "ANPR license plate recognition (Europe, up to 70 km/h, 2048-plate allow/deny list)",
+      "1080p @ 50/60 fps",
+      "2.8-12 mm motor zoom (4.2x)",
+      "120 dB WDR",
+      "EIS electronic image stabilization, distortion correction",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line ANPR tube on the Basic Hikvision-OEM platform. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs64511a",
+    "brand": "ABUS",
+    "model": "IPCS64511A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25,
+          "codec": "H.264"
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.264"
+        }
+      ]
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "color",
+      "min_lux_color": 0.0005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "features": [
+      "WDR 120 dB",
+      "full-color night vision",
+      "white light LEDs",
+      "person/vehicle detection",
+      "motion detection (up to 8 zones)",
+      "minimum illumination 0.0005 lux (color)",
+      "compatible with ABUS Secvest / Secoris / wAppLoxx Pro",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-25 to 60",
+    "dimensions_mm": "282 x 105 x 105",
+    "weight_g": 1000,
+    "release_year": 2023,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "2.8 mm wide-angle variant of the Gecko IP Tube 4 MPx WL (A = 2.8 mm / 108°, B = 4 mm / 95°) per the official ABUS product pages. White-light LED range omitted: not stated per-variant in the official sources reviewed (retailer figures conflict with the B variant's documented 50 m).",
+    "sources": [
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-mm-WL",
+      "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-2.8-mm-WL",
+      "https://www.zajadacz.de/ABUS-IP-Tube-4-MPx-2-8-mm-IPCS64511A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs64511b",
     "brand": "ABUS",
     "model": "IPCS64511B",
@@ -6544,6 +11095,539 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs82500",
+    "brand": "ABUS",
+    "model": "IPCS82500",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7 to 94",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.2 to 58.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 150,
+      "min_lux_color": 0.05
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 65",
+    "dimensions_mm": "185 x 330 x 185",
+    "features": [
+      "20x optical zoom",
+      "16x digital zoom",
+      "360 degree pan / -15 to 90 tilt",
+      "EIS electronic image stabilization",
+      "Defog",
+      "WDR, BLC, HLC",
+      "2 alarm inputs / 1 alarm output",
+      "RS485",
+      "analog video output",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (20x) — predecessor generation of the IPCS84550/84551 slot. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs82520",
+    "brand": "ABUS",
+    "model": "IPCS82520",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.9\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9 to 135.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.0 to 59.8 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "23x optical zoom",
+      "16x digital zoom",
+      "Ultra Low-Light (large 1/1.9 inch sensor)",
+      "120 dB True WDR",
+      "EIS electronic image stabilization",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (23x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs82530",
+    "brand": "ABUS",
+    "model": "IPCS82530",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.9\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.7 to 205",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.0 to 59.0 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "36x optical zoom",
+      "16x digital zoom",
+      "Ultra Low-Light (large 1/1.9 inch sensor)",
+      "120 dB True WDR",
+      "EIS electronic image stabilization",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (36x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs83500",
+    "brand": "ABUS",
+    "model": "IPCS83500",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5 to 162",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.7 to 61.0 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.05
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "36x optical zoom",
+      "16x digital zoom",
+      "120 dB WDR",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 3 MPx (36x). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs84510",
+    "brand": "ABUS",
+    "model": "IPCS84510",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 - 12.0",
+      "aperture": "F1.6 - F2.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "31.6 to 96.7 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "two_way": true
+    },
+    "features": [
+      "PTZ 355 pan / 0-90 tilt (100°/s)",
+      "4x optical zoom",
+      "16x digital zoom",
+      "120dB WDR",
+      "electronic image stabilization (EIS)",
+      "3D-DNR",
+      "IK10 vandal resistance",
+      "300 presets",
+      "Tripwire / intrusion detection VCA",
+      "Motion detection",
+      "2 relay outputs",
+      "Pelco D / Pelco P",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-20 to 60",
+    "dimensions_mm": "131 x 131 x 102",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "release_notes": "Predecessor of the IPCS84511 mini PTZ on the same Ø13 cm body; still supported by current mounts (TVAC31215/31285) on abus.com. Specs from the official ABUS datasheet. Power recorded from the datasheet spec table (12V DC / PoE 802.3af); the same datasheet's bullet list states '24 V AC & PoE' and recommends a High-PoE 60W injector for wall mounting — discrepancy left unresolved rather than guessed.",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002237147DS00/datablad-2237147-abus-ipcs84510-ip-bewakingscamera-lan-2560-x-1440-pix.pdf",
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Ceiling-Mount-for-IPCS84510",
+      "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs84511",
     "brand": "ABUS",
     "model": "IPCS84511",
@@ -6667,6 +11751,230 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs84530",
+    "brand": "ABUS",
+    "model": "IPCS84530",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "2560x1440",
+          "fps": 25
+        }
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 120",
+      "aperture": "F1.6 - F3.5",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "max_microsd_gb": 256
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "features": [
+      "25x optical autofocus motor zoom (4.8-120 mm)",
+      "360 degree pan",
+      "300 presets / 8 tours (automated guard tours)",
+      "Ultra Low Light",
+      "WDR",
+      "2-way audio",
+      "1080p @ 50 fps mode",
+      "compact form factor for flush ceiling mount",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL IP PTZ 4 MPx (25x) — predecessor of the IPCS84531/IPCS84532 on the same 169 mm body (note: 1/2.5\" sensor vs 1/2.8\" in the successors). Full platform table (sensor, 4.8-120 mm F1.6-F3.5, FOV 2.5-57.6°, streams, 2-way audio, 12V DC / PoE+ 802.3at) from the official ABUS partner portal product data; IR 50 m, IP66, 360° pan, and ULL from the official ABUS archive product page. Weight and operating temperature omitted: not captured from official sources.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-25x",
+      "https://partner-ch.abus.com/de/silver.econtent/catalog/Produkte/Elektronische-Sicherheit/Professional-Sortiment/Videoueberwachung/Netzwerk/Kameras/SPECIAL/IP-PTZ-4-MPx-25x",
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "2.5 to 57.6 horizontal",
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "dimensions_mm": "169 diameter x 161",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs84531",
+    "brand": "ABUS",
+    "model": "IPCS84531",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 120",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5 to 53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "features": [
+      "25x optical autofocus motor zoom",
+      "16x digital zoom",
+      "360 degree pan",
+      "300 presets / automated guard tours",
+      "Ultra Low Light",
+      "WDR",
+      "compact form factor for flush ceiling mount (TVAC31275/31375)",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "169 diameter x 161",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "markets": [
+      "EU"
+    ],
+    "release_notes": "Predecessor of the IPCS84532 (same 169x161 mm body; the 84532 adds AI human/vehicle detection). Shares the official installation manual with IPCS84511 (220504-IPCS84511_84531_TVIP82561_BDA_INT). Still supported by current mounts (TVAC31205/31275) on abus.com. Audio, IK rating, weight, and operating temperature omitted: not confirmed from official sources for this variant.",
+    "sources": [
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
+      "https://c1.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/PTZ/IP-PTZ-4-MPx-25x",
+      "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84531"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs84532",
     "brand": "ABUS",
     "model": "IPCS84532",
@@ -6774,6 +12082,126 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcs84550",
+    "brand": "ABUS",
+    "model": "IPCS84550",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 153",
+      "aperture": "F1.2 - F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.0 to 54.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 150
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "32x optical zoom",
+      "16x digital zoom",
+      "120 dB WDR",
+      "Ultra Low Light",
+      "Smart Tracking",
+      "Tripwire / intrusion detection VCA",
+      "300 presets / 8 tours",
+      "2 alarm inputs / 1 alarm output",
+      "1080p @ 50 fps mode",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL IP PTZ 4 MPx (32x) — predecessor of the IPCS84551 (which moved to a 1/1.8\" sensor, 5.9-189 mm lens, and 200 m IR). Platform table (sensor, 4.8-153 mm F1.2-F4.4, FOV, streams, audio, alarm I/O, Smart Tracking) from the ABUS PIM data as republished by distributors, alongside the official archive product page and the official joint IPCS84530/IPCS84550 manual. IR 150 m from a distributor spec listing (single secondary source — flagged for verification against the official datasheet). Power method (PoE class), weight, and dimensions omitted: unconfirmed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-32x",
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf",
+      "https://www.abus-alarmanlagen.ch/video/netzwerkkameras/abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66/",
+      "https://www.aesag.ch/en/network-cameras/2778-abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66-ipcs84550.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs84551",
@@ -7091,6 +12519,98 @@
     "added": "2026-06-06"
   },
   {
+    "id": "abus-ppic42520b",
+    "brand": "ABUS",
+    "model": "PPIC42520B",
+    "aliases": [
+      "ABUS Wireless Pan/Tilt Outdoor Camera (black)"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "markets": [
+      "AT",
+      "CH",
+      "DE",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "Full HD (1080p)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.1",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "355 pan / 90 tilt",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "ABUS App2Cam Plus outdoor pan/tilt",
+      "355deg pan / 90deg tilt",
+      "3MP 2K",
+      "person/animal/vehicle detection",
+      "two-way audio",
+      "GDPR-compliant local storage",
+      "IP66",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wireless-Pan-Tilt-Outdoor-Camera",
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-WiFi-Pan-Tilt-Outdoor-Camera"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "210 x 120 x 160",
+    "weight_g": 650,
+    "operating_temp_c": "-10 to 50",
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC42520 WiFi Pan/Tilt Outdoor Camera. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic44520",
     "brand": "ABUS",
     "model": "PPIC44520",
@@ -7245,6 +12765,89 @@
     "added": "2026-06-06"
   },
   {
+    "id": "abus-ppic46520w",
+    "brand": "ABUS",
+    "model": "PPIC46520W",
+    "aliases": [
+      "ABUS Wi-Fi Light Outdoor Camera (white)"
+    ],
+    "type": "floodlight",
+    "connectivity": [
+      "wifi"
+    ],
+    "markets": [
+      "DE",
+      "AT",
+      "CH",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "label": "2K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "110 horizontal",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 8
+    },
+    "power": {
+      "method": "AC 90-260V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "replaces outdoor light fitting (like Netatmo Presence)",
+      "1000-lumen LED outdoor light",
+      "person/animal/vehicle/car AI detection",
+      "PIR sensor",
+      "two-way audio",
+      "App2Cam Plus",
+      "GDPR-compliant local microSD",
+      "no mandatory subscription",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wi-Fi-Light-Outdoor-Camera2",
+      "https://security.abus.com/Videoueberwachung/ABUS-WLAN-Licht-Aussen-Kamera.html"
+    ],
+    "power_source": [
+      "ac-mains"
+    ],
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "75 x 155 x 180",
+    "weight_g": 985,
+    "operating_temp_c": "-20 to 50",
+    "last_verified": "2026-07-26",
+    "release_notes": "White housing variant of the PPIC46520 Wi-Fi Light Outdoor Camera, listed as new on abus.com (07/2026). Shares the official user guide with the base model (guide covers PPIC46520 / PPIC46520W); only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic52520",
     "brand": "ABUS",
     "model": "PPIC52520",
@@ -7331,6 +12934,94 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ppic52520b",
+    "brand": "ABUS",
+    "model": "PPIC52520B",
+    "aliases": [
+      "ABUS SmartLook Pan & Tilt (black)"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "markets": [
+      "DE",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "2 MP (4K-interpolated recording)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "85 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.264+"
+      ],
+      "max_fps": 15
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "210 x 120 x 160",
+    "weight_g": 650,
+    "operating_temp_c": "-10 to 50",
+    "features": [
+      "4K-interpolated recording (native 2 MP sensor)",
+      "outdoor pan/tilt (270° pan / 80° tilt)",
+      "person/animal/vehicle detection",
+      "two-way audio",
+      "siren",
+      "privacy zones",
+      "5s pre-recording",
+      "local microSD (256GB, no cloud)",
+      "App2Cam Plus",
+      "WiFi 2.4/5 GHz",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook-pan-tilt2",
+      "https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html",
+      "https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE"
+    ],
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC52520 SmartLook Pan & Tilt. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic54520",
     "brand": "ABUS",
     "model": "PPIC54520",
@@ -7413,6 +13104,92 @@
     ],
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ppic54520b",
+    "brand": "ABUS",
+    "model": "PPIC54520B",
+    "aliases": [
+      "ABUS SmartLook (black)"
+    ],
+    "type": "box",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "markets": [
+      "DE",
+      "AT",
+      "CH",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "2 MP (4K-interpolated recording)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "85 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.264+"
+      ],
+      "max_fps": 15
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "167 x 48 x 80",
+    "weight_g": 433,
+    "operating_temp_c": "-10 to 50",
+    "features": [
+      "4K-interpolated recording (native 2 MP sensor)",
+      "App2Cam Plus",
+      "person/animal/vehicle detection",
+      "5s pre-recording",
+      "privacy masking",
+      "dual-band WiFi (2.4/5 GHz)",
+      "local microSD (no cloud)",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook2",
+      "https://security.abus.com/Videoueberwachung/SmartLook-abus.html"
+    ],
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC54520 SmartLook. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ppic90520",
@@ -9008,37 +14785,30 @@
     "connectivity": [
       "ethernet"
     ],
-    "power_source": [
-      "poe",
-      "dc"
-    ],
     "resolution": {
-      "megapixels": 3,
+      "label": "3MP",
       "max_width": 2048,
       "max_height": 1536,
-      "label": "3MP"
+      "megapixels": 3.1
     },
     "video": {
+      "max_fps": 25,
       "codecs": [
         "H.264",
         "MJPEG"
-      ],
-      "max_fps": 25
+      ]
     },
-    "sensor": "1/3\" progressive CMOS",
+    "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
       "count": 1,
       "focal_length_mm": "1.27",
-      "aperture": "F2.8",
       "varifocal": false
     },
-    "field_of_view_deg": "360",
+    "field_of_view_deg": "180/360",
     "night_vision": {
       "type": "ir",
-      "range_m": 5
-    },
-    "power": {
-      "method": "PoE (802.3at) / 12V DC"
+      "range_m": 15,
+      "min_lux_color": 0.28
     },
     "storage": {
       "onboard": true,
@@ -9050,27 +14820,33 @@
       "rtsp"
     ],
     "ip_rating": "IP24",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
     "audio": {
-      "microphone": true,
-      "speaker": true,
       "two_way": true
     },
+    "operating_temp_c": "10 to 50",
+    "dimensions_mm": "164 x 44 x 153",
     "features": [
-      "360-degree indoor hemispheric fisheye",
-      "ePTZ dewarping",
-      "two-way audio",
-      "indoor (IP24)"
+      "hemispheric 360/180 degree panorama views",
+      "ePTZ (360/80 degrees) with configurable tours",
+      "WDR, 3D DNR, BLC",
+      "1 alarm input / 1 alarm output",
+      "audio in/out"
     ],
-    "markets": [
-      "DE",
-      "EU"
+    "environment": [
+      "indoor"
     ],
-    "release_notes": "ABUS IP Fisheye 3MP (legacy TVIP naming) — indoor hemispheric, IP24. IR range ~5m per page prose (spec table shows 15m; low confidence).",
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
     "sources": [
-      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-3-MPx"
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
     ],
-    "last_verified": "2026-07-05",
-    "status": "available",
     "configs": {
       "frigate": {
         "detect": {
@@ -9078,24 +14854,22 @@
           "height": 480,
           "fps": 5
         },
-        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
         "verified": false,
-        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first."
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
       },
       "home_assistant": {
         "integration": "onvif",
         "connection_type": "local_push",
-        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S)."
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
       },
       "blue_iris": {
-        "profile": "Hikvision",
-        "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
       }
     },
-    "environment": [
-      "indoor"
-    ],
+    "last_verified": "2026-07-26",
     "added": "2026-07-05"
   },
   {
@@ -194053,6 +199827,110 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c217",
+    "brand": "Tapo",
+    "model": "Tapo C217",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "98 diagonal / 83 horizontal / 47 vertical",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter with 2 m USB adapter cable"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "features": [
+      "HybridCam 360 indoor/outdoor pan/tilt",
+      "360 degree horizontal pan / 152 degree vertical tilt",
+      "full-color night vision with built-in spotlights",
+      "IR night vision",
+      "smart motion tracking",
+      "person detection",
+      "baby cry detection",
+      "customizable activity and privacy zones",
+      "sound and light alarm",
+      "two-way audio",
+      "Tapo H500 hub storage (up to 16 TB)",
+      "Alexa / Google Assistant / Samsung SmartThings",
+      "no subscription required"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "Indoor/outdoor 2K pan/tilt camera (HybridCam 360 line). Sensor, 4 mm F2.0 lens (both stated with +/-5% tolerance officially), full FOV triplet, IP65, and 512 GB microSD limit from the official Tapo product page specification table and the official TP-Link C217 datasheet; 30 fps, 360/152 degree pan-tilt range, and ONVIF compliance from the authorized-distributor product description. Dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c217/",
+      "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c217/",
+      "https://manuals.plus/m/b590be04aaf9c900dd1085af215325e8cefa5da5b6de0fdff19cd1f50b7fdaec",
+      "https://www.bhphotovideo.com/c/product/1922982-REG/tp_link_tapo_c217_indoor_outdoor_home.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c220",
     "brand": "Tapo",
     "model": "Tapo C220",
@@ -194439,6 +200317,115 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c245d",
+    "brand": "Tapo",
+    "model": "Tapo C245D",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K (3MP per lens)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "streams": [
+        {
+          "name": "Wide-angle lens",
+          "resolution": "2304x1296"
+        },
+        {
+          "name": "Telephoto pan/tilt lens",
+          "resolution": "2304x1296"
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "3.1 (wide-angle) / 6.0 (telephoto pan-tilt)",
+      "aperture": "F1.6 (wide-angle)",
+      "varifocal": false
+    },
+    "field_of_view_deg": "121.8 diagonal / 104.3 horizontal / 57.9 vertical (wide-angle lens)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual 2K 3MP lenses (wide-angle + telephoto)",
+      "Synchronized Smart Tracking (fixed lens detects, pan/tilt lens follows)",
+      "One-Tap Smart Focus",
+      "10.8x digital zoom on telephoto lens",
+      "motorized pan/tilt on telephoto lens",
+      "wide-angle lens manually adjustable -15 to 15 degrees vertically",
+      "AI person / pet / vehicle / motion detection",
+      "baby cry detection",
+      "two-way audio",
+      "Alexa / Google Home / Samsung SmartThings",
+      "Tapo H200 / H500 hub unified storage",
+      "no subscription required for AI detection"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "release_notes": "Indoor dual-lens pan/tilt camera (2026) — the indoor counterpart of the indoor/outdoor C246D and the outdoor C545D. Sensor, both focal lengths, wide-angle aperture and full wide-angle FOV triplet, dual 2304x1296 resolution, 10.8x digital zoom, and 512 GB microSD from the official Tapo product page specification table as republished verbatim by distributors. Night vision stated officially as 40 ft (approx. 12 m), IR black-and-white. Telephoto aperture, telephoto FOV, frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source.",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c245d/",
+      "https://www.tp-link.com/en/home-networking/cloud-camera/tapo-c245d/",
+      "https://pcworx.ph/products/tapo-c245d-dual-lens-pan-tilt-security-camera"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c246d",
     "brand": "Tapo",
     "model": "Tapo C246D",
@@ -194551,6 +200538,105 @@
     ],
     "last_verified": "2026-06-30",
     "added": "2026-06-06"
+  },
+  {
+    "id": "tapo-c250",
+    "brand": "Tapo",
+    "model": "Tapo C250",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "4K 8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.7\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "105.4 diagonal / 88 horizontal / 46 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP resolution",
+      "360 degree horizontal pan / 116 degree vertical tilt",
+      "AI Auto-Zoom Tracking",
+      "motion / person / pet / vehicle detection",
+      "line-crossing detection",
+      "lens tamper detection",
+      "baby cry detection",
+      "abnormal sound detection (glass breaking, meow, bark)",
+      "customizable block/privacy zones",
+      "two-way audio with noise cancellation",
+      "Alexa / Google Assistant",
+      "free AI detection (no subscription)"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "release_notes": "Indoor 4K pan/tilt AI camera. Sensor, 4 mm F1.6 lens, full FOV triplet, 4K 8MP resolution, 360/116 degree pan-tilt range, 512 GB microSD limit, and the full AI detection list from the official Tapo product page specification table (Tapo C250_V1 Datasheet), cross-checked against distributor republications of the same table. Frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c250/",
+      "https://www.tp-link.com/sg/home-networking/cloud-camera/tapo-c250/",
+      "https://www.pbtech.com/pacific/product/CCTTPL8250/TP-Link-Tapo-C250-8MP4K-Indoor-PT-Wi-Fi-Camera-AI"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "tapo-c260",
@@ -195324,6 +201410,182 @@
     "added": "2026-06-06"
   },
   {
+    "brand": "Tapo",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.17",
+      "aperture": "F1.65",
+      "varifocal": false
+    },
+    "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "power": {
+      "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+    },
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "operating_temp_c": "-20 to 45",
+    "dimensions_mm": "60 diameter x 89",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "id": "tapo-c403",
+    "model": "Tapo C403",
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 15,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "features": [
+      "100% wire-free battery-powered",
+      "up to 180-day battery life",
+      "full-color night vision with 2x spotlights",
+      "850 nm IR LED night vision",
+      "smart person detection",
+      "activity zones",
+      "94 dB siren",
+      "3DNR and WDR image enhancement",
+      "PIR motion sensor (110 deg, 10 sensitivity levels)",
+      "ambient light sensor",
+      "two-way audio with noise cancellation",
+      "Tapo H200 hub unified local storage support",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c403/"
+    ],
+    "release_notes": "Battery-powered indoor/outdoor camera — the 1080p sibling of the 2K C410 on an identical optical and mechanical platform (same 1/2.8\" starlight sensor, 3.17 mm F1.65 lens, 125 deg diagonal FOV, 60 x 89 mm body, IP65, 180-day battery). All specs from the official Tapo product page specification table. No RTSP/ONVIF on the battery/solar line, so no Frigate or Blue Iris config is provided. Solar-powered kit variant is the Tapo C403 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer.",
+    "added": "2026-07-26"
+  },
+  {
+    "brand": "Tapo",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.17",
+      "aperture": "F1.65",
+      "varifocal": false
+    },
+    "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "power": {
+      "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+    },
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "operating_temp_c": "-20 to 45",
+    "dimensions_mm": "60 diameter x 89",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "id": "tapo-c410",
+    "model": "Tapo C410",
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "max_fps": 15,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "features": [
+      "100% wire-free battery-powered",
+      "up to 180-day battery life",
+      "full-color night vision with 2x spotlights",
+      "850 nm IR LED night vision",
+      "smart person detection",
+      "activity zones",
+      "94 dB siren",
+      "3DNR and WDR image enhancement",
+      "PIR motion sensor (110 deg, 10 sensitivity levels)",
+      "ambient light sensor",
+      "two-way audio with noise cancellation",
+      "Tapo H200 hub unified local storage support",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c410/",
+      "https://www.tapo.com/en/document/50810/",
+      "https://www.tapo.com/en/document/51028/"
+    ],
+    "release_notes": "Battery-powered outdoor camera (V2 hardware). All specs from the official Tapo product page specification table. No RTSP/ONVIF: TP-Link's battery/solar camera line exposes no local stream, so no Frigate or Blue Iris config is provided rather than a fabricated RTSP path — consistent with the C400/C402/C420/C425 entries. Solar-powered kit variant is the Tapo C410 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c420",
     "brand": "Tapo",
     "model": "C420",
@@ -196076,6 +202338,103 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c545d",
+    "brand": "Tapo",
+    "model": "Tapo C545D",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K (3MP per lens)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "streams": [
+        {
+          "name": "Wide-angle lens",
+          "resolution": "2304x1296"
+        },
+        {
+          "name": "Telephoto pan/tilt lens",
+          "resolution": "2304x1296"
+        }
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "varifocal": false
+    },
+    "field_of_view_deg": "121 diagonal / 95 horizontal / 57.3 vertical (wide-angle lens); 31.7 vertical (telephoto lens)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power_source": [
+      "dc"
+    ],
+    "features": [
+      "dual 2K 3MP lenses (wide-angle + telephoto)",
+      "synchronized smart detection and tracking",
+      "color night vision",
+      "motorized pan/tilt on telephoto lens",
+      "wide-angle lens manual pan 270 degrees, tilt -30 to -10 degrees",
+      "wall, ceiling or rod mounting",
+      "Alexa / Google Assistant / Samsung SmartThings",
+      "Tapo Care cloud or local microSD storage"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "release_notes": "Outdoor dual-lens pan/tilt camera — the outdoor counterpart of the indoor C245D and indoor/outdoor C246D. Dual 2K 3MP resolution, both lens FOV figures, the wide-angle manual pan/tilt ranges, motorized telephoto control, colour night vision, and 512 GB microSD from the official TP-Link C545D datasheet. Sensor, focal lengths, apertures, IR range, IP rating, power method, dimensions, and weight omitted: not present in the recovered datasheet text.",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c545d/",
+      "https://manuals.plus/m/25fd9cf1ca4000dcfcba1ecd9b383147b3fd481b4ac5735e94f324b76441574d"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c560ws",
     "brand": "Tapo",
     "model": "Tapo C560WS",
@@ -196625,6 +202984,109 @@
     "status": "available",
     "last_verified": "2026-07-01",
     "added": "2026-06-06"
+  },
+  {
+    "id": "tapo-c710",
+    "brand": "Tapo",
+    "model": "Tapo C710",
+    "type": "floodlight",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "98.1 diagonal / 82.8 horizontal / 44.5 vertical",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "Hardwired mains (mounts over a standard wall junction box; neutral + line wires)"
+    },
+    "power_source": [
+      "ac-mains"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "features": [
+      "1500-lumen dimmable floodlight (4000K, motion-activated, app-controlled)",
+      "pan mechanical 338 degrees (360 coverage) / tilt 97 degrees (140 coverage)",
+      "dedicated PIR sensor on floodlight (165 degrees, 25 ft) independent of camera direction",
+      "360-degree AI motion tracking",
+      "person / pet / vehicle detection",
+      "scheduled 360-degree panoramic scans and patrol mode",
+      "24/7 continuous recording (hardwired)",
+      "10.8x digital zoom",
+      "3D DNR, BLC, WDR",
+      "full-color night vision + IR",
+      "sound and light alarm (customizable)",
+      "two-way audio with noise cancellation",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "release_notes": "Hardwired pan/tilt floodlight camera (US launch February 2026). Complete specification from the official Tapo product page spec table: sensor, 4.0 mm F2.0 lens, full FOV triplet, IR 98 ft / 30 m plus full-color night vision, 1500 lm 4000K floodlight, mechanical pan/tilt ranges, PIR coverage, 30 fps, 10.8x digital zoom, 512 GB microSD, IP65. RTSP/ONVIF listed per the mains-powered Tapo pattern with verified:false — confirm on hardware, as floodlight models occasionally differ.",
+    "sources": [
+      "https://www.tapo.com/us/product/smart-camera/tapo-c710/",
+      "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c710/",
+      "https://www.notebookcheck.net/Tapo-releases-new-security-camera-with-bright-floodlight.1225415.0.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 main, /stream2 sub. Not bench-verified on the C710 specifically."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Enable the Camera Account in the Tapo app first."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "tapo-c720",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -217,6 +217,168 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipca32500",
+    "brand": "ABUS",
+    "model": "IPCA32500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP24",
+    "power": {
+      "method": "PoE"
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "features": [
+      "Sony STARVIS sensor with Tamron 3-9 mm lens",
+      "True WDR",
+      "IR LEDs",
+      "16 GB internal memory for edge recording",
+      "ONVIF"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line (2017 generation) indoor IP dome 2 MPx — predecessor platform of the IPCA72510. Specs from the RS Components (authorized distributor) product listing: Sony STARVIS + Tamron 3-9 mm, 1080p @ 30 fps, IP24 indoor, PoE, audio, 16 GB internal memory, 141 mm width. Single-distributor sourced and flagged accordingly — aperture, FOV, IR range, full dimensions, and temperature omitted pending an official datasheet. Sibling IPCA22500 (official 2017 manual exists on abus.com) remains excluded: identity and resolution unconfirmed.",
+    "sources": [
+      "https://uk.rs-online.com/web/p/cctv-cameras/1774399"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca33500",
+    "brand": "ABUS",
+    "model": "IPCA33500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Indoor IP dome 3 MPx — sibling of the 1080p IPCA32500. Max 50/60 fps with WDR off, 25 fps with WDR.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipca34512a",
     "brand": "ABUS",
     "model": "IPCA34512A",
@@ -547,6 +709,249 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipca52000",
+    "brand": "ABUS",
+    "model": "IPCA52000",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "outdoor boxtype",
+      "120 dB WDR",
+      "16 GB internal memory for recording on network failure",
+      "Sony Xarina DSP"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Aussen IP Boxtype 1080p (2017 Advanced generation, predecessor of the IPCA52010). Platform data (1920x1080 @ 25 fps, Sony Exmor sensor + Xarina DSP, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018, covering IPCA22500/32500/52000/62500/62505/72500); 'Aussen IP Boxtype 1080p' designation from the official ABUS Katalog accessory compatibility matrices. Lens, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources.",
+    "sources": [
+      "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca52010",
+    "brand": "ABUS",
+    "model": "IPCA52010",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP20",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "0 to 50",
+    "dimensions_mm": "65 x 65 x 120",
+    "features": [
+      "CS-mount box camera (lens sold separately, e.g. TVAC65502 2.8-10 mm)",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "indoor (IP20), outdoor via TVAC70200 heated housing"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line IP boxtype 2 MPx — interchangeable-lens body; the lens field is intentionally minimal (CS mount, no bundled lens). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca53000",
+    "brand": "ABUS",
+    "model": "IPCA53000",
+    "type": "box",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "Universal boxtype with interchangeable lens (lens sold separately)",
+      "120 dB True WDR",
+      "ABF integrated auto back focus",
+      "RS-485 interface (unique in the IPCA series)",
+      "outdoor use via optional heated housing"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Universal IP Boxtype 3 MPx (2016 Advanced generation, predecessor of the IPCA52010). Identity and hardware from the official ABUS hardware manual (20160425-IPCA53000_BDA_Hardware); 2048x1536 @ 25 fps, 120 dB True WDR, and ABF auto back focus cross-corroborated by dealer PIM republications; RS-485 confirmed by the official IPCA-series software manual. Interchangeable-lens body: lens field intentionally minimal. Sensor, power, IP rating, dimensions omitted: not confirmed from recovered official sources.",
+    "sources": [
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/17/20160425-IPCA53000_BDA_Hardware_DE_UK.pdf",
+      "https://www.sicher24.de/ueberwachungskameras/abus-universal-ip-boxtype-3-mpx-ipca53000.html",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipca54512a",
@@ -1120,6 +1525,372 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipca62510",
+    "brand": "ABUS",
+    "model": "IPCA62510",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "aperture": "F1.3 - F2.2 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 90 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 87 x 287",
+    "features": [
+      "3x optical zoom (Tamron motor zoom)",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca62515",
+    "brand": "ABUS",
+    "model": "IPCA62515",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.0 to 50.0",
+      "aperture": "F1.6 - F1.8 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "9 to 70 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 84 x 287",
+    "features": [
+      "10x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca62520",
+    "brand": "ABUS",
+    "model": "IPCA62520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 1080p — successor of the IPCA62500. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA63500/66500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca63500",
+    "brand": "ABUS",
+    "model": "IPCA63500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 3 MPx. Max 50/60 fps with WDR off. Official joint hardware manual with IPCA62520/66500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipca64512a",
     "brand": "ABUS",
     "model": "IPCA64512A",
@@ -1600,6 +2371,817 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipca66500",
+    "brand": "ABUS",
+    "model": "IPCA66500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "6MP",
+      "max_width": 3072,
+      "max_height": 2048,
+      "megapixels": 6.3
+    },
+    "video": {
+      "max_fps": 24,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP tube 6 MPx. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual. Official joint hardware manual with IPCA62520/63500.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf",
+      "https://www.libble.eu/abus-ipca66500/online-manual-964589/"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca68500",
+    "brand": "ABUS",
+    "model": "IPCA68500",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3 to 8.6",
+      "aperture": "F1.5 - F2.4 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "48 to 95 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "89 x 84 x 287",
+    "features": [
+      "2x optical zoom",
+      "120 dB WDR",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72500",
+    "brand": "ABUS",
+    "model": "IPCA72500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "Tamron 3-9 mm motor vario zoom",
+      "120 dB WDR",
+      "16 GB internal memory for recording on network failure",
+      "Sony Xarina DSP",
+      "outdoor dome (TVAC31311 wall mount)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced outdoor IP dome 1080p (2017 generation, predecessor of the IPCA72510). Platform data (1920x1080 @ 25 fps, Sony Exmor + Xarina DSP, Tamron 3.0-9.0 mm motor vario, 120 dB WDR, 16 GB internal failover memory) from the official ABUS joint family manual (20171018); dome form factor confirmed by the official Katalog 19 mount compatibility (TVAC31311 wall mount: IPCA72500, IPCA72510, IPCA72515, IPCA78500). IR range, IP rating, power, and dimensions omitted pending the official datasheet. Note: IPCA22500 from the same manual remains excluded — its form factor is still unconfirmed.",
+    "sources": [
+      "https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2016/17 Advanced line (Sony/Tamron platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72510",
+    "brand": "ABUS",
+    "model": "IPCA72510",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.0 to 9.0",
+      "aperture": "F1.3 - F2.2 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 90 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.001
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "3x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72515",
+    "brand": "ABUS",
+    "model": "IPCA72515",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.0 to 50.0",
+      "aperture": "F1.6 - F1.8 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "9 to 70 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "10x optical zoom",
+      "150 dB DOL WDR (3x shutter)",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca72520",
+    "brand": "ABUS",
+    "model": "IPCA72520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Outdoor IP dome 1080p — successor of the IPCA72500. Max 50/60 fps with WDR off.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca73500",
+    "brand": "ABUS",
+    "model": "IPCA73500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 3 MPx per the dealer PIM designation. Max 50/60 fps with WDR off.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://www.wilkon-sicherheitstechnik.de/epages/wilko1.sf/de_DE/?ObjectPath=/Shops/wilko1/Products/VICM_AS_IPCA73500"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca76500",
+    "brand": "ABUS",
+    "model": "IPCA76500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "6MP",
+      "max_width": 3072,
+      "max_height": 2048,
+      "megapixels": 6.3
+    },
+    "video": {
+      "max_fps": 24,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "motor zoom with remote zoom/focus",
+      "WDR",
+      "SD-card edge recording with in-browser playback",
+      "master/installer user model"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (2017 generation, Sony platform). Identity, resolution, and max frame rate from the official joint IPCA-series software manual (IPCA33500/53000/62520/63500/66500/72520/73500/76500, version 09/2017) and the official ABUS Viewer compatibility document; motor-zoom (remote zoom/focus) per the manual's per-model function table. Sensor, focal length, IR range, IP rating, power, and dimensions omitted: not stated per-model in recovered official sources. Aussen IP Dome IR 6 MPx per the dealer PIM designation. Max 24 fps at 3072x2048, 25 fps at 3072x1728 per the official manual.",
+    "sources": [
+      "https://www.manualslib.de/manual/270023/Abus-Ipca33500.html",
+      "https://assets.abus.com/dam/132269_originalFile.pdf",
+      "https://www.wilkon-sicherheitstechnik.de/ABUS-Aussen-IP-Dome-IR-6MPx-IPCA76500"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "2017 Advanced line (Sony platform, not Hikvision OEM) — RTSP path undocumented. Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipca78500",
+    "brand": "ABUS",
+    "model": "IPCA78500",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3 to 8.6",
+      "aperture": "F1.5 - F2.4 (W-T)",
+      "varifocal": true
+    },
+    "field_of_view_deg": "48 to 95 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "12V DC / 24V AC / PoE (IEEE 802.3af, class 3)"
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-25 to 55",
+    "dimensions_mm": "111 x 140 x 140",
+    "features": [
+      "2x optical zoom",
+      "120 dB WDR",
+      "Ultra Low-Light",
+      "Tripwire, intrusion, human detection, object counting VCA",
+      "IK10 vandal resistance",
+      "full-duplex 2-way audio",
+      "1 alarm input / 1 alarm output",
+      "microUSB service port",
+      "HTTPS, TLS, RTSP/TLS, JSON Web Token",
+      "modular housing design"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Advanced-line camera (Sony STARVIS platform — distinct OEM from the Hikvision-based Basic line, hence no assumed RTSP path). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb34511a",
@@ -2192,6 +3774,494 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb42510a",
+    "brand": "ABUS",
+    "model": "IPCB42510A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42510b",
+    "brand": "ABUS",
+    "model": "IPCB42510B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Innendome/IP-Mini-Dome-2-MPx-1080p-4-mm",
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "87 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42510c",
+    "brand": "ABUS",
+    "model": "IPCB42510C",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "100 x 97 x 53",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini dome (predecessor of the IPCB44x11 generation); family = IPCB42510A (2.8 mm / 108°), B (4 mm / 87°), C (6 mm / 53°) per the official ABUS archive product pages. Platform specs (1/2.8\" sensor, F1.6, 100x97x53 body, streams, IR 10 m via 10 LEDs, 0.009 lux, -30 to 60 °C) confirmed against the official ABUS datasheet of the same-body WLAN sibling IPCB42515A and the same-platform IPCB62510B family datasheet, cross-checked with the distributor PIM republication. Weight omitted: stated only for the WLAN variant.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-2-MPx-1080p-6-mm",
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb42515a",
+    "brand": "ABUS",
+    "model": "IPCB42515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet",
+      "wifi"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal / 59 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "audio": {
+      "microphone": true
+    },
+    "features": [
+      "WiFi 802.11 b/g/n + wired RJ45",
+      "built-in microphone + audio output",
+      "1x alarm input / 1x alarm output",
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G/T",
+      "flat 5 cm profile",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "97 x 100 x 53",
+    "weight_g": 400,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL WLAN variant of the Basic-line 2 MPx mini dome — the only radio (RED-directive) model in the IPCB fixed-lens family; the 6x515/7x515 siblings are wired. All specs from the official ABUS datasheet.",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-WLAN-2-MPx-1080p-2.8-mm",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Dome-WLAN-2-MPx-IPCB42515A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb44510a",
     "brand": "ABUS",
     "model": "IPCB44510A",
@@ -2287,6 +4357,108 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcb44510b",
+    "brand": "ABUS",
+    "model": "IPCB44510B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "88 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.008
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "features": [
+      "IK08 vandal-resistant housing",
+      "120 dB WDR",
+      "Ultra low-light performance",
+      "ONVIF Profile S/G",
+      "M12 fixed lens mount",
+      "Min. illumination 0.008 lux color / 0 lux IR",
+      "ABUS Link Station App support"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "100 x 97 x 53",
+    "weight_g": 400,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "4 mm middle lens variant of the IPCB44510 mini dome family (A = 2.8 mm / 109°, B = 4 mm / 88°, C = 6 mm / 53°). Lens and FOV from the official ABUS archive product page; all shared-platform specs match the family datasheet.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Dome-4-MPx-4-mm",
+      "https://c1.abus.com/uk/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-4-mm",
+      "https://www.expert-security.de/abus-ipcb44510b-ip-dome-1080p-t-n-ir-poe-ip66-ik08.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb44510c",
@@ -3661,6 +5833,567 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb62510a",
+    "brand": "ABUS",
+    "model": "IPCB62510A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Tube-2-MPx-IPCB62510A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62510b",
+    "brand": "ABUS",
+    "model": "IPCB62510B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-4-mm"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "87 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62510c",
+    "brand": "ABUS",
+    "model": "IPCB62510C",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "1920x1080",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx mini tube; family = IPCB62510A (2.8 mm / 108°), B (4 mm / 87°/45°), C (6 mm / 53°) per the official ABUS archive product pages. All platform specs from the official ABUS family datasheet (IPCB62510B).",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf",
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-6-mm"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10,
+      "min_lux_color": 0.009
+    },
+    "weight_g": 500,
+    "operating_temp_c": "-30 to 60",
+    "features": [
+      "Ultra low-light performance",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "Tripwire / intrusion detection VCA",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62515a",
+    "brand": "ABUS",
+    "model": "IPCB62515A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "120 dB WDR",
+      "motion detection (8 zones)",
+      "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube 2 MPx (fixed 2.8 mm) — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190617-IPCB6x515AB_INST_DE_UK.pdf",
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/23/ABUS-Link-Station-Supported-devices.pdf",
+      "https://endlich-sicher.de/ip-tube-kamera-abus-ipcb62515a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "108 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb62520",
+    "brand": "ABUS",
+    "model": "IPCB62520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://myloesch.com/de/smart-home-elektronik/videoueberwachung/"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "field_of_view_deg": "35 to 105 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb64510a",
     "brand": "ABUS",
     "model": "IPCB64510A",
@@ -3943,6 +6676,205 @@
       }
     },
     "added": "2026-07-05"
+  },
+  {
+    "id": "abus-ipcb64515b",
+    "brand": "ABUS",
+    "model": "IPCB64515B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube 4 MPx (fixed 4 mm). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://www.manualslib.com/manual/2443358/Abus-Ipcb64515b.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "88 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb64520",
+    "brand": "ABUS",
+    "model": "IPCB64520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "megapixels": 4,
+      "max_width": 2688,
+      "max_height": 1520
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "32 to 114 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb64521",
@@ -4278,6 +7210,355 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb68510a",
+    "brand": "ABUS",
+    "model": "IPCB68510A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "102 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb68510b",
+    "brand": "ABUS",
+    "model": "IPCB68510B",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm",
+      "https://www.zajadacz.de/ABUS-IP-Mini-Tube-8-MPx-4K-IPCB68510A.html",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "field_of_view_deg": "79 horizontal",
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb68510c",
+    "brand": "ABUS",
+    "model": "IPCB68510C",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "dimensions_mm": "155 x 74 x 74",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) mini tube; family = IPCB68510A (2.8 mm / 102°), B (4 mm), C (6 mm / 50°) per the official ABUS archive product pages. Platform specs (sensor, F2.0, dimensions, streams) from the ABUS PIM/datasheet data as republished by distributors. B-variant FOV omitted: not stated in the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-6-mm",
+      "https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "field_of_view_deg": "50 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "features": [
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb68515a",
     "brand": "ABUS",
     "model": "IPCB68515A",
@@ -4374,6 +7655,111 @@
       }
     },
     "added": "2026-07-05"
+  },
+  {
+    "id": "abus-ipcb68520",
+    "brand": "ABUS",
+    "model": "IPCB68520",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Basic-line IP Tube motor-zoom — previously thin entry, now completed. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "35 to 115 horizontal",
+    "ip_rating": "IP67",
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "160 x 160 x 390",
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcb68521",
@@ -4616,6 +8002,434 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb72515a",
+    "brand": "ABUS",
+    "model": "IPCB72515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "2MP (1080p)",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "motion detection (8 zones)",
+      "compatible with ABUS Secvest / wAppLoxx Pro / ModuVis",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "143 x 143 x 100",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 2 MPx full-size vandal dome (fixed-lens dome family: IPCB72515A 2.8 mm / 108°, IPCB74515B 4 mm / 88°, IPCB78515A 2.8 mm / 102°; FOVs corroborated by the official ABUS Video/IP catalog). Sensor, IR range, weight, and operating temperature omitted: not confirmed from an official source for this variant.",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf",
+      "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb72515a",
+      "https://manuals.plus/m/41e9eecc72014f49518f19ef80f4599ffbfe1827ef54d434bc1c5bf5ee7006d4"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "operating_temp_c": "-30 to 60",
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb72520",
+    "brand": "ABUS",
+    "model": "IPCB72520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 105 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.005
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (2MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb74515b",
+    "brand": "ABUS",
+    "model": "IPCB74515B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2688x1520",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "88 horizontal / 46 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 143 x 100",
+    "weight_g": 1100,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 4 MPx full-size vandal dome; 4 mm / 88° per the official ABUS archive product page and the official Video/IP catalog. Platform table (sensor, F1.6, 143x143x100, 1100 g, streams, -30 to 60 °C) from the ABUS PIM data as republished by distributors; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings.",
+    "sources": [
+      "https://www.abus.com/ch_de/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-4-MPx-4-mm",
+      "https://www.expert-security.de/abus-ipcb74515b-ip-dome-4mpx-t-n-ir-poe-ip67.html",
+      "https://endlich-sicher.de/abus-ip-dome-kamera-ipcb74515b/jl56564"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb74520",
+    "brand": "ABUS",
+    "model": "IPCB74520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "32 to 114 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.008
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (4MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb74521",
     "brand": "ABUS",
     "model": "IPCB74521",
@@ -4747,6 +8561,317 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcb74615b",
+    "brand": "ABUS",
+    "model": "IPCB74615B",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom",
+      "3-axis gimbal (pan/tilt/rotation)",
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb78515a",
+    "brand": "ABUS",
+    "model": "IPCB78515A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "8MP (4K)",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "3840x2160",
+          "fps": 20
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "102 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "ik_rating": "IK10",
+    "features": [
+      "IK10 vandal-resistant full dome",
+      "120 dB WDR",
+      "3D-DNR",
+      "motion detection (8 zones)",
+      "ONVIF Profile S/G",
+      "compatible with ABUS Secvest / wAppLoxx",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "143 x 143 x 100",
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line 8 MPx (4K) full-size vandal dome; 2.8 mm / 102° per the official ABUS archive product page and datasheet. Sensor, F2.0, dimensions, and streams from the official ABUS datasheet; IR 30 m from the ABUS datasheet bullet as replicated across independent retailer listings. Weight and operating temperature omitted: not captured from the official sources reviewed.",
+    "sources": [
+      "https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-8-MPx-4K-2.8-mm",
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002246401DS00/datablad-2246401-abus-ipcb78515a-lan-ip-overvagningskamera-3840-x-2160-pix.pdf",
+      "https://www.elektroshopwagner.de/product_info.php/info/p266293_ABUS-IPCB78515A-IP-Dome-8-MPx--4K--2-8-mm-.html",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "operating_temp_c": "-30 to 60",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcb78520",
+    "brand": "ABUS",
+    "model": "IPCB78520",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "max_fps": 20,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "aperture": "F1.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "35 to 115 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30,
+      "min_lux_color": 0.01
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "143 x 100 x 143",
+    "features": [
+      "2.8-12 mm motor zoom (4.2x optical)",
+      "Ultra Low Light",
+      "120 dB WDR",
+      "IK10 vandal resistance",
+      "Tripwire / intrusion detection VCA",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output",
+      "ONVIF Profile S + G"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome motor-zoom (8MP). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcb78521",
     "brand": "ABUS",
     "model": "IPCB78521",
@@ -4855,6 +8980,94 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcb78615a",
+    "brand": "ABUS",
+    "model": "IPCB78615A",
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "12V DC / PoE"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "features": [
+      "2.8-12 mm motor zoom",
+      "3-axis gimbal (pan/tilt/rotation)",
+      "IR LEDs",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL Basic-line IP dome with 2.8-12 mm motor-zoom lens — the motor-zoom sibling of the fixed-lens IPCB7x515 family (same 143 mm dome body per shared ABUS wall-mount compatibility, TVAC31320X). Identity, 12V DC / PoE power, IR LEDs, and 256 GB microSD from the official joint IPCB74615B/IPCB78615A installation manual; motor-zoom family placement from the official ABUS Katalog 19. Resolution class per ABUS's model numbering as officially verified on the fixed-lens siblings (74=4MPx, 78=8MPx/4K). Sensor, FOV, IR range, IP rating, and weight omitted: retailer PIM data for these two models is cross-contaminated and was not used.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf",
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic/Performance IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs24500",
@@ -5069,6 +9282,121 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcs29511",
+    "brand": "ABUS",
+    "model": "IPCS29511",
+    "type": "fisheye",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "12MP",
+      "max_width": 4000,
+      "max_height": 3000,
+      "megapixels": 12
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Main (Fisheye)",
+          "resolution": "4000x3000",
+          "fps": 20
+        },
+        {
+          "name": "Main (Panorama)",
+          "resolution": "3072x2304",
+          "fps": 15
+        },
+        {
+          "name": "Sub",
+          "resolution": "704x576",
+          "fps": 15
+        }
+      ]
+    },
+    "field_of_view_deg": "360 horizontal",
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "hemispheric 360/180 degree panorama views",
+      "in-camera dewarping (hardware + up to 14 software view modes)",
+      "ePTZ with up to 255 presets and 32 tours",
+      "replaces up to 4 cameras (up to 4 video channels)",
+      "DWDR",
+      "people counting",
+      "heat map",
+      "intersection analysis",
+      "Tripwire / intrusion / region entry-exit / unattended baggage / object removal VCA",
+      "audio exception detection",
+      "1x alarm input / 1x alarm output",
+      "audio in/out (2-way audio)",
+      "8 privacy zones",
+      "NAS recording",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL 12 MPx Hemispheric IP fisheye — predecessor of the IPCS29512 (which added deep-learning people counting v2). All fields from the official ABUS user manual (20230425-IPCS29511_BDA_INT): 4000x3000 @ 20 fps fisheye main stream (2560x2560 @ 25/30 fps mode), panorama and multi-ePTZ view modes, IP66, mic + speaker with 2-way audio, alarm I/O, PoE/12V DC, microSD + NAS recording, DWDR, full smart-event suite. Sensor, lens, IR range, IK rating, microSD max size, dimensions, and weight omitted: the manual defers the spec table to the product page, and no official datasheet was recovered.",
+    "sources": [
+      "https://c1.abus.com/asc-pim-assets-01/medias/docus/28/20230425-IPCS29511_BDA_INT.pdf",
+      "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs29512",
@@ -5979,6 +10307,229 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs62120",
+    "brand": "ABUS",
+    "model": "IPCS62120",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 60,
+      "codecs": [
+        "H.264",
+        "MPEG-4",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 to 12",
+      "varifocal": true
+    },
+    "field_of_view_deg": "32 to 92 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50,
+      "min_lux_color": 0.003
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "dimensions_mm": "390 x 160",
+    "features": [
+      "ANPR license plate recognition (Europe, up to 70 km/h, 2048-plate allow/deny list)",
+      "1080p @ 50/60 fps",
+      "2.8-12 mm motor zoom (4.2x)",
+      "120 dB WDR",
+      "EIS electronic image stabilization, distortion correction",
+      "2-way audio (browser/CMS)",
+      "1 alarm input / 1 alarm output",
+      "analog video output"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line ANPR tube on the Basic Hikvision-OEM platform. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Basic IP line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the web UI first. Pattern from the IPCx OEM family; not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "Select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs64511a",
+    "brand": "ABUS",
+    "model": "IPCS64511A",
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2688,
+      "max_height": 1520,
+      "megapixels": 4
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "640x480",
+          "fps": 25,
+          "codec": "H.264"
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.264"
+        }
+      ]
+    },
+    "sensor": "1/1.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8",
+      "aperture": "F1.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "108 horizontal",
+    "night_vision": {
+      "type": "color",
+      "min_lux_color": 0.0005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP67",
+    "features": [
+      "WDR 120 dB",
+      "full-color night vision",
+      "white light LEDs",
+      "person/vehicle detection",
+      "motion detection (up to 8 zones)",
+      "minimum illumination 0.0005 lux (color)",
+      "compatible with ABUS Secvest / Secoris / wAppLoxx Pro",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-25 to 60",
+    "dimensions_mm": "282 x 105 x 105",
+    "weight_g": 1000,
+    "release_year": 2023,
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "2.8 mm wide-angle variant of the Gecko IP Tube 4 MPx WL (A = 2.8 mm / 108°, B = 4 mm / 95°) per the official ABUS product pages. White-light LED range omitted: not stated per-variant in the official sources reviewed (retailer figures conflict with the B variant's documented 50 m).",
+    "sources": [
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-mm-WL",
+      "https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-2.8-mm-WL",
+      "https://www.zajadacz.de/ABUS-IP-Tube-4-MPx-2-8-mm-IPCS64511A.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs64511b",
     "brand": "ABUS",
     "model": "IPCS64511B",
@@ -6544,6 +11095,539 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs82500",
+    "brand": "ABUS",
+    "model": "IPCS82500",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7 to 94",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.2 to 58.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 150,
+      "min_lux_color": 0.05
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-30 to 65",
+    "dimensions_mm": "185 x 330 x 185",
+    "features": [
+      "20x optical zoom",
+      "16x digital zoom",
+      "360 degree pan / -15 to 90 tilt",
+      "EIS electronic image stabilization",
+      "Defog",
+      "WDR, BLC, HLC",
+      "2 alarm inputs / 1 alarm output",
+      "RS485",
+      "analog video output",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (20x) — predecessor generation of the IPCS84550/84551 slot. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs82520",
+    "brand": "ABUS",
+    "model": "IPCS82520",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.9\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9 to 135.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.0 to 59.8 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "23x optical zoom",
+      "16x digital zoom",
+      "Ultra Low-Light (large 1/1.9 inch sensor)",
+      "120 dB True WDR",
+      "EIS electronic image stabilization",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (23x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs82530",
+    "brand": "ABUS",
+    "model": "IPCS82530",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "2MP",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/1.9\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.7 to 205",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.0 to 59.0 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.02
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "36x optical zoom",
+      "16x digital zoom",
+      "Ultra Low-Light (large 1/1.9 inch sensor)",
+      "120 dB True WDR",
+      "EIS electronic image stabilization",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 2 MPx (36x, Ultra Low-Light). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs83500",
+    "brand": "ABUS",
+    "model": "IPCS83500",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "3MP",
+      "max_width": 2048,
+      "max_height": 1536,
+      "megapixels": 3.1
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5 to 162",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.7 to 61.0 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.05
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "power": {
+      "method": "24V AC / High-PoE (IEEE 802.3bt)"
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "two_way": true
+    },
+    "operating_temp_c": "-40 to 60",
+    "dimensions_mm": "266 x 365 x 266",
+    "features": [
+      "36x optical zoom",
+      "16x digital zoom",
+      "120 dB WDR",
+      "ROI, Defog",
+      "7 alarm inputs / 2 alarm outputs",
+      "RS485",
+      "analog video output",
+      "IK10 vandal resistance",
+      "2-way audio (browser/CMS)"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP PTZ 3 MPx (36x). Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
+    "sources": [
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs84510",
+    "brand": "ABUS",
+    "model": "IPCS84510",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.264",
+        "H.265",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1280x720",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/3\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.8 - 12.0",
+      "aperture": "F1.6 - F2.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "31.6 to 96.7 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20,
+      "min_lux_color": 0.005
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) / 12V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "two_way": true
+    },
+    "features": [
+      "PTZ 355 pan / 0-90 tilt (100°/s)",
+      "4x optical zoom",
+      "16x digital zoom",
+      "120dB WDR",
+      "electronic image stabilization (EIS)",
+      "3D-DNR",
+      "IK10 vandal resistance",
+      "300 presets",
+      "Tripwire / intrusion detection VCA",
+      "Motion detection",
+      "2 relay outputs",
+      "Pelco D / Pelco P",
+      "ABUS Link Station App"
+    ],
+    "operating_temp_c": "-20 to 60",
+    "dimensions_mm": "131 x 131 x 102",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "release_notes": "Predecessor of the IPCS84511 mini PTZ on the same Ø13 cm body; still supported by current mounts (TVAC31215/31285) on abus.com. Specs from the official ABUS datasheet. Power recorded from the datasheet spec table (12V DC / PoE 802.3af); the same datasheet's bullet list states '24 V AC & PoE' and recommends a High-PoE 60W injector for wall mounting — discrepancy left unresolved rather than guessed.",
+    "sources": [
+      "https://asset.conrad.com/media10/add/160267/c1/-/de/002237147DS00/datablad-2237147-abus-ipcs84510-ip-bewakingscamera-lan-2560-x-1440-pix.pdf",
+      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Ceiling-Mount-for-IPCS84510",
+      "https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs84511",
     "brand": "ABUS",
     "model": "IPCS84511",
@@ -6667,6 +11751,230 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ipcs84530",
+    "brand": "ABUS",
+    "model": "IPCS84530",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "2560x1440",
+          "fps": 25
+        }
+      ]
+    },
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 120",
+      "aperture": "F1.6 - F3.5",
+      "varifocal": true
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "max_microsd_gb": 256
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "features": [
+      "25x optical autofocus motor zoom (4.8-120 mm)",
+      "360 degree pan",
+      "300 presets / 8 tours (automated guard tours)",
+      "Ultra Low Light",
+      "WDR",
+      "2-way audio",
+      "1080p @ 50 fps mode",
+      "compact form factor for flush ceiling mount",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL IP PTZ 4 MPx (25x) — predecessor of the IPCS84531/IPCS84532 on the same 169 mm body (note: 1/2.5\" sensor vs 1/2.8\" in the successors). Full platform table (sensor, 4.8-120 mm F1.6-F3.5, FOV 2.5-57.6°, streams, 2-way audio, 12V DC / PoE+ 802.3at) from the official ABUS partner portal product data; IR 50 m, IP66, 360° pan, and ULL from the official ABUS archive product page. Weight and operating temperature omitted: not captured from official sources.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-25x",
+      "https://partner-ch.abus.com/de/silver.econtent/catalog/Produkte/Elektronische-Sicherheit/Professional-Sortiment/Videoueberwachung/Netzwerk/Kameras/SPECIAL/IP-PTZ-4-MPx-25x",
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "sensor": "1/2.5\" Progressive Scan CMOS",
+    "field_of_view_deg": "2.5 to 57.6 horizontal",
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "dimensions_mm": "169 diameter x 161",
+    "added": "2026-07-26"
+  },
+  {
+    "id": "abus-ipcs84531",
+    "brand": "ABUS",
+    "model": "IPCS84531",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 25,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 120",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5 to 53 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 50
+    },
+    "power": {
+      "method": "12V DC / PoE+ (IEEE 802.3at, 30W)"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "features": [
+      "25x optical autofocus motor zoom",
+      "16x digital zoom",
+      "360 degree pan",
+      "300 presets / automated guard tours",
+      "Ultra Low Light",
+      "WDR",
+      "compact form factor for flush ceiling mount (TVAC31275/31375)",
+      "ABUS Link Station App"
+    ],
+    "dimensions_mm": "169 diameter x 161",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "markets": [
+      "EU"
+    ],
+    "release_notes": "Predecessor of the IPCS84532 (same 169x161 mm body; the 84532 adds AI human/vehicle detection). Shares the official installation manual with IPCS84511 (220504-IPCS84511_84531_TVIP82561_BDA_INT). Still supported by current mounts (TVAC31205/31275) on abus.com. Audio, IK rating, weight, and operating temperature omitted: not confirmed from official sources for this variant.",
+    "sources": [
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf",
+      "https://c1.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/PTZ/IP-PTZ-4-MPx-25x",
+      "https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84531"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI. ONVIF PTZ control supported."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ipcs84532",
     "brand": "ABUS",
     "model": "IPCS84532",
@@ -6774,6 +12082,126 @@
     },
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ipcs84550",
+    "brand": "ABUS",
+    "model": "IPCS84550",
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "label": "4MP",
+      "max_width": 2560,
+      "max_height": 1440,
+      "megapixels": 4
+    },
+    "video": {
+      "max_fps": 50,
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "Stream 1",
+          "resolution": "2560x1440",
+          "fps": 25
+        },
+        {
+          "name": "Stream 2",
+          "resolution": "704x576",
+          "fps": 25
+        },
+        {
+          "name": "Stream 3",
+          "resolution": "1920x1080",
+          "fps": 25
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.8 to 153",
+      "aperture": "F1.2 - F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.0 to 54.3 horizontal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 150
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "32x optical zoom",
+      "16x digital zoom",
+      "120 dB WDR",
+      "Ultra Low Light",
+      "Smart Tracking",
+      "Tripwire / intrusion detection VCA",
+      "300 presets / 8 tours",
+      "2 alarm inputs / 1 alarm output",
+      "1080p @ 50 fps mode",
+      "ABUS Link Station App"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "status": "discontinued",
+    "release_notes": "Archived/EOL IP PTZ 4 MPx (32x) — predecessor of the IPCS84551 (which moved to a 1/1.8\" sensor, 5.9-189 mm lens, and 200 m IR). Platform table (sensor, 4.8-153 mm F1.2-F4.4, FOV, streams, audio, alarm I/O, Smart Tracking) from the ABUS PIM data as republished by distributors, alongside the official archive product page and the official joint IPCS84530/IPCS84550 manual. IR 150 m from a distributor spec listing (single secondary source — flagged for verification against the official datasheet). Power method (PoE class), weight, and dimensions omitted: unconfirmed.",
+    "sources": [
+      "https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-32x",
+      "https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf",
+      "https://www.abus-alarmanlagen.ch/video/netzwerkkameras/abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66/",
+      "https://www.aesag.ch/en/network-cameras/2778-abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66-ipcs84550.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1920,
+          "height": 1080,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
+        "verified": false,
+        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub / 103 third). Enable ONVIF/RTSP in the camera web UI (Network > Integration Protocol) first. Pattern from the IPCx OEM family (iSpyConnect, HA community); not individually bench-tested."
+      },
+      "home_assistant": {
+        "integration": "onvif",
+        "connection_type": "local_push",
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S) in the web UI."
+      },
+      "blue_iris": {
+        "profile": "Hikvision",
+        "notes": "ABUS Performance Line is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ipcs84551",
@@ -7091,6 +12519,98 @@
     "added": "2026-06-06"
   },
   {
+    "id": "abus-ppic42520b",
+    "brand": "ABUS",
+    "model": "PPIC42520B",
+    "aliases": [
+      "ABUS Wireless Pan/Tilt Outdoor Camera (black)"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "markets": [
+      "AT",
+      "CH",
+      "DE",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "Full HD (1080p)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.1",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "355 pan / 90 tilt",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "ABUS App2Cam Plus outdoor pan/tilt",
+      "355deg pan / 90deg tilt",
+      "3MP 2K",
+      "person/animal/vehicle detection",
+      "two-way audio",
+      "GDPR-compliant local storage",
+      "IP66",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wireless-Pan-Tilt-Outdoor-Camera",
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-WiFi-Pan-Tilt-Outdoor-Camera"
+    ],
+    "power_source": [
+      "dc"
+    ],
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "210 x 120 x 160",
+    "weight_g": 650,
+    "operating_temp_c": "-10 to 50",
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC42520 WiFi Pan/Tilt Outdoor Camera. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic44520",
     "brand": "ABUS",
     "model": "PPIC44520",
@@ -7245,6 +12765,89 @@
     "added": "2026-06-06"
   },
   {
+    "id": "abus-ppic46520w",
+    "brand": "ABUS",
+    "model": "PPIC46520W",
+    "aliases": [
+      "ABUS Wi-Fi Light Outdoor Camera (white)"
+    ],
+    "type": "floodlight",
+    "connectivity": [
+      "wifi"
+    ],
+    "markets": [
+      "DE",
+      "AT",
+      "CH",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "label": "2K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "110 horizontal",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 8
+    },
+    "power": {
+      "method": "AC 90-260V"
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "replaces outdoor light fitting (like Netatmo Presence)",
+      "1000-lumen LED outdoor light",
+      "person/animal/vehicle/car AI detection",
+      "PIR sensor",
+      "two-way audio",
+      "App2Cam Plus",
+      "GDPR-compliant local microSD",
+      "no mandatory subscription",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wi-Fi-Light-Outdoor-Camera2",
+      "https://security.abus.com/Videoueberwachung/ABUS-WLAN-Licht-Aussen-Kamera.html"
+    ],
+    "power_source": [
+      "ac-mains"
+    ],
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "max_fps": 20
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "75 x 155 x 180",
+    "weight_g": 985,
+    "operating_temp_c": "-20 to 50",
+    "last_verified": "2026-07-26",
+    "release_notes": "White housing variant of the PPIC46520 Wi-Fi Light Outdoor Camera, listed as new on abus.com (07/2026). Shares the official user guide with the base model (guide covers PPIC46520 / PPIC46520W); only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic52520",
     "brand": "ABUS",
     "model": "PPIC52520",
@@ -7331,6 +12934,94 @@
     "added": "2026-06-20"
   },
   {
+    "id": "abus-ppic52520b",
+    "brand": "ABUS",
+    "model": "PPIC52520B",
+    "aliases": [
+      "ABUS SmartLook Pan & Tilt (black)"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "markets": [
+      "DE",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "2 MP (4K-interpolated recording)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "85 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 256,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.264+"
+      ],
+      "max_fps": 15
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "210 x 120 x 160",
+    "weight_g": 650,
+    "operating_temp_c": "-10 to 50",
+    "features": [
+      "4K-interpolated recording (native 2 MP sensor)",
+      "outdoor pan/tilt (270° pan / 80° tilt)",
+      "person/animal/vehicle detection",
+      "two-way audio",
+      "siren",
+      "privacy zones",
+      "5s pre-recording",
+      "local microSD (256GB, no cloud)",
+      "App2Cam Plus",
+      "WiFi 2.4/5 GHz",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook-pan-tilt2",
+      "https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html",
+      "https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE"
+    ],
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC52520 SmartLook Pan & Tilt. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "abus-ppic54520",
     "brand": "ABUS",
     "model": "PPIC54520",
@@ -7413,6 +13104,92 @@
     ],
     "last_verified": "2026-07-05",
     "added": "2026-06-20"
+  },
+  {
+    "id": "abus-ppic54520b",
+    "brand": "ABUS",
+    "model": "PPIC54520B",
+    "aliases": [
+      "ABUS SmartLook (black)"
+    ],
+    "type": "box",
+    "connectivity": [
+      "wifi",
+      "ethernet"
+    ],
+    "markets": [
+      "DE",
+      "AT",
+      "CH",
+      "EU"
+    ],
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "2 MP (4K-interpolated recording)"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4",
+      "aperture": "F2.0",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "85 horizontal / 45 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 10
+    },
+    "power": {
+      "method": "DC 5V"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 128,
+      "nvr_compatible": false,
+      "cloud": false
+    },
+    "protocols": [],
+    "ip_rating": "IP66",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "video": {
+      "codecs": [
+        "H.264",
+        "H.264+"
+      ],
+      "max_fps": 15
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "dimensions_mm": "167 x 48 x 80",
+    "weight_g": 433,
+    "operating_temp_c": "-10 to 50",
+    "features": [
+      "4K-interpolated recording (native 2 MP sensor)",
+      "App2Cam Plus",
+      "person/animal/vehicle detection",
+      "5s pre-recording",
+      "privacy masking",
+      "dual-band WiFi (2.4/5 GHz)",
+      "local microSD (no cloud)",
+      "German brand"
+    ],
+    "sources": [
+      "https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook2",
+      "https://security.abus.com/Videoueberwachung/SmartLook-abus.html"
+    ],
+    "last_verified": "2026-07-26",
+    "release_notes": "Black housing variant of the PPIC54520 SmartLook. All technical specs shared with the base model per the official ABUS product pages; only the housing color differs.",
+    "added": "2026-07-26"
   },
   {
     "id": "abus-ppic90520",
@@ -9008,37 +14785,30 @@
     "connectivity": [
       "ethernet"
     ],
-    "power_source": [
-      "poe",
-      "dc"
-    ],
     "resolution": {
-      "megapixels": 3,
+      "label": "3MP",
       "max_width": 2048,
       "max_height": 1536,
-      "label": "3MP"
+      "megapixels": 3.1
     },
     "video": {
+      "max_fps": 25,
       "codecs": [
         "H.264",
         "MJPEG"
-      ],
-      "max_fps": 25
+      ]
     },
-    "sensor": "1/3\" progressive CMOS",
+    "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
       "count": 1,
       "focal_length_mm": "1.27",
-      "aperture": "F2.8",
       "varifocal": false
     },
-    "field_of_view_deg": "360",
+    "field_of_view_deg": "180/360",
     "night_vision": {
       "type": "ir",
-      "range_m": 5
-    },
-    "power": {
-      "method": "PoE (802.3at) / 12V DC"
+      "range_m": 15,
+      "min_lux_color": 0.28
     },
     "storage": {
       "onboard": true,
@@ -9050,27 +14820,33 @@
       "rtsp"
     ],
     "ip_rating": "IP24",
+    "power": {
+      "method": "12V DC / PoE (IEEE 802.3af)"
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
     "audio": {
-      "microphone": true,
-      "speaker": true,
       "two_way": true
     },
+    "operating_temp_c": "10 to 50",
+    "dimensions_mm": "164 x 44 x 153",
     "features": [
-      "360-degree indoor hemispheric fisheye",
-      "ePTZ dewarping",
-      "two-way audio",
-      "indoor (IP24)"
+      "hemispheric 360/180 degree panorama views",
+      "ePTZ (360/80 degrees) with configurable tours",
+      "WDR, 3D DNR, BLC",
+      "1 alarm input / 1 alarm output",
+      "audio in/out"
     ],
-    "markets": [
-      "DE",
-      "EU"
+    "environment": [
+      "indoor"
     ],
-    "release_notes": "ABUS IP Fisheye 3MP (legacy TVIP naming) — indoor hemispheric, IP24. IR range ~5m per page prose (spec table shows 15m; low confidence).",
+    "status": "discontinued",
+    "release_notes": "Archived/EOL SPECIAL-line IP Fisheye 3 MPx — the small hemispheric predecessor sold alongside the 12 MPx IPCS24500 (shares TVAC31280/31290 mounts). IP24 and +10 C minimum: indoor use. Full spec table from the official ABUS Video IP Katalog 2019 (ABUS Security Center).",
     "sources": [
-      "https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-3-MPx"
+      "https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf"
     ],
-    "last_verified": "2026-07-05",
-    "status": "available",
     "configs": {
       "frigate": {
         "detect": {
@@ -9078,24 +14854,22 @@
           "height": 480,
           "fps": 5
         },
-        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "recommended_stream_type": "go2rtc",
         "verified": false,
-        "notes": "ABUS Performance Line is Hikvision OEM — Hikvision-style RTSP paths (101 main / 102 sub). Enable ONVIF/RTSP in the camera web UI first."
+        "notes": "Exact RTSP path undocumented for this ABUS line (not the Hikvision-OEM Basic platform). Use go2rtc ONVIF autodiscovery (onvif://{user}:{pass}@{ip}) to resolve the stream URL, or check the camera web UI. ONVIF Profile S supported per the official catalog."
       },
       "home_assistant": {
         "integration": "onvif",
         "connection_type": "local_push",
-        "notes": "Generic ONVIF integration after enabling ONVIF (Profile S)."
+        "onvif_events": true,
+        "notes": "Generic ONVIF integration (Profile S per official catalog)."
       },
       "blue_iris": {
-        "profile": "Hikvision",
-        "notes": "ABUS is Hikvision OEM — select the 'Hikvision' profile (or Generic ONVIF/RTSP)."
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic ONVIF/RTSP with 'Find/inspect' to discover the stream path."
       }
     },
-    "environment": [
-      "indoor"
-    ],
+    "last_verified": "2026-07-26",
     "added": "2026-07-05"
   },
   {
@@ -194053,6 +199827,110 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c217",
+    "brand": "Tapo",
+    "model": "Tapo C217",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "98 diagonal / 83 horizontal / 47 vertical",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter with 2 m USB adapter cable"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "features": [
+      "HybridCam 360 indoor/outdoor pan/tilt",
+      "360 degree horizontal pan / 152 degree vertical tilt",
+      "full-color night vision with built-in spotlights",
+      "IR night vision",
+      "smart motion tracking",
+      "person detection",
+      "baby cry detection",
+      "customizable activity and privacy zones",
+      "sound and light alarm",
+      "two-way audio",
+      "Tapo H500 hub storage (up to 16 TB)",
+      "Alexa / Google Assistant / Samsung SmartThings",
+      "no subscription required"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "release_notes": "Indoor/outdoor 2K pan/tilt camera (HybridCam 360 line). Sensor, 4 mm F2.0 lens (both stated with +/-5% tolerance officially), full FOV triplet, IP65, and 512 GB microSD limit from the official Tapo product page specification table and the official TP-Link C217 datasheet; 30 fps, 360/152 degree pan-tilt range, and ONVIF compliance from the authorized-distributor product description. Dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c217/",
+      "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c217/",
+      "https://manuals.plus/m/b590be04aaf9c900dd1085af215325e8cefa5da5b6de0fdff19cd1f50b7fdaec",
+      "https://www.bhphotovideo.com/c/product/1922982-REG/tp_link_tapo_c217_indoor_outdoor_home.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c220",
     "brand": "Tapo",
     "model": "Tapo C220",
@@ -194439,6 +200317,115 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c245d",
+    "brand": "Tapo",
+    "model": "Tapo C245D",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K (3MP per lens)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "streams": [
+        {
+          "name": "Wide-angle lens",
+          "resolution": "2304x1296"
+        },
+        {
+          "name": "Telephoto pan/tilt lens",
+          "resolution": "2304x1296"
+        }
+      ]
+    },
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "3.1 (wide-angle) / 6.0 (telephoto pan-tilt)",
+      "aperture": "F1.6 (wide-angle)",
+      "varifocal": false
+    },
+    "field_of_view_deg": "121.8 diagonal / 104.3 horizontal / 57.9 vertical (wide-angle lens)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "dual 2K 3MP lenses (wide-angle + telephoto)",
+      "Synchronized Smart Tracking (fixed lens detects, pan/tilt lens follows)",
+      "One-Tap Smart Focus",
+      "10.8x digital zoom on telephoto lens",
+      "motorized pan/tilt on telephoto lens",
+      "wide-angle lens manually adjustable -15 to 15 degrees vertically",
+      "AI person / pet / vehicle / motion detection",
+      "baby cry detection",
+      "two-way audio",
+      "Alexa / Google Home / Samsung SmartThings",
+      "Tapo H200 / H500 hub unified storage",
+      "no subscription required for AI detection"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "release_notes": "Indoor dual-lens pan/tilt camera (2026) — the indoor counterpart of the indoor/outdoor C246D and the outdoor C545D. Sensor, both focal lengths, wide-angle aperture and full wide-angle FOV triplet, dual 2304x1296 resolution, 10.8x digital zoom, and 512 GB microSD from the official Tapo product page specification table as republished verbatim by distributors. Night vision stated officially as 40 ft (approx. 12 m), IR black-and-white. Telephoto aperture, telephoto FOV, frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source.",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c245d/",
+      "https://www.tp-link.com/en/home-networking/cloud-camera/tapo-c245d/",
+      "https://pcworx.ph/products/tapo-c245d-dual-lens-pan-tilt-security-camera"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c246d",
     "brand": "Tapo",
     "model": "Tapo C246D",
@@ -194551,6 +200538,105 @@
     ],
     "last_verified": "2026-06-30",
     "added": "2026-06-06"
+  },
+  {
+    "id": "tapo-c250",
+    "brand": "Tapo",
+    "model": "Tapo C250",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "4K 8MP",
+      "max_width": 3840,
+      "max_height": 2160,
+      "megapixels": 8.3
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.7\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F1.6",
+      "varifocal": false
+    },
+    "field_of_view_deg": "105.4 diagonal / 88 horizontal / 46 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 12
+    },
+    "power": {
+      "method": "DC power adapter"
+    },
+    "power_source": [
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K 8MP resolution",
+      "360 degree horizontal pan / 116 degree vertical tilt",
+      "AI Auto-Zoom Tracking",
+      "motion / person / pet / vehicle detection",
+      "line-crossing detection",
+      "lens tamper detection",
+      "baby cry detection",
+      "abnormal sound detection (glass breaking, meow, bark)",
+      "customizable block/privacy zones",
+      "two-way audio with noise cancellation",
+      "Alexa / Google Assistant",
+      "free AI detection (no subscription)"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "release_notes": "Indoor 4K pan/tilt AI camera. Sensor, 4 mm F1.6 lens, full FOV triplet, 4K 8MP resolution, 360/116 degree pan-tilt range, 512 GB microSD limit, and the full AI detection list from the official Tapo product page specification table (Tapo C250_V1 Datasheet), cross-checked against distributor republications of the same table. Frame rate, dimensions, weight, and operating temperature omitted: not recovered from an official source. Night vision stated officially as 40 ft (approx. 12 m).",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c250/",
+      "https://www.tp-link.com/sg/home-networking/cloud-camera/tapo-c250/",
+      "https://www.pbtech.com/pacific/product/CCTTPL8250/TP-Link-Tapo-C250-8MP4K-Indoor-PT-Wi-Fi-Camera-AI"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Must enable the Camera Account / ONVIF in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "tapo-c260",
@@ -195324,6 +201410,182 @@
     "added": "2026-06-06"
   },
   {
+    "brand": "Tapo",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.17",
+      "aperture": "F1.65",
+      "varifocal": false
+    },
+    "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "power": {
+      "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+    },
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "operating_temp_c": "-20 to 45",
+    "dimensions_mm": "60 diameter x 89",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "id": "tapo-c403",
+    "model": "Tapo C403",
+    "resolution": {
+      "label": "1080p Full HD",
+      "max_width": 1920,
+      "max_height": 1080,
+      "megapixels": 2
+    },
+    "video": {
+      "max_fps": 15,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "features": [
+      "100% wire-free battery-powered",
+      "up to 180-day battery life",
+      "full-color night vision with 2x spotlights",
+      "850 nm IR LED night vision",
+      "smart person detection",
+      "activity zones",
+      "94 dB siren",
+      "3DNR and WDR image enhancement",
+      "PIR motion sensor (110 deg, 10 sensitivity levels)",
+      "ambient light sensor",
+      "two-way audio with noise cancellation",
+      "Tapo H200 hub unified local storage support",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c403/"
+    ],
+    "release_notes": "Battery-powered indoor/outdoor camera — the 1080p sibling of the 2K C410 on an identical optical and mechanical platform (same 1/2.8\" starlight sensor, 3.17 mm F1.65 lens, 125 deg diagonal FOV, 60 x 89 mm body, IP65, 180-day battery). All specs from the official Tapo product page specification table. No RTSP/ONVIF on the battery/solar line, so no Frigate or Blue Iris config is provided. Solar-powered kit variant is the Tapo C403 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer.",
+    "added": "2026-07-26"
+  },
+  {
+    "brand": "Tapo",
+    "type": "bullet",
+    "connectivity": [
+      "wifi"
+    ],
+    "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.17",
+      "aperture": "F1.65",
+      "varifocal": false
+    },
+    "field_of_view_deg": "125 (diagonal) / 111 (horizontal) / 56 (vertical)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 9
+    },
+    "power": {
+      "method": "Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging"
+    },
+    "power_source": [
+      "battery",
+      "solar"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "operating_temp_c": "-20 to 45",
+    "dimensions_mm": "60 diameter x 89",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Battery/solar Tapo cameras do not support RTSP/ONVIF (TP-Link FAQ). Integrate via the community HomeAssistant-Tapo-Control integration (proprietary Tapo API, not ONVIF) or the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "id": "tapo-c410",
+    "model": "Tapo C410",
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 3
+    },
+    "video": {
+      "max_fps": 15,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "features": [
+      "100% wire-free battery-powered",
+      "up to 180-day battery life",
+      "full-color night vision with 2x spotlights",
+      "850 nm IR LED night vision",
+      "smart person detection",
+      "activity zones",
+      "94 dB siren",
+      "3DNR and WDR image enhancement",
+      "PIR motion sensor (110 deg, 10 sensitivity levels)",
+      "ambient light sensor",
+      "two-way audio with noise cancellation",
+      "Tapo H200 hub unified local storage support",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c410/",
+      "https://www.tapo.com/en/document/50810/",
+      "https://www.tapo.com/en/document/51028/"
+    ],
+    "release_notes": "Battery-powered outdoor camera (V2 hardware). All specs from the official Tapo product page specification table. No RTSP/ONVIF: TP-Link's battery/solar camera line exposes no local stream, so no Frigate or Blue Iris config is provided rather than a fabricated RTSP path — consistent with the C400/C402/C420/C425 entries. Solar-powered kit variant is the Tapo C410 KIT. Night vision range is stated officially as 30 ft / 9.1 m; stored as 9 m because the schema requires an integer.",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c420",
     "brand": "Tapo",
     "model": "C420",
@@ -196076,6 +202338,103 @@
     "added": "2026-06-06"
   },
   {
+    "id": "tapo-c545d",
+    "brand": "Tapo",
+    "model": "Tapo C545D",
+    "type": "ptz",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K (3MP per lens)",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "codecs": [
+        "H.264"
+      ],
+      "streams": [
+        {
+          "name": "Wide-angle lens",
+          "resolution": "2304x1296"
+        },
+        {
+          "name": "Telephoto pan/tilt lens",
+          "resolution": "2304x1296"
+        }
+      ]
+    },
+    "lens": {
+      "count": 2,
+      "varifocal": false
+    },
+    "field_of_view_deg": "121 diagonal / 95 horizontal / 57.3 vertical (wide-angle lens); 31.7 vertical (telephoto lens)",
+    "night_vision": {
+      "type": "hybrid"
+    },
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power_source": [
+      "dc"
+    ],
+    "features": [
+      "dual 2K 3MP lenses (wide-angle + telephoto)",
+      "synchronized smart detection and tracking",
+      "color night vision",
+      "motorized pan/tilt on telephoto lens",
+      "wide-angle lens manual pan 270 degrees, tilt -30 to -10 degrees",
+      "wall, ceiling or rod mounting",
+      "Alexa / Google Assistant / Samsung SmartThings",
+      "Tapo Care cloud or local microSD storage"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "release_notes": "Outdoor dual-lens pan/tilt camera — the outdoor counterpart of the indoor C245D and indoor/outdoor C246D. Dual 2K 3MP resolution, both lens FOV figures, the wide-angle manual pan/tilt ranges, motorized telephoto control, colour night vision, and 512 GB microSD from the official TP-Link C545D datasheet. Sensor, focal lengths, apertures, IR range, IP rating, power method, dimensions, and weight omitted: not present in the recovered datasheet text.",
+    "sources": [
+      "https://www.tapo.com/en/product/smart-camera/tapo-c545d/",
+      "https://manuals.plus/m/25fd9cf1ca4000dcfcba1ecd9b383147b3fd481b4ac5735e94f324b76441574d"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1, /stream2. Must enable ONVIF/Camera Account in the Tapo app."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
+  },
+  {
     "id": "tapo-c560ws",
     "brand": "Tapo",
     "model": "Tapo C560WS",
@@ -196625,6 +202984,109 @@
     "status": "available",
     "last_verified": "2026-07-01",
     "added": "2026-06-06"
+  },
+  {
+    "id": "tapo-c710",
+    "brand": "Tapo",
+    "model": "Tapo C710",
+    "type": "floodlight",
+    "connectivity": [
+      "wifi"
+    ],
+    "resolution": {
+      "label": "2K 3MP",
+      "max_width": 2304,
+      "max_height": 1296,
+      "megapixels": 2.99
+    },
+    "video": {
+      "max_fps": 30,
+      "codecs": [
+        "H.264"
+      ]
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0",
+      "aperture": "F2.0",
+      "varifocal": false
+    },
+    "field_of_view_deg": "98.1 diagonal / 82.8 horizontal / 44.5 vertical",
+    "night_vision": {
+      "type": "hybrid",
+      "range_m": 30
+    },
+    "power": {
+      "method": "Hardwired mains (mounts over a standard wall junction box; neutral + line wires)"
+    },
+    "power_source": [
+      "ac-mains"
+    ],
+    "storage": {
+      "onboard": false,
+      "max_microsd_gb": 512,
+      "nvr_compatible": false,
+      "cloud": true
+    },
+    "protocols": [
+      "rtsp",
+      "onvif"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP65",
+    "features": [
+      "1500-lumen dimmable floodlight (4000K, motion-activated, app-controlled)",
+      "pan mechanical 338 degrees (360 coverage) / tilt 97 degrees (140 coverage)",
+      "dedicated PIR sensor on floodlight (165 degrees, 25 ft) independent of camera direction",
+      "360-degree AI motion tracking",
+      "person / pet / vehicle detection",
+      "scheduled 360-degree panoramic scans and patrol mode",
+      "24/7 continuous recording (hardwired)",
+      "10.8x digital zoom",
+      "3D DNR, BLC, WDR",
+      "full-color night vision + IR",
+      "sound and light alarm (customizable)",
+      "two-way audio with noise cancellation",
+      "Alexa / Google Assistant",
+      "no subscription required"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "release_notes": "Hardwired pan/tilt floodlight camera (US launch February 2026). Complete specification from the official Tapo product page spec table: sensor, 4.0 mm F2.0 lens, full FOV triplet, IR 98 ft / 30 m plus full-color night vision, 1500 lm 4000K floodlight, mechanical pan/tilt ranges, PIR coverage, 30 fps, 10.8x digital zoom, 512 GB microSD, IP65. RTSP/ONVIF listed per the mains-powered Tapo pattern with verified:false — confirm on hardware, as floodlight models occasionally differ.",
+    "sources": [
+      "https://www.tapo.com/us/product/smart-camera/tapo-c710/",
+      "https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c710/",
+      "https://www.notebookcheck.net/Tapo-releases-new-security-camera-with-bright-floodlight.1225415.0.html"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "verified": false,
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 main, /stream2 sub. Not bench-verified on the C710 specifically."
+      },
+      "home_assistant": {
+        "integration": "tapo",
+        "notes": "Native TP-Link Tapo integration. Requires Tapo cloud account credentials."
+      },
+      "blue_iris": {
+        "profile": "Generic/ONVIF",
+        "notes": "Use Generic/ONVIF profile. RTSP streams: /stream1 (main), /stream2 (sub). Enable the Camera Account in the Tapo app first."
+      }
+    },
+    "last_verified": "2026-07-26",
+    "added": "2026-07-26"
   },
   {
     "id": "tapo-c720",

--- a/docs/cameras/abus/ipca32500.md
+++ b/docs/cameras/abus/ipca32500.md
@@ -1,0 +1,32 @@
+# ABUS IPCA32500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA32500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 3.0 to 9.0mm |
+| Night vision | ir |
+| Power | PoE |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP24 |
+| Two-way audio | Yes |
+
+## Features
+
+- Sony STARVIS sensor with Tamron 3-9 mm lens
+- True WDR
+- IR LEDs
+- 16 GB internal memory for edge recording
+- ONVIF
+
+## Sources
+
+- https://uk.rs-online.com/web/p/cctv-cameras/1774399
+
+---
+*Auto-generated from abus-ipca32500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca33500.md
+++ b/docs/cameras/abus/ipca33500.md
@@ -1,0 +1,28 @@
+# ABUS IPCA33500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA33500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+
+---
+*Auto-generated from abus-ipca33500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca52000.md
+++ b/docs/cameras/abus/ipca52000.md
@@ -1,0 +1,28 @@
+# ABUS IPCA52000
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA52000 |
+| Type | box |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | Sony Exmor CMOS (Sony Xarina DSP) |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- outdoor boxtype
+- 120 dB WDR
+- 16 GB internal memory for recording on network failure
+- Sony Xarina DSP
+
+## Sources
+
+- https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca52000.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca52010.md
+++ b/docs/cameras/abus/ipca52010.md
@@ -1,0 +1,35 @@
+# ABUS IPCA52010
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA52010 |
+| Type | box |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× |
+| Night vision | none, 0.001 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 128GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP20 |
+| Two-way audio | Yes |
+| Operating temp | 0 to 50°C |
+
+## Features
+
+- CS-mount box camera (lens sold separately, e.g. TVAC65502 2.8-10 mm)
+- 150 dB DOL WDR (3x shutter)
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- indoor (IP20), outdoor via TVAC70200 heated housing
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca52010.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca53000.md
+++ b/docs/cameras/abus/ipca53000.md
@@ -1,0 +1,29 @@
+# ABUS IPCA53000
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA53000 |
+| Type | box |
+| Connectivity | ethernet |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Lens | 1× |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- Universal boxtype with interchangeable lens (lens sold separately)
+- 120 dB True WDR
+- ABF integrated auto back focus
+- RS-485 interface (unique in the IPCA series)
+- outdoor use via optional heated housing
+
+## Sources
+
+- https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/17/20160425-IPCA53000_BDA_Hardware_DE_UK.pdf
+- https://www.sicher24.de/ueberwachungskameras/abus-universal-ip-boxtype-3-mpx-ipca53000.html
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca53000.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca62510.md
+++ b/docs/cameras/abus/ipca62510.md
@@ -1,0 +1,39 @@
+# ABUS IPCA62510
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA62510 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 3.0 to 9.0mm F1.3 - F2.2 (W-T) |
+| Field of view | 35 to 90 horizontal° |
+| Night vision | ir (30m), 0.001 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 3x optical zoom (Tamron motor zoom)
+- 150 dB DOL WDR (3x shutter)
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca62510.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca62515.md
+++ b/docs/cameras/abus/ipca62515.md
@@ -1,0 +1,39 @@
+# ABUS IPCA62515
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA62515 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 5.0 to 50.0mm F1.6 - F1.8 (W-T) |
+| Field of view | 9 to 70 horizontal° |
+| Night vision | ir (30m), 0.02 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 128GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 10x optical zoom
+- 150 dB DOL WDR (3x shutter)
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca62515.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca62520.md
+++ b/docs/cameras/abus/ipca62520.md
@@ -1,0 +1,29 @@
+# ABUS IPCA62520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA62520 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf
+
+---
+*Auto-generated from abus-ipca62520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca63500.md
+++ b/docs/cameras/abus/ipca63500.md
@@ -1,0 +1,29 @@
+# ABUS IPCA63500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA63500 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf
+
+---
+*Auto-generated from abus-ipca63500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca66500.md
+++ b/docs/cameras/abus/ipca66500.md
@@ -1,0 +1,30 @@
+# ABUS IPCA66500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA66500 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.3MP, 3072×2048) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/18/20170124-IPCA6x500_BDA_Hardware_DE_UK.pdf
+- https://www.libble.eu/abus-ipca66500/online-manual-964589/
+
+---
+*Auto-generated from abus-ipca66500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca68500.md
+++ b/docs/cameras/abus/ipca68500.md
@@ -1,0 +1,39 @@
+# ABUS IPCA68500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA68500 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 8MP (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 4.3 to 8.6mm F1.5 - F2.4 (W-T) |
+| Field of view | 48 to 95 horizontal° |
+| Night vision | ir (30m), 0.01 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 128GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 2x optical zoom
+- 120 dB WDR
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca68500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca72500.md
+++ b/docs/cameras/abus/ipca72500.md
@@ -1,0 +1,30 @@
+# ABUS IPCA72500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA72500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | Sony Exmor CMOS (Sony Xarina DSP) |
+| Lens | 1× 3.0 to 9.0mm |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- Tamron 3-9 mm motor vario zoom
+- 120 dB WDR
+- 16 GB internal memory for recording on network failure
+- Sony Xarina DSP
+- outdoor dome (TVAC31311 wall mount)
+
+## Sources
+
+- https://www.abus.com/var/ImagesPIM/d110001/medias/docus/19/20171018-IPCA22500_BDA_INT.pdf
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca72500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca72510.md
+++ b/docs/cameras/abus/ipca72510.md
@@ -1,0 +1,39 @@
+# ABUS IPCA72510
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA72510 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 3.0 to 9.0mm F1.3 - F2.2 (W-T) |
+| Field of view | 35 to 90 horizontal° |
+| Night vision | ir (20m), 0.001 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 3x optical zoom
+- 150 dB DOL WDR (3x shutter)
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca72510.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca72515.md
+++ b/docs/cameras/abus/ipca72515.md
@@ -1,0 +1,39 @@
+# ABUS IPCA72515
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA72515 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 5.0 to 50.0mm F1.6 - F1.8 (W-T) |
+| Field of view | 9 to 70 horizontal° |
+| Night vision | ir (20m), 0.02 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 10x optical zoom
+- 150 dB DOL WDR (3x shutter)
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca72515.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca72520.md
+++ b/docs/cameras/abus/ipca72520.md
@@ -1,0 +1,28 @@
+# ABUS IPCA72520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA72520 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+
+---
+*Auto-generated from abus-ipca72520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca73500.md
+++ b/docs/cameras/abus/ipca73500.md
@@ -1,0 +1,29 @@
+# ABUS IPCA73500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA73500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+- https://www.wilkon-sicherheitstechnik.de/epages/wilko1.sf/de_DE/?ObjectPath=/Shops/wilko1/Products/VICM_AS_IPCA73500
+
+---
+*Auto-generated from abus-ipca73500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca76500.md
+++ b/docs/cameras/abus/ipca76500.md
@@ -1,0 +1,29 @@
+# ABUS IPCA76500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA76500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.3MP, 3072×2048) |
+| Lens | 1× |
+| Night vision | ir |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- motor zoom with remote zoom/focus
+- WDR
+- SD-card edge recording with in-browser playback
+- master/installer user model
+
+## Sources
+
+- https://www.manualslib.de/manual/270023/Abus-Ipca33500.html
+- https://assets.abus.com/dam/132269_originalFile.pdf
+- https://www.wilkon-sicherheitstechnik.de/ABUS-Aussen-IP-Dome-IR-6MPx-IPCA76500
+
+---
+*Auto-generated from abus-ipca76500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipca78500.md
+++ b/docs/cameras/abus/ipca78500.md
@@ -1,0 +1,39 @@
+# ABUS IPCA78500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCA78500 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 8MP (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" Sony Exmor R STARVIS CMOS |
+| Lens | 1× 4.3 to 8.6mm F1.5 - F2.4 (W-T) |
+| Field of view | 48 to 95 horizontal° |
+| Night vision | ir (20m), 0.01 lux color |
+| Power | 12V DC / 24V AC / PoE (IEEE 802.3af, class 3) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -25 to 55°C |
+
+## Features
+
+- 2x optical zoom
+- 120 dB WDR
+- Ultra Low-Light
+- Tripwire, intrusion, human detection, object counting VCA
+- IK10 vandal resistance
+- full-duplex 2-way audio
+- 1 alarm input / 1 alarm output
+- microUSB service port
+- HTTPS, TLS, RTSP/TLS, JSON Web Token
+- modular housing design
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipca78500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb42510a.md
+++ b/docs/cameras/abus/ipcb42510a.md
@@ -1,0 +1,38 @@
+# ABUS IPCB42510A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB42510A |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F1.6 |
+| Field of view | 108 horizontal° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm
+- https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf
+
+---
+*Auto-generated from abus-ipcb42510a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb42510b.md
+++ b/docs/cameras/abus/ipcb42510b.md
@@ -1,0 +1,39 @@
+# ABUS IPCB42510B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB42510B |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4mm F1.6 |
+| Field of view | 87 horizontal° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/at/Objektsicherheit/Videoueberwachung/IP/Kameras/Innendome/IP-Mini-Dome-2-MPx-1080p-4-mm
+- https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm
+- https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf
+
+---
+*Auto-generated from abus-ipcb42510b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb42510c.md
+++ b/docs/cameras/abus/ipcb42510c.md
@@ -1,0 +1,39 @@
+# ABUS IPCB42510C
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB42510C |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 6mm F1.6 |
+| Field of view | 53 horizontal° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-Mini-Dome-2-MPx-1080p-6-mm
+- https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Mini-Dome-2-MPx-1080p-2.8-mm
+- https://www.solarics.de/products/abus-abus-ipcb42510b-ip-mini-dome-2-mpx-1080p-4-mm-art-ipcb42510b
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf
+
+---
+*Auto-generated from abus-ipcb42510c.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb42515a.md
+++ b/docs/cameras/abus/ipcb42515a.md
@@ -1,0 +1,44 @@
+# ABUS IPCB42515A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB42515A |
+| Type | dome |
+| Connectivity | ethernet, wifi |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F1.6 |
+| Field of view | 108 horizontal / 59 vertical° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK08 |
+| Two-way audio | No |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- WiFi 802.11 b/g/n + wired RJ45
+- built-in microphone + audio output
+- 1x alarm input / 1x alarm output
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G/T
+- flat 5 cm profile
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002238113DS00/tehnicni-podatki-2238113-abus-ipcb42515a-lan-wlan-ip-nadzorna-kamera-1920-x-1080-piksel.pdf
+- https://www.abus.com/de/Archiv/IP-Mini-Dome-WLAN-2-MPx-1080p-2.8-mm
+- https://www.zajadacz.de/ABUS-IP-Mini-Dome-WLAN-2-MPx-IPCB42515A.html
+
+---
+*Auto-generated from abus-ipcb42515a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb44510b.md
+++ b/docs/cameras/abus/ipcb44510b.md
@@ -1,0 +1,38 @@
+# ABUS IPCB44510B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB44510B |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 4mm F1.6 |
+| Field of view | 88 horizontal° |
+| Night vision | ir (10m), 0.008 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK08 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- IK08 vandal-resistant housing
+- 120 dB WDR
+- Ultra low-light performance
+- ONVIF Profile S/G
+- M12 fixed lens mount
+- Min. illumination 0.008 lux color / 0 lux IR
+- ABUS Link Station App support
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-Mini-Dome-4-MPx-4-mm
+- https://c1.abus.com/uk/Archive/Video-surveillance/Surveillance-cameras/IP-Mini-Dome-4-MPx-4-mm
+- https://www.expert-security.de/abus-ipcb44510b-ip-dome-1080p-t-n-ir-poe-ip66-ik08.html
+
+---
+*Auto-generated from abus-ipcb44510b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb62510a.md
+++ b/docs/cameras/abus/ipcb62510a.md
@@ -1,0 +1,37 @@
+# ABUS IPCB62510A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB62510A |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F1.6 |
+| Field of view | 108 horizontal° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf
+- https://www.zajadacz.de/ABUS-IP-Mini-Tube-2-MPx-IPCB62510A.html
+
+---
+*Auto-generated from abus-ipcb62510a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb62510b.md
+++ b/docs/cameras/abus/ipcb62510b.md
@@ -1,0 +1,37 @@
+# ABUS IPCB62510B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB62510B |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4mm F1.6 |
+| Field of view | 87 horizontal / 45 vertical° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf
+- https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-4-mm
+
+---
+*Auto-generated from abus-ipcb62510b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb62510c.md
+++ b/docs/cameras/abus/ipcb62510c.md
@@ -1,0 +1,37 @@
+# ABUS IPCB62510C
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB62510C |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 6mm F1.6 |
+| Field of view | 53 horizontal° |
+| Night vision | ir (10m), 0.009 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- Ultra low-light performance
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- Tripwire / intrusion detection VCA
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002240250DS00/datasheet-2240250-abus-ipcb62510b-lan-ip-bezpecnostna-kamera-1920-x-1080-pixel.pdf
+- https://www.abus.com/de/Archiv/IP-Mini-Tube-2-MPx-1080p-6-mm
+
+---
+*Auto-generated from abus-ipcb62510c.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb62515a.md
+++ b/docs/cameras/abus/ipcb62515a.md
@@ -1,0 +1,35 @@
+# ABUS IPCB62515A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB62515A |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F1.6 |
+| Field of view | 108 horizontal° |
+| Night vision | ir (50m), 0.005 lux color |
+| Power | 12V DC / PoE (IEEE 802.3af) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 120 dB WDR
+- motion detection (8 zones)
+- compatible with ABUS Secvest / wAppLoxx Pro / ModuVis
+- ABUS Link Station App
+
+## Sources
+
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190617-IPCB6x515AB_INST_DE_UK.pdf
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/23/ABUS-Link-Station-Supported-devices.pdf
+- https://endlich-sicher.de/ip-tube-kamera-abus-ipcb62515a
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb62515a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb62520.md
+++ b/docs/cameras/abus/ipcb62520.md
@@ -1,0 +1,38 @@
+# ABUS IPCB62520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB62520 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 35 to 105 horizontal° |
+| Night vision | ir (50m), 0.005 lux color |
+| Power | 12V DC / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+- https://myloesch.com/de/smart-home-elektronik/videoueberwachung/
+
+---
+*Auto-generated from abus-ipcb62520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb64515b.md
+++ b/docs/cameras/abus/ipcb64515b.md
@@ -1,0 +1,31 @@
+# ABUS IPCB64515B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB64515B |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 4.0mm F1.6 |
+| Field of view | 88 horizontal° |
+| Night vision | ir (50m), 0.008 lux color |
+| Power | 12V DC / PoE |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- IR LEDs
+- ABUS Link Station App
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+- https://www.manualslib.com/manual/2443358/Abus-Ipcb64515b.html
+
+---
+*Auto-generated from abus-ipcb64515b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb64520.md
+++ b/docs/cameras/abus/ipcb64520.md
@@ -1,0 +1,37 @@
+# ABUS IPCB64520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB64520 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 32 to 114 horizontal° |
+| Night vision | ir (50m), 0.008 lux color |
+| Power | 12V DC / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb64520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb68510a.md
+++ b/docs/cameras/abus/ipcb68510a.md
@@ -1,0 +1,36 @@
+# ABUS IPCB68510A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB68510A |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 8MP (4K) (8MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F2.0 |
+| Field of view | 102 horizontal° |
+| Night vision | ir (10m) |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm
+- https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb68510a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb68510b.md
+++ b/docs/cameras/abus/ipcb68510b.md
@@ -1,0 +1,37 @@
+# ABUS IPCB68510B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB68510B |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 8MP (4K) (8MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 4mm F2.0 |
+| Field of view | 79 horizontal° |
+| Night vision | ir (10m) |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-2.8-mm
+- https://www.zajadacz.de/ABUS-IP-Mini-Tube-8-MPx-4K-IPCB68510A.html
+- https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb68510b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb68510c.md
+++ b/docs/cameras/abus/ipcb68510c.md
@@ -1,0 +1,36 @@
+# ABUS IPCB68510C
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB68510C |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 8MP (4K) (8MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 6mm F2.0 |
+| Field of view | 50 horizontal° |
+| Night vision | ir (10m) |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-Mini-Tube-8-MPx-4K-6-mm
+- https://www.solarics.de/products/abus-abus-ipcb68510a-ip-mini-tube-8-mpx-4k-2-8-mm-art-ipcb68510a
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb68510c.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb68520.md
+++ b/docs/cameras/abus/ipcb68520.md
@@ -1,0 +1,37 @@
+# ABUS IPCB68520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB68520 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 8MP (8.3MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 35 to 115 horizontal° |
+| Night vision | ir (50m), 0.01 lux color |
+| Power | 12V DC / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb68520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb72515a.md
+++ b/docs/cameras/abus/ipcb72515a.md
@@ -1,0 +1,36 @@
+# ABUS IPCB72515A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB72515A |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm |
+| Field of view | 108 horizontal° |
+| Night vision | ir, 0.005 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| IK rating | IK10 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- IK10 vandal-resistant full dome
+- 120 dB WDR
+- motion detection (8 zones)
+- compatible with ABUS Secvest / wAppLoxx Pro / ModuVis
+- ABUS Link Station App
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+- https://endlich-sicher.de/abus-ip-dome-kamera-ipcb72515a
+- https://manuals.plus/m/41e9eecc72014f49518f19ef80f4599ffbfe1827ef54d434bc1c5bf5ee7006d4
+
+---
+*Auto-generated from abus-ipcb72515a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb72520.md
+++ b/docs/cameras/abus/ipcb72520.md
@@ -1,0 +1,38 @@
+# ABUS IPCB72520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB72520 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 35 to 105 horizontal° |
+| Night vision | ir (30m), 0.005 lux color |
+| Power | 12V DC / PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+- ONVIF Profile S + G
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb72520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb74515b.md
+++ b/docs/cameras/abus/ipcb74515b.md
@@ -1,0 +1,38 @@
+# ABUS IPCB74515B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB74515B |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 4mm F1.6 |
+| Field of view | 88 horizontal / 46 vertical° |
+| Night vision | ir (30m) |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| IK rating | IK10 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- IK10 vandal-resistant full dome
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/ch_de/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-4-MPx-4-mm
+- https://www.expert-security.de/abus-ipcb74515b-ip-dome-4mpx-t-n-ir-poe-ip67.html
+- https://endlich-sicher.de/abus-ip-dome-kamera-ipcb74515b/jl56564
+
+---
+*Auto-generated from abus-ipcb74515b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb74520.md
+++ b/docs/cameras/abus/ipcb74520.md
@@ -1,0 +1,38 @@
+# ABUS IPCB74520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB74520 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 32 to 114 horizontal° |
+| Night vision | ir (30m), 0.008 lux color |
+| Power | 12V DC / PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+- ONVIF Profile S + G
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb74520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb74615b.md
+++ b/docs/cameras/abus/ipcb74615b.md
@@ -1,0 +1,29 @@
+# ABUS IPCB74615B
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB74615B |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP) |
+| Lens | 1× 2.8 to 12mm |
+| Night vision | ir |
+| Power | 12V DC / PoE |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- 2.8-12 mm motor zoom
+- 3-axis gimbal (pan/tilt/rotation)
+- IR LEDs
+- ABUS Link Station App
+
+## Sources
+
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb74615b.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb78515a.md
+++ b/docs/cameras/abus/ipcb78515a.md
@@ -1,0 +1,39 @@
+# ABUS IPCB78515A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB78515A |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 8MP (4K) (8MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F2.0 |
+| Field of view | 102 horizontal° |
+| Night vision | ir (30m) |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| IK rating | IK10 |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- IK10 vandal-resistant full dome
+- 120 dB WDR
+- 3D-DNR
+- motion detection (8 zones)
+- ONVIF Profile S/G
+- compatible with ABUS Secvest / wAppLoxx
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/ger/Archiv/Videoueberwachung/Ueberwachungskameras/IP-Dome-8-MPx-4K-2.8-mm
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002246401DS00/datablad-2246401-abus-ipcb78515a-lan-ip-overvagningskamera-3840-x-2160-pix.pdf
+- https://www.elektroshopwagner.de/product_info.php/info/p266293_ABUS-IPCB78515A-IP-Dome-8-MPx--4K--2-8-mm-.html
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb78515a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb78520.md
+++ b/docs/cameras/abus/ipcb78520.md
@@ -1,0 +1,38 @@
+# ABUS IPCB78520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB78520 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 8MP (8.3MP, 3840×2160) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm F1.4 |
+| Field of view | 35 to 115 horizontal° |
+| Night vision | ir (30m), 0.01 lux color |
+| Power | 12V DC / PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 60°C |
+
+## Features
+
+- 2.8-12 mm motor zoom (4.2x optical)
+- Ultra Low Light
+- 120 dB WDR
+- IK10 vandal resistance
+- Tripwire / intrusion detection VCA
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+- ONVIF Profile S + G
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb78520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcb78615a.md
+++ b/docs/cameras/abus/ipcb78615a.md
@@ -1,0 +1,29 @@
+# ABUS IPCB78615A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCB78615A |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 8MP (8.3MP, 3840×2160) |
+| Lens | 1× 2.8 to 12mm |
+| Night vision | ir |
+| Power | 12V DC / PoE |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+
+## Features
+
+- 2.8-12 mm motor zoom
+- 3-axis gimbal (pan/tilt/rotation)
+- IR LEDs
+- ABUS Link Station App
+
+## Sources
+
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/22/20190619-IPCB7x615AB_INST_DE_GB.pdf
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcb78615a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs29511.md
+++ b/docs/cameras/abus/ipcs29511.md
@@ -1,0 +1,41 @@
+# ABUS IPCS29511
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS29511 |
+| Type | fisheye |
+| Connectivity | ethernet |
+| Resolution | 12MP (12MP, 4000×3000) |
+| Field of view | 360 horizontal° |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- hemispheric 360/180 degree panorama views
+- in-camera dewarping (hardware + up to 14 software view modes)
+- ePTZ with up to 255 presets and 32 tours
+- replaces up to 4 cameras (up to 4 video channels)
+- DWDR
+- people counting
+- heat map
+- intersection analysis
+- Tripwire / intrusion / region entry-exit / unattended baggage / object removal VCA
+- audio exception detection
+- 1x alarm input / 1x alarm output
+- audio in/out (2-way audio)
+- 8 privacy zones
+- NAS recording
+- ABUS Link Station App
+
+## Sources
+
+- https://c1.abus.com/asc-pim-assets-01/medias/docus/28/20230425-IPCS29511_BDA_INT.pdf
+- https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html
+
+---
+*Auto-generated from abus-ipcs29511.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs62120.md
+++ b/docs/cameras/abus/ipcs62120.md
@@ -1,0 +1,36 @@
+# ABUS IPCS62120
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS62120 |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8 to 12mm |
+| Field of view | 32 to 92 horizontal° |
+| Night vision | ir (50m), 0.003 lux color |
+| Power | 12V DC / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Two-way audio | Yes |
+
+## Features
+
+- ANPR license plate recognition (Europe, up to 70 km/h, 2048-plate allow/deny list)
+- 1080p @ 50/60 fps
+- 2.8-12 mm motor zoom (4.2x)
+- 120 dB WDR
+- EIS electronic image stabilization, distortion correction
+- 2-way audio (browser/CMS)
+- 1 alarm input / 1 alarm output
+- analog video output
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcs62120.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs64511a.md
+++ b/docs/cameras/abus/ipcs64511a.md
@@ -1,0 +1,39 @@
+# ABUS IPCS64511A
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS64511A |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1520) |
+| Sensor | 1/1.8" Progressive Scan CMOS |
+| Lens | 1× 2.8mm F1.0 |
+| Field of view | 108 horizontal° |
+| Night vision | color, 0.0005 lux color |
+| Power | PoE (IEEE 802.3af) or 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP67 |
+| Operating temp | -25 to 60°C |
+| Released | 2023 |
+
+## Features
+
+- WDR 120 dB
+- full-color night vision
+- white light LEDs
+- person/vehicle detection
+- motion detection (up to 8 zones)
+- minimum illumination 0.0005 lux (color)
+- compatible with ABUS Secvest / Secoris / wAppLoxx Pro
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Tube-4-MPx-2.8-mm-WL
+- https://c4.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/Tube/IP-Tube-4-MPx-2.8-mm-WL
+- https://www.zajadacz.de/ABUS-IP-Tube-4-MPx-2-8-mm-IPCS64511A.html
+
+---
+*Auto-generated from abus-ipcs64511a.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs82500.md
+++ b/docs/cameras/abus/ipcs82500.md
@@ -1,0 +1,39 @@
+# ABUS IPCS82500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS82500 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4.7 to 94mm |
+| Field of view | 3.2 to 58.3 horizontal° |
+| Night vision | ir (150m), 0.05 lux color |
+| Power | 24V AC / High-PoE (IEEE 802.3bt) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 65°C |
+
+## Features
+
+- 20x optical zoom
+- 16x digital zoom
+- 360 degree pan / -15 to 90 tilt
+- EIS electronic image stabilization
+- Defog
+- WDR, BLC, HLC
+- 2 alarm inputs / 1 alarm output
+- RS485
+- analog video output
+- 2-way audio (browser/CMS)
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcs82500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs82520.md
+++ b/docs/cameras/abus/ipcs82520.md
@@ -1,0 +1,40 @@
+# ABUS IPCS82520
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS82520 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/1.9" Progressive Scan CMOS |
+| Lens | 1× 5.9 to 135.7mm |
+| Field of view | 3.0 to 59.8 horizontal° |
+| Night vision | ir (200m), 0.02 lux color |
+| Power | 24V AC / High-PoE (IEEE 802.3bt) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 23x optical zoom
+- 16x digital zoom
+- Ultra Low-Light (large 1/1.9 inch sensor)
+- 120 dB True WDR
+- EIS electronic image stabilization
+- ROI, Defog
+- 7 alarm inputs / 2 alarm outputs
+- RS485
+- analog video output
+- IK10 vandal resistance
+- 2-way audio (browser/CMS)
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcs82520.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs82530.md
+++ b/docs/cameras/abus/ipcs82530.md
@@ -1,0 +1,40 @@
+# ABUS IPCS82530
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS82530 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 2MP (2MP, 1920×1080) |
+| Sensor | 1/1.9" Progressive Scan CMOS |
+| Lens | 1× 5.7 to 205mm |
+| Field of view | 2.0 to 59.0 horizontal° |
+| Night vision | ir (200m), 0.02 lux color |
+| Power | 24V AC / High-PoE (IEEE 802.3bt) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 36x optical zoom
+- 16x digital zoom
+- Ultra Low-Light (large 1/1.9 inch sensor)
+- 120 dB True WDR
+- EIS electronic image stabilization
+- ROI, Defog
+- 7 alarm inputs / 2 alarm outputs
+- RS485
+- analog video output
+- IK10 vandal resistance
+- 2-way audio (browser/CMS)
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcs82530.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs83500.md
+++ b/docs/cameras/abus/ipcs83500.md
@@ -1,0 +1,38 @@
+# ABUS IPCS83500
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS83500 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 4.5 to 162mm |
+| Field of view | 3.7 to 61.0 horizontal° |
+| Night vision | ir (200m), 0.05 lux color |
+| Power | 24V AC / High-PoE (IEEE 802.3bt) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -40 to 60°C |
+
+## Features
+
+- 36x optical zoom
+- 16x digital zoom
+- 120 dB WDR
+- ROI, Defog
+- 7 alarm inputs / 2 alarm outputs
+- RS485
+- analog video output
+- IK10 vandal resistance
+- 2-way audio (browser/CMS)
+
+## Sources
+
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
+
+---
+*Auto-generated from abus-ipcs83500.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs84510.md
+++ b/docs/cameras/abus/ipcs84510.md
@@ -1,0 +1,45 @@
+# ABUS IPCS84510
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS84510 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2560×1440) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 2.8 - 12.0mm F1.6 - F2.7 |
+| Field of view | 31.6 to 96.7 horizontal° |
+| Night vision | ir (20m), 0.005 lux color |
+| Power | PoE (IEEE 802.3af) / 12V DC |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 60°C |
+
+## Features
+
+- PTZ 355 pan / 0-90 tilt (100°/s)
+- 4x optical zoom
+- 16x digital zoom
+- 120dB WDR
+- electronic image stabilization (EIS)
+- 3D-DNR
+- IK10 vandal resistance
+- 300 presets
+- Tripwire / intrusion detection VCA
+- Motion detection
+- 2 relay outputs
+- Pelco D / Pelco P
+- ABUS Link Station App
+
+## Sources
+
+- https://asset.conrad.com/media10/add/160267/c1/-/de/002237147DS00/datablad-2237147-abus-ipcs84510-ip-bewakingscamera-lan-2560-x-1440-pix.pdf
+- https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/Ceiling-Mount-for-IPCS84510
+- https://www.manualslib.com/manual/2285047/Abus-Ipcs84510.html
+
+---
+*Auto-generated from abus-ipcs84510.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs84530.md
+++ b/docs/cameras/abus/ipcs84530.md
@@ -1,0 +1,39 @@
+# ABUS IPCS84530
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS84530 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2560×1440) |
+| Sensor | 1/2.5" Progressive Scan CMOS |
+| Lens | 1× 4.8 to 120mm F1.6 - F3.5 |
+| Field of view | 2.5 to 57.6 horizontal° |
+| Night vision | ir (50m) |
+| Power | 12V DC / PoE+ (IEEE 802.3at, 30W) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- 25x optical autofocus motor zoom (4.8-120 mm)
+- 360 degree pan
+- 300 presets / 8 tours (automated guard tours)
+- Ultra Low Light
+- WDR
+- 2-way audio
+- 1080p @ 50 fps mode
+- compact form factor for flush ceiling mount
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-25x
+- https://partner-ch.abus.com/de/silver.econtent/catalog/Produkte/Elektronische-Sicherheit/Professional-Sortiment/Videoueberwachung/Netzwerk/Kameras/SPECIAL/IP-PTZ-4-MPx-25x
+- https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf
+
+---
+*Auto-generated from abus-ipcs84530.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs84531.md
+++ b/docs/cameras/abus/ipcs84531.md
@@ -1,0 +1,37 @@
+# ABUS IPCS84531
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS84531 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2560×1440) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4.8 to 120mm |
+| Field of view | 2.5 to 53 horizontal° |
+| Night vision | ir (50m) |
+| Power | 12V DC / PoE+ (IEEE 802.3at, 30W) |
+| Storage | microSD ≤ 256GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+
+## Features
+
+- 25x optical autofocus motor zoom
+- 16x digital zoom
+- 360 degree pan
+- 300 presets / automated guard tours
+- Ultra Low Light
+- WDR
+- compact form factor for flush ceiling mount (TVAC31275/31375)
+- ABUS Link Station App
+
+## Sources
+
+- https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/29/220504-IPCS84511_84531_TVIP82561_BDA_INT.pdf
+- https://c1.abus.com/ch_de/Objektsicherheit/Videoueberwachung/IP/Kameras/PTZ/IP-PTZ-4-MPx-25x
+- https://www.alarm-technik.eu/IP-PTZ-IR-Dome-4-MPx-25x-ABUS-IPCS84531
+
+---
+*Auto-generated from abus-ipcs84531.json — do not edit by hand.*

--- a/docs/cameras/abus/ipcs84550.md
+++ b/docs/cameras/abus/ipcs84550.md
@@ -1,0 +1,40 @@
+# ABUS IPCS84550
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | IPCS84550 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2560×1440) |
+| Sensor | 1/2.8" Progressive Scan CMOS |
+| Lens | 1× 4.8 to 153mm F1.2 - F4.4 |
+| Field of view | 2.0 to 54.3 horizontal° |
+| Night vision | ir (150m) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+
+## Features
+
+- 32x optical zoom
+- 16x digital zoom
+- 120 dB WDR
+- Ultra Low Light
+- Smart Tracking
+- Tripwire / intrusion detection VCA
+- 300 presets / 8 tours
+- 2 alarm inputs / 1 alarm output
+- 1080p @ 50 fps mode
+- ABUS Link Station App
+
+## Sources
+
+- https://www.abus.com/de/Archiv/IP-PTZ-4-MPx-32x
+- https://c1.abus.com/var/ImagesPIM/d110001/medias/docus/23/20200218-IPCS84530_IPCS84550-BDA-INT.pdf
+- https://www.abus-alarmanlagen.ch/video/netzwerkkameras/abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66/
+- https://www.aesag.ch/en/network-cameras/2778-abus-ip-ptz-dome-4-mpx-32x-t-n-ir-poe-ip66-ipcs84550.html
+
+---
+*Auto-generated from abus-ipcs84550.json — do not edit by hand.*

--- a/docs/cameras/abus/ppic42520b.md
+++ b/docs/cameras/abus/ppic42520b.md
@@ -1,0 +1,39 @@
+# ABUS PPIC42520B
+
+*Also known as: ABUS Wireless Pan/Tilt Outdoor Camera (black)*
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | PPIC42520B |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | Full HD (1080p) (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.1mm F2.0 |
+| Field of view | 355 pan / 90 tilt° |
+| Night vision | ir (20m) |
+| Power | DC 5V |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- ABUS App2Cam Plus outdoor pan/tilt
+- 355deg pan / 90deg tilt
+- 3MP 2K
+- person/animal/vehicle detection
+- two-way audio
+- GDPR-compliant local storage
+- IP66
+- German brand
+
+## Sources
+
+- https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wireless-Pan-Tilt-Outdoor-Camera
+- https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-WiFi-Pan-Tilt-Outdoor-Camera
+
+---
+*Auto-generated from abus-ppic42520b.json — do not edit by hand.*

--- a/docs/cameras/abus/ppic46520w.md
+++ b/docs/cameras/abus/ppic46520w.md
@@ -1,0 +1,40 @@
+# ABUS PPIC46520W
+
+*Also known as: ABUS Wi-Fi Light Outdoor Camera (white)*
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | PPIC46520W |
+| Type | floodlight |
+| Connectivity | wifi |
+| Resolution | 2K (2MP) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4mm F2.0 |
+| Field of view | 110 horizontal° |
+| Night vision | hybrid (8m) |
+| Power | AC 90-260V |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- replaces outdoor light fitting (like Netatmo Presence)
+- 1000-lumen LED outdoor light
+- person/animal/vehicle/car AI detection
+- PIR sensor
+- two-way audio
+- App2Cam Plus
+- GDPR-compliant local microSD
+- no mandatory subscription
+- German brand
+
+## Sources
+
+- https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/ABUS-Wi-Fi-Light-Outdoor-Camera2
+- https://security.abus.com/Videoueberwachung/ABUS-WLAN-Licht-Aussen-Kamera.html
+
+---
+*Auto-generated from abus-ppic46520w.json — do not edit by hand.*

--- a/docs/cameras/abus/ppic52520b.md
+++ b/docs/cameras/abus/ppic52520b.md
@@ -1,0 +1,43 @@
+# ABUS PPIC52520B
+
+*Also known as: ABUS SmartLook Pan & Tilt (black)*
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | PPIC52520B |
+| Type | ptz |
+| Connectivity | wifi, ethernet |
+| Resolution | 2 MP (4K-interpolated recording) (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4mm F2.0 |
+| Field of view | 85 horizontal / 45 vertical° |
+| Night vision | ir (20m) |
+| Power | DC 5V |
+| Storage | microSD ≤ 256GB |
+| IP rating | IP66 |
+| Two-way audio | Yes |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- 4K-interpolated recording (native 2 MP sensor)
+- outdoor pan/tilt (270° pan / 80° tilt)
+- person/animal/vehicle detection
+- two-way audio
+- siren
+- privacy zones
+- 5s pre-recording
+- local microSD (256GB, no cloud)
+- App2Cam Plus
+- WiFi 2.4/5 GHz
+- German brand
+
+## Sources
+
+- https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook-pan-tilt2
+- https://security.abus.com/Videoueberwachung/SmartLook-Schwenken-Neigen.html
+- https://www.abus.com/de/abusproductsheet.pdf/PPIC52520/ger-DE
+
+---
+*Auto-generated from abus-ppic52520b.json — do not edit by hand.*

--- a/docs/cameras/abus/ppic54520b.md
+++ b/docs/cameras/abus/ppic54520b.md
@@ -1,0 +1,39 @@
+# ABUS PPIC54520B
+
+*Also known as: ABUS SmartLook (black)*
+
+| Field | Spec |
+|-------|------|
+| Brand | ABUS |
+| Model | PPIC54520B |
+| Type | box |
+| Connectivity | wifi, ethernet |
+| Resolution | 2 MP (4K-interpolated recording) (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4mm F2.0 |
+| Field of view | 85 horizontal / 45 vertical° |
+| Night vision | ir (10m) |
+| Power | DC 5V |
+| Storage | microSD ≤ 128GB |
+| IP rating | IP66 |
+| Two-way audio | No |
+| Operating temp | -10 to 50°C |
+
+## Features
+
+- 4K-interpolated recording (native 2 MP sensor)
+- App2Cam Plus
+- person/animal/vehicle detection
+- 5s pre-recording
+- privacy masking
+- dual-band WiFi (2.4/5 GHz)
+- local microSD (no cloud)
+- German brand
+
+## Sources
+
+- https://www.abus.com/int/Consumer/Video-surveillance/DIY-systems/Cameras/SmartLook2
+- https://security.abus.com/Videoueberwachung/SmartLook-abus.html
+
+---
+*Auto-generated from abus-ppic54520b.json — do not edit by hand.*

--- a/docs/cameras/abus/tvip83900.md
+++ b/docs/cameras/abus/tvip83900.md
@@ -6,27 +6,29 @@
 | Model | TVIP83900 |
 | Type | fisheye |
 | Connectivity | ethernet |
-| Resolution | 3MP (3MP, 2048×1536) |
-| Sensor | 1/3" progressive CMOS |
-| Lens | 1× 1.27mm F2.8 |
-| Field of view | 360° |
-| Night vision | ir (5m) |
-| Power | PoE (802.3at) / 12V DC |
+| Resolution | 3MP (3.1MP, 2048×1536) |
+| Sensor | 1/3" Progressive Scan CMOS |
+| Lens | 1× 1.27mm |
+| Field of view | 180/360° |
+| Night vision | ir (15m), 0.28 lux color |
+| Power | 12V DC / PoE (IEEE 802.3af) |
 | Storage | microSD ≤ 128GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP24 |
 | Two-way audio | Yes |
+| Operating temp | 10 to 50°C |
 
 ## Features
 
-- 360-degree indoor hemispheric fisheye
-- ePTZ dewarping
-- two-way audio
-- indoor (IP24)
+- hemispheric 360/180 degree panorama views
+- ePTZ (360/80 degrees) with configurable tours
+- WDR, 3D DNR, BLC
+- 1 alarm input / 1 alarm output
+- audio in/out
 
 ## Sources
 
-- https://www.abus.com/int/Commercial-Security/Video-surveillance/Network-technology/IP-Fisheye-3-MPx
+- https://www.tinnes24.de/pdf/ABUS-Katalog-19-Video-IP-Sortiment.pdf
 
 ---
 *Auto-generated from abus-tvip83900.json — do not edit by hand.*

--- a/docs/cameras/tapo/c217.md
+++ b/docs/cameras/tapo/c217.md
@@ -1,0 +1,44 @@
+# Tapo Tapo C217
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C217 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K 3MP (2.99MP, 2304×1296) |
+| Sensor | 1/2.8" Progressive Scan CMOS Starlight Sensor |
+| Lens | 1× 4.0mm F2.0 |
+| Field of view | 98 diagonal / 83 horizontal / 47 vertical° |
+| Night vision | hybrid (12m) |
+| Power | DC power adapter with 2 m USB adapter cable |
+| Storage | microSD ≤ 512GB |
+| Protocols | rtsp, onvif |
+| IP rating | IP65 |
+| Two-way audio | Yes |
+
+## Features
+
+- HybridCam 360 indoor/outdoor pan/tilt
+- 360 degree horizontal pan / 152 degree vertical tilt
+- full-color night vision with built-in spotlights
+- IR night vision
+- smart motion tracking
+- person detection
+- baby cry detection
+- customizable activity and privacy zones
+- sound and light alarm
+- two-way audio
+- Tapo H500 hub storage (up to 16 TB)
+- Alexa / Google Assistant / Samsung SmartThings
+- no subscription required
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c217/
+- https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c217/
+- https://manuals.plus/m/b590be04aaf9c900dd1085af215325e8cefa5da5b6de0fdff19cd1f50b7fdaec
+- https://www.bhphotovideo.com/c/product/1922982-REG/tp_link_tapo_c217_indoor_outdoor_home.html
+
+---
+*Auto-generated from tapo-c217.json — do not edit by hand.*

--- a/docs/cameras/tapo/c245d.md
+++ b/docs/cameras/tapo/c245d.md
@@ -1,0 +1,41 @@
+# Tapo Tapo C245D
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C245D |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (3MP per lens) (2.99MP, 2304×1296) |
+| Sensor | 1/2.8" Progressive Scan CMOS Starlight Sensor |
+| Lens | 2× 3.1 (wide-angle) / 6.0 (telephoto pan-tilt)mm F1.6 (wide-angle) |
+| Field of view | 121.8 diagonal / 104.3 horizontal / 57.9 vertical (wide-angle lens)° |
+| Night vision | ir (12m) |
+| Power | DC power adapter |
+| Storage | microSD ≤ 512GB |
+| Protocols | rtsp, onvif |
+| Two-way audio | Yes |
+
+## Features
+
+- dual 2K 3MP lenses (wide-angle + telephoto)
+- Synchronized Smart Tracking (fixed lens detects, pan/tilt lens follows)
+- One-Tap Smart Focus
+- 10.8x digital zoom on telephoto lens
+- motorized pan/tilt on telephoto lens
+- wide-angle lens manually adjustable -15 to 15 degrees vertically
+- AI person / pet / vehicle / motion detection
+- baby cry detection
+- two-way audio
+- Alexa / Google Home / Samsung SmartThings
+- Tapo H200 / H500 hub unified storage
+- no subscription required for AI detection
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c245d/
+- https://www.tp-link.com/en/home-networking/cloud-camera/tapo-c245d/
+- https://pcworx.ph/products/tapo-c245d-dual-lens-pan-tilt-security-camera
+
+---
+*Auto-generated from tapo-c245d.json — do not edit by hand.*

--- a/docs/cameras/tapo/c250.md
+++ b/docs/cameras/tapo/c250.md
@@ -1,0 +1,41 @@
+# Tapo Tapo C250
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C250 |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 4K 8MP (8.3MP, 3840×2160) |
+| Sensor | 1/2.7" CMOS |
+| Lens | 1× 4.0mm F1.6 |
+| Field of view | 105.4 diagonal / 88 horizontal / 46 vertical° |
+| Night vision | ir (12m) |
+| Power | DC power adapter |
+| Storage | microSD ≤ 512GB |
+| Protocols | rtsp, onvif |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K 8MP resolution
+- 360 degree horizontal pan / 116 degree vertical tilt
+- AI Auto-Zoom Tracking
+- motion / person / pet / vehicle detection
+- line-crossing detection
+- lens tamper detection
+- baby cry detection
+- abnormal sound detection (glass breaking, meow, bark)
+- customizable block/privacy zones
+- two-way audio with noise cancellation
+- Alexa / Google Assistant
+- free AI detection (no subscription)
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c250/
+- https://www.tp-link.com/sg/home-networking/cloud-camera/tapo-c250/
+- https://www.pbtech.com/pacific/product/CCTTPL8250/TP-Link-Tapo-C250-8MP4K-Indoor-PT-Wi-Fi-Camera-AI
+
+---
+*Auto-generated from tapo-c250.json — do not edit by hand.*

--- a/docs/cameras/tapo/c403.md
+++ b/docs/cameras/tapo/c403.md
@@ -1,0 +1,42 @@
+# Tapo Tapo C403
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C403 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 1080p Full HD (2MP, 1920×1080) |
+| Sensor | 1/2.8" Progressive Scan CMOS Starlight Sensor |
+| Lens | 1× 3.17mm F1.65 |
+| Field of view | 125 (diagonal) / 111 (horizontal) / 56 (vertical)° |
+| Night vision | ir (9m) |
+| Power | Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging |
+| Storage | microSD ≤ 512GB |
+| IP rating | IP65 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 45°C |
+
+## Features
+
+- 100% wire-free battery-powered
+- up to 180-day battery life
+- full-color night vision with 2x spotlights
+- 850 nm IR LED night vision
+- smart person detection
+- activity zones
+- 94 dB siren
+- 3DNR and WDR image enhancement
+- PIR motion sensor (110 deg, 10 sensitivity levels)
+- ambient light sensor
+- two-way audio with noise cancellation
+- Tapo H200 hub unified local storage support
+- Alexa / Google Assistant
+- no subscription required
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c403/
+
+---
+*Auto-generated from tapo-c403.json — do not edit by hand.*

--- a/docs/cameras/tapo/c410.md
+++ b/docs/cameras/tapo/c410.md
@@ -1,0 +1,44 @@
+# Tapo Tapo C410
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C410 |
+| Type | bullet |
+| Connectivity | wifi |
+| Resolution | 2K 3MP (3MP, 2304×1296) |
+| Sensor | 1/2.8" Progressive Scan CMOS Starlight Sensor |
+| Lens | 1× 3.17mm F1.65 |
+| Field of view | 125 (diagonal) / 111 (horizontal) / 56 (vertical)° |
+| Night vision | ir (9m) |
+| Power | Built-in rechargeable lithium-ion battery; optional Tapo A201 solar panel (sold separately); 5V/1A USB adapter for charging |
+| Storage | microSD ≤ 512GB |
+| IP rating | IP65 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 45°C |
+
+## Features
+
+- 100% wire-free battery-powered
+- up to 180-day battery life
+- full-color night vision with 2x spotlights
+- 850 nm IR LED night vision
+- smart person detection
+- activity zones
+- 94 dB siren
+- 3DNR and WDR image enhancement
+- PIR motion sensor (110 deg, 10 sensitivity levels)
+- ambient light sensor
+- two-way audio with noise cancellation
+- Tapo H200 hub unified local storage support
+- Alexa / Google Assistant
+- no subscription required
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c410/
+- https://www.tapo.com/en/document/50810/
+- https://www.tapo.com/en/document/51028/
+
+---
+*Auto-generated from tapo-c410.json — do not edit by hand.*

--- a/docs/cameras/tapo/c545d.md
+++ b/docs/cameras/tapo/c545d.md
@@ -1,0 +1,34 @@
+# Tapo Tapo C545D
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C545D |
+| Type | ptz |
+| Connectivity | wifi |
+| Resolution | 2K (3MP per lens) (2.99MP, 2304×1296) |
+| Lens | 2× |
+| Field of view | 121 diagonal / 95 horizontal / 57.3 vertical (wide-angle lens); 31.7 vertical (telephoto lens)° |
+| Night vision | hybrid |
+| Storage | microSD ≤ 512GB |
+| Protocols | rtsp, onvif |
+| Two-way audio | Yes |
+
+## Features
+
+- dual 2K 3MP lenses (wide-angle + telephoto)
+- synchronized smart detection and tracking
+- color night vision
+- motorized pan/tilt on telephoto lens
+- wide-angle lens manual pan 270 degrees, tilt -30 to -10 degrees
+- wall, ceiling or rod mounting
+- Alexa / Google Assistant / Samsung SmartThings
+- Tapo Care cloud or local microSD storage
+
+## Sources
+
+- https://www.tapo.com/en/product/smart-camera/tapo-c545d/
+- https://manuals.plus/m/25fd9cf1ca4000dcfcba1ecd9b383147b3fd481b4ac5735e94f324b76441574d
+
+---
+*Auto-generated from tapo-c545d.json — do not edit by hand.*

--- a/docs/cameras/tapo/c710.md
+++ b/docs/cameras/tapo/c710.md
@@ -1,0 +1,44 @@
+# Tapo Tapo C710
+
+| Field | Spec |
+|-------|------|
+| Brand | Tapo |
+| Model | Tapo C710 |
+| Type | floodlight |
+| Connectivity | wifi |
+| Resolution | 2K 3MP (2.99MP, 2304×1296) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0mm F2.0 |
+| Field of view | 98.1 diagonal / 82.8 horizontal / 44.5 vertical° |
+| Night vision | hybrid (30m) |
+| Power | Hardwired mains (mounts over a standard wall junction box; neutral + line wires) |
+| Storage | microSD ≤ 512GB |
+| Protocols | rtsp, onvif |
+| IP rating | IP65 |
+| Two-way audio | Yes |
+
+## Features
+
+- 1500-lumen dimmable floodlight (4000K, motion-activated, app-controlled)
+- pan mechanical 338 degrees (360 coverage) / tilt 97 degrees (140 coverage)
+- dedicated PIR sensor on floodlight (165 degrees, 25 ft) independent of camera direction
+- 360-degree AI motion tracking
+- person / pet / vehicle detection
+- scheduled 360-degree panoramic scans and patrol mode
+- 24/7 continuous recording (hardwired)
+- 10.8x digital zoom
+- 3D DNR, BLC, WDR
+- full-color night vision + IR
+- sound and light alarm (customizable)
+- two-way audio with noise cancellation
+- Alexa / Google Assistant
+- no subscription required
+
+## Sources
+
+- https://www.tapo.com/us/product/smart-camera/tapo-c710/
+- https://www.tp-link.com/us/home-networking/cloud-camera/tapo-c710/
+- https://www.notebookcheck.net/Tapo-releases-new-security-camera-with-bright-floodlight.1225415.0.html
+
+---
+*Auto-generated from tapo-c710.json — do not edit by hand.*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Adds **64 cameras** — 57 ABUS across the professional IP range (IPCA ×18, IPCB bullets ×24, IPCS domes/turrets ×11, PPIC pan/floodlight ×4) and 7 Tapo (`C217`, `C245D`, `C250`, `C403`, `C410`, `C545D`, `C710`). Net **2,330 → 2,394**.

Also corrects `abus-tvip83900` (SPECIAL-line 3 MPx fisheye): resolution 3→3.1 MP, IR range 5→15 m, sensor naming, marked **discontinued**, and removes an incorrect "Hikvision-OEM" claim — integration guidance now Generic ONVIF (Profile S) per the official ABUS catalog.

### Validation
- AJV schema: ✅ (build 2,330 → 2,394)
- ids match filenames, brands correct, required fields present, no duplicates
- resolution physics (MP vs W×H): 0 warnings
- types/enums valid; 61/65 have integration configs

### Note on sources
Several added ABUS models are **discontinued / EOL** with no live abus.com pages. Where no official manufacturer source was available, specs were taken from the official **ABUS Video IP catalog** and reputable retailer/distributor listings, flagged for a future re-source if official archived datasheets surface.

_README stats (repo tree, badges, brand table) auto-regenerated by `build.js`; ABUS now enters the top-6 tree at #5._