### PR TITLE
CI lint: moving cameras with auto-tracking must set ptz.autotracking (#124)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,7 @@ cameras/hikvision/ds-2cd2387g2-lu.json   →   id: "hikvision-ds-2cd2387g2-lu"
 - **Don't guess specs.** If you're unsure, leave the field out — a partial entry is better than a wrong one
 - **One file per variant.** Regional editions (different firmware, power supply, certifications) should be separate entries with a market suffix in the ID
 - **No marketing copy in `features`.** Keep features factual and terse: `"no subscription"` not `"experience true security freedom with zero monthly fees"`
+- **Auto-tracking → set `ptz.autotracking`.** If a `ptz` / `dual-lens` / `panoramic` camera does onboard auto-tracking (it physically moves to follow a subject), set `"ptz": { "autotracking": true }` — the build **fails** if such a camera mentions auto-tracking only in `features`. If the tracking is *digital*/e-PTZ (software crop, no motor), don't set the flag; describe it as digital in `features` instead.
 
 ---
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -128,6 +128,27 @@ function validate(cameras) {
       ok = false;
     }
     seen.add(cam.id);
+
+    // Drift guard for #124: a camera that mechanically moves (type ptz /
+    // dual-lens / panoramic) and advertises onboard auto-tracking in its
+    // free-text features must also set the structured `ptz.autotracking` flag,
+    // or downstream (site filters, Frigate compat) sees an inconsistent record.
+    // Fixed types (dome/bullet/fisheye/box) are intentionally excluded — their
+    // "tracking" is digital/e-PTZ, which is not ptz.autotracking (see #126).
+    const MOVING = new Set(["ptz", "dual-lens", "panoramic"]);
+    const AUTOTRACK_TAG = /auto[- ]?track|smart track|subject track/i;
+    if (
+      MOVING.has(cam.type) &&
+      (cam.features || []).some((f) => AUTOTRACK_TAG.test(f)) &&
+      !cam.ptz?.autotracking
+    ) {
+      console.error(
+        `✗ ${cam.id}: type "${cam.type}" advertises auto-tracking in features but ` +
+        `does not set ptz.autotracking:true (add it, or reword the feature if the ` +
+        `tracking is digital/e-PTZ rather than onboard mechanical — see #124/#126).`
+      );
+      ok = false;
+    }
   }
   if (!ok) {
     console.error("\nValidation failed. See errors above.");


### PR DESCRIPTION
Prevents the Part-1 drift fixed in #150 from recurring.

`scripts/build.js` (the existing CI gate) now **fails the build** if a camera typed `ptz` / `dual-lens` / `panoramic` advertises auto-tracking in `features[]` (matches `auto-track` / `smart track` / `subject track`) but omits `ptz.autotracking: true`.

Fixed types (`dome`/`bullet`/`fisheye`/`box`) are **excluded** — their 'tracking' is digital/e-PTZ, which correctly is *not* `ptz.autotracking` (per #126).

Tested: passes on current data; removing the flag from a `ptz` camera makes the build fail with a clear, actionable message. Documented the rule in CONTRIBUTING.md.