### PR TITLE
Flag 12 PTZ/dual-lens cameras with ptz.autotracking (Part-1 gap, #124)

### DIFF
--- a/cameras/abus/ipcs84550.json
+++ b/cameras/abus/ipcs84550.json
@@ -3,6 +3,9 @@
   "brand": "ABUS",
   "model": "IPCS84550",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/abus/ipcs84551.json
+++ b/cameras/abus/ipcs84551.json
@@ -3,6 +3,9 @@
   "brand": "ABUS",
   "model": "IPCS84551",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
+++ b/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
@@ -3,6 +3,9 @@
   "brand": "Dahua",
   "model": "SDT8C842-8P-FA-APV-0280",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/hi-focus/hc-ipc-sd0440t-al.json
+++ b/cameras/hi-focus/hc-ipc-sd0440t-al.json
@@ -3,6 +3,9 @@
   "brand": "Hi-Focus",
   "model": "HC-IPC-SD0440T-AL",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/imou/a1-pro-4k.json
+++ b/cameras/imou/a1-pro-4k.json
@@ -3,6 +3,9 @@
   "brand": "IMOU",
   "model": "A1 Pro 4K",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi",
     "ethernet"

--- a/cameras/imou/aov-dual.json
+++ b/cameras/imou/aov-dual.json
@@ -3,6 +3,9 @@
   "brand": "IMOU",
   "model": "AOV Dual",
   "type": "dual-lens",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi",
     "4g"

--- a/cameras/imou/cruiser-dual-2c-4g.json
+++ b/cameras/imou/cruiser-dual-2c-4g.json
@@ -6,6 +6,9 @@
     "IPC-S7XCP-6M1TED"
   ],
   "type": "dual-lens",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "4g",
     "wifi",

--- a/cameras/imou/dk7-5mp.json
+++ b/cameras/imou/dk7-5mp.json
@@ -7,6 +7,9 @@
     "IPC-DK7P-3H1WE (3MP)"
   ],
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi"
   ],

--- a/cameras/imou/ps70f-10mp.json
+++ b/cameras/imou/ps70f-10mp.json
@@ -6,6 +6,9 @@
     "IPC-PS70FP-10M0"
   ],
   "type": "dual-lens",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/imou/ps7f-5mp.json
+++ b/cameras/imou/ps7f-5mp.json
@@ -7,6 +7,9 @@
     "IPC-PS7FN-5M0"
   ],
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "ethernet"
   ],

--- a/cameras/imou/ranger-s2.json
+++ b/cameras/imou/ranger-s2.json
@@ -7,6 +7,9 @@
     "IMOU Ranger S2 3MP"
   ],
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi"
   ],

--- a/cameras/tapo/c245d.json
+++ b/cameras/tapo/c245d.json
@@ -3,6 +3,9 @@
   "brand": "Tapo",
   "model": "Tapo C245D",
   "type": "ptz",
+  "ptz": {
+    "autotracking": true
+  },
   "connectivity": [
     "wifi"
   ],

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -12088,6 +12088,9 @@
     "brand": "ABUS",
     "model": "IPCS84550",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -12208,6 +12211,9 @@
     "brand": "ABUS",
     "model": "IPCS84551",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -92878,6 +92884,9 @@
     "brand": "Dahua",
     "model": "SDT8C842-8P-FA-APV-0280",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -113598,6 +113607,9 @@
     "brand": "Hi-Focus",
     "model": "HC-IPC-SD0440T-AL",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -156984,6 +156996,9 @@
     "brand": "IMOU",
     "model": "A1 Pro 4K",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi",
       "ethernet"
@@ -157070,6 +157085,9 @@
     "brand": "IMOU",
     "model": "AOV Dual",
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi",
       "4g"
@@ -159522,6 +159540,9 @@
       "IPC-S7XCP-6M1TED"
     ],
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "4g",
       "wifi",
@@ -160271,6 +160292,9 @@
       "IPC-DK7P-3H1WE (3MP)"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -160802,6 +160826,9 @@
       "IPC-PS70FP-10M0"
     ],
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -160895,6 +160922,9 @@
       "IPC-PS7FN-5M0"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -161526,6 +161556,9 @@
       "IMOU Ranger S2 3MP"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -200321,6 +200354,9 @@
     "brand": "Tapo",
     "model": "Tapo C245D",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -12088,6 +12088,9 @@
     "brand": "ABUS",
     "model": "IPCS84550",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -12208,6 +12211,9 @@
     "brand": "ABUS",
     "model": "IPCS84551",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -92878,6 +92884,9 @@
     "brand": "Dahua",
     "model": "SDT8C842-8P-FA-APV-0280",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -113598,6 +113607,9 @@
     "brand": "Hi-Focus",
     "model": "HC-IPC-SD0440T-AL",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -156984,6 +156996,9 @@
     "brand": "IMOU",
     "model": "A1 Pro 4K",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi",
       "ethernet"
@@ -157070,6 +157085,9 @@
     "brand": "IMOU",
     "model": "AOV Dual",
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi",
       "4g"
@@ -159522,6 +159540,9 @@
       "IPC-S7XCP-6M1TED"
     ],
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "4g",
       "wifi",
@@ -160271,6 +160292,9 @@
       "IPC-DK7P-3H1WE (3MP)"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -160802,6 +160826,9 @@
       "IPC-PS70FP-10M0"
     ],
     "type": "dual-lens",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -160895,6 +160922,9 @@
       "IPC-PS7FN-5M0"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -161526,6 +161556,9 @@
       "IMOU Ranger S2 3MP"
     ],
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],
@@ -200321,6 +200354,9 @@
     "brand": "Tapo",
     "model": "Tapo C245D",
     "type": "ptz",
+    "ptz": {
+      "autotracking": true
+    },
     "connectivity": [
       "wifi"
     ],


### PR DESCRIPTION
Part 1 of #124 (schema + camera-side migration) was marked complete, but **PTZ/dual-lens cameras added since the original migration were never flagged** — the free-text-vs-`ptz.autotracking` drift had grown to 12 cameras (some from my own recent PRs #141/#149).

Adds `ptz.autotracking: true` to these 12 mechanical PTZ/PT cameras (all typed `ptz`/`dual-lens` with onboard smart-tracking/auto-follow specs):

- Imou: `a1-pro-4k`, `aov-dual`, `cruiser-dual-2c-4g`, `dk7-5mp`, `ps70f-10mp`, `ps7f-5mp`, `ranger-s2`
- `dahua-sdt8c842-8p-fa-apv-0280` (X-Spans), `tapo-c245d`, `abus-ipcs84550`, `abus-ipcs84551`, `hifocus-hc-ipc-sd0440t-al`

After this, **0** PTZ/dual-lens cameras with an autotracking tag remain unflagged (198 total `ptz.autotracking:true`). Fixed-type digital/e-PTZ cameras remain correctly excluded (consistent with #126).

Does **not** touch Part 2 (`onvif_ptz` / `configs.frigate.autotracking`), which stays open as a community-sourced effort.