### PR TITLE
Populate onvif_ptz + frigate.autotracking (Part 2, #124)

### DIFF
--- a/cameras/amcrest/ip2m-841b.json
+++ b/cameras/amcrest/ip2m-841b.json
@@ -65,7 +65,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "amcrest",

--- a/cameras/amcrest/ip8m-2899ew-ai.json
+++ b/cameras/amcrest/ip8m-2899ew-ai.json
@@ -3,8 +3,16 @@
   "brand": "Amcrest",
   "model": "IP8M-2899EW-AI",
   "type": "ptz",
-  "connectivity": ["ethernet"],
-  "power_source": ["poe", "dc"],
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
   "resolution": {
     "megapixels": 8,
     "max_width": 3840,
@@ -12,7 +20,10 @@
     "label": "4K"
   },
   "video": {
-    "codecs": ["H.265", "H.264"],
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
     "max_fps": 25
   },
   "sensor": "1/2.8\" CMOS",
@@ -36,12 +47,26 @@
     "nvr_compatible": true
   },
   "ip_rating": "IP66",
-  "protocols": ["onvif", "rtsp", "http"],
-  "features": ["25x optical zoom", "human detection", "vehicle detection", "face detection", "perimeter protection"],
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
+  "features": [
+    "25x optical zoom",
+    "human detection",
+    "vehicle detection",
+    "face detection",
+    "perimeter protection"
+  ],
   "operating_temp_c": "-40 to 70",
   "dimensions_mm": "160 x 160 x 259",
-  "environment": ["outdoor"],
-  "markets": ["global"],
+  "environment": [
+    "outdoor"
+  ],
+  "markets": [
+    "global"
+  ],
   "sources": [
     "https://support.amcrest.com/hc/en-us/articles/4505722116621-Technical-Specifications-IP8M-2899EW-AI",
     "https://amcrest.com/4k-8-megapixel-ip-poe-camera-ptz-25x-optical-zoom-ai-ip8m-2899ew-ai-v2.html"
@@ -53,7 +78,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "notes": "Amcrest (Dahua OEM) RTSP. Enable RTSP in the Amcrest web UI; use the sub-stream (subtype=1) for Frigate detect. PTZ via ONVIF.",
-      "verified": false
+      "verified": false,
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/dh-sd49425xb-hnr.json
+++ b/cameras/dahua/dh-sd49425xb-hnr.json
@@ -29,7 +29,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE (802.3at) / AC 24V"
@@ -74,7 +75,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/dh-sd6al245xa-hnr.json
+++ b/cameras/dahua/dh-sd6al245xa-hnr.json
@@ -27,7 +27,8 @@
     "range_m": 550
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE++ (802.3bt) / AC 24V"
@@ -75,7 +76,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
+++ b/cameras/dahua/dh-sdt7425-4p-ad3e-pv-i.json
@@ -29,7 +29,8 @@
     "min_lux_color": 0.001
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "DC 36V/2.23A (±25%)",
@@ -74,7 +75,8 @@
         "height": 360,
         "fps": 5
       },
-      "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE."
+      "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49225xa-hnr-mena.json
+++ b/cameras/dahua/sd49225xa-hnr-mena.json
@@ -35,7 +35,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE (802.3at) / AC 24V"
@@ -82,7 +83,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49425db-hny.json
+++ b/cameras/dahua/sd49425db-hny.json
@@ -29,7 +29,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "12VDC/PoE+",
@@ -73,7 +74,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49825gb-hnr.json
+++ b/cameras/dahua/sd49825gb-hnr.json
@@ -17,7 +17,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE (802.3at)"
@@ -69,7 +70,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4d225mb-hnr.json
+++ b/cameras/dahua/sd4d225mb-hnr.json
@@ -29,7 +29,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "12VDC/PoE+",
@@ -73,7 +74,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4d425mb-hnr.json
+++ b/cameras/dahua/sd4d425mb-hnr.json
@@ -29,7 +29,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "12VDC/PoE+",
@@ -73,7 +74,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4d825mb-hnr.json
+++ b/cameras/dahua/sd4d825mb-hnr.json
@@ -29,7 +29,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "12VDC/PoE+",
@@ -74,7 +75,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a432gb-hnr.json
+++ b/cameras/dahua/sd5a432gb-hnr.json
@@ -26,7 +26,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V / AC 24V"
@@ -73,7 +74,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
@@ -41,7 +41,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "24VAC / PoE+ (802.3at)",
@@ -103,7 +104,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-      "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs."
+      "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs.",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
@@ -21,7 +21,8 @@
     "type": "hybrid"
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / 12 VDC 3 A"
@@ -72,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sdt4e425-8p-gb-apv1.json
+++ b/cameras/dahua/sdt4e425-8p-gb-apv1.json
@@ -21,7 +21,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "Hi-PoE (802.3bt) / 24 VAC"
@@ -71,7 +72,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
+++ b/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
@@ -4,7 +4,8 @@
   "model": "SDT8C842-8P-FA-APV-0280",
   "type": "ptz",
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "connectivity": [
     "ethernet"
@@ -91,7 +92,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a404iwg-e-w.json
+++ b/cameras/hikvision/ds-2de3a404iwg-e-w.json
@@ -3,6 +3,9 @@
   "brand": "Hikvision",
   "model": "DS-2DE3A404IWG-E/W",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
   "connectivity": [
     "wifi",
     "ethernet"
@@ -69,7 +72,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a404iwg-e.json
+++ b/cameras/hikvision/ds-2de3a404iwg-e.json
@@ -3,6 +3,9 @@
   "brand": "Hikvision",
   "model": "DS-2DE3A404IWG-E",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
   "connectivity": [
     "ethernet"
   ],
@@ -67,7 +70,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/reolink/altas-go-pt.json
+++ b/cameras/reolink/altas-go-pt.json
@@ -24,7 +24,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery (20000mAh) / solar panel"

--- a/cameras/reolink/altas-pt-ultra.json
+++ b/cameras/reolink/altas-pt-ultra.json
@@ -18,7 +18,8 @@
     "type": "color"
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"

--- a/cameras/reolink/argus-pt-2k.json
+++ b/cameras/reolink/argus-pt-2k.json
@@ -3,6 +3,9 @@
   "brand": "Reolink",
   "model": "Argus PT 2K",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "absolute"
+  },
   "connectivity": [
     "wifi"
   ],

--- a/cameras/reolink/argus-pt-ultra.json
+++ b/cameras/reolink/argus-pt-ultra.json
@@ -29,7 +29,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery / solar optional"

--- a/cameras/reolink/argus-pt.json
+++ b/cameras/reolink/argus-pt.json
@@ -3,6 +3,9 @@
   "brand": "Reolink",
   "model": "Argus PT",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "absolute"
+  },
   "connectivity": [
     "wifi"
   ],

--- a/cameras/reolink/argus-track.json
+++ b/cameras/reolink/argus-track.json
@@ -28,7 +28,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Built-in rechargeable battery / solar panel optional"

--- a/cameras/reolink/e1-indoor.json
+++ b/cameras/reolink/e1-indoor.json
@@ -19,7 +19,8 @@
     "range_m": 12
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "DC 5V USB"

--- a/cameras/reolink/go-pt-plus.json
+++ b/cameras/reolink/go-pt-plus.json
@@ -19,7 +19,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "6000mAh rechargeable battery / solar optional / USB-C"

--- a/cameras/reolink/go-pt-s-lite.json
+++ b/cameras/reolink/go-pt-s-lite.json
@@ -24,7 +24,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery / solar panel"

--- a/cameras/reolink/go-pt-ultra.json
+++ b/cameras/reolink/go-pt-ultra.json
@@ -19,7 +19,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "21.6Wh rechargeable battery / solar optional / USB-C"

--- a/cameras/reolink/go-pt.json
+++ b/cameras/reolink/go-pt.json
@@ -3,6 +3,9 @@
   "brand": "Reolink",
   "model": "Go PT",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "absolute"
+  },
   "connectivity": [
     "4g"
   ],

--- a/cameras/reolink/go-ranger-pt.json
+++ b/cameras/reolink/go-ranger-pt.json
@@ -23,7 +23,8 @@
     "range_m": 10
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery / solar panel"

--- a/cameras/reolink/keen-ranger-pt.json
+++ b/cameras/reolink/keen-ranger-pt.json
@@ -3,6 +3,9 @@
   "brand": "Reolink",
   "model": "Keen Ranger PT",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "absolute"
+  },
   "connectivity": [
     "4g"
   ],

--- a/cameras/reolink/omvi-3i-poe.json
+++ b/cameras/reolink/omvi-3i-poe.json
@@ -26,7 +26,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "PoE (802.3at/PoE+, 48V, active) / DC 12V, 2A backup, <24W",
@@ -80,7 +81,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "reolink",

--- a/cameras/reolink/omvi-3i-wifi.json
+++ b/cameras/reolink/omvi-3i-wifi.json
@@ -28,7 +28,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "DC 12V, 2A, <24W (plug-in only, no battery)",
@@ -77,7 +78,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "reolink",

--- a/cameras/reolink/omvi-x16-poe.json
+++ b/cameras/reolink/omvi-x16-poe.json
@@ -26,7 +26,8 @@
     "range_m": 75
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "PoE / DC 12V (exact PoE standard/class not yet published by Reolink)"
@@ -69,7 +70,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "reolink",

--- a/cameras/reolink/rlc-823a.json
+++ b/cameras/reolink/rlc-823a.json
@@ -38,7 +38,8 @@
     "range_m": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "PoE (IEEE 802.3at) / DC 12V",

--- a/cameras/reolink/rlc-830a.json
+++ b/cameras/reolink/rlc-830a.json
@@ -25,7 +25,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/reolink/trackmix-lte-c.json
+++ b/cameras/reolink/trackmix-lte-c.json
@@ -24,7 +24,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery (5100mAh) / solar panel"

--- a/cameras/reolink/trackmix-lte-plus.json
+++ b/cameras/reolink/trackmix-lte-plus.json
@@ -25,7 +25,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"

--- a/cameras/reolink/trackmix-lte.json
+++ b/cameras/reolink/trackmix-lte.json
@@ -19,7 +19,8 @@
     "range_m": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "absolute"
   },
   "power": {
     "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -38546,7 +38546,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "amcrest",
@@ -39395,6 +39396,9 @@
     "brand": "Amcrest",
     "model": "IP8M-2899EW-AI",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -39467,7 +39471,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "notes": "Amcrest (Dahua OEM) RTSP. Enable RTSP in the Amcrest web UI; use the sub-stream (subtype=1) for Frigate detect. PTZ via ONVIF.",
-        "verified": false
+        "verified": false,
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76222,7 +76227,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
@@ -76267,7 +76273,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76314,7 +76321,8 @@
       "range_m": 550
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE++ (802.3bt) / AC 24V"
@@ -76362,7 +76370,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76411,7 +76420,8 @@
       "min_lux_color": 0.001
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "DC 36V/2.23A (±25%)",
@@ -76456,7 +76466,8 @@
           "height": 360,
           "fps": 5
         },
-        "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE."
+        "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -91976,7 +91987,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
@@ -92023,7 +92035,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92068,7 +92081,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92112,7 +92126,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92147,7 +92162,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at)"
@@ -92199,7 +92215,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92247,7 +92264,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92291,7 +92309,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92338,7 +92357,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92382,7 +92402,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92429,7 +92450,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92474,7 +92496,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92518,7 +92541,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V"
@@ -92565,7 +92589,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92625,7 +92650,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "24VAC / PoE+ (802.3at)",
@@ -92687,7 +92713,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92723,7 +92750,8 @@
       "type": "hybrid"
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 12 VDC 3 A"
@@ -92774,7 +92802,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92813,7 +92842,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
@@ -92863,7 +92893,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92885,7 +92916,8 @@
     "model": "SDT8C842-8P-FA-APV-0280",
     "type": "ptz",
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "connectivity": [
       "ethernet"
@@ -92972,7 +93004,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150180,6 +150213,9 @@
     "brand": "Hikvision",
     "model": "DS-2DE3A404IWG-E",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -150244,7 +150280,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150283,6 +150320,9 @@
     "brand": "Hikvision",
     "model": "DS-2DE3A404IWG-E/W",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "wifi",
       "ethernet"
@@ -150349,7 +150389,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -178774,7 +178815,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery (20000mAh) / solar panel"
@@ -178850,7 +178892,8 @@
       "type": "color"
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"
@@ -180045,6 +180088,9 @@
     "brand": "Reolink",
     "model": "Argus PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "wifi"
     ],
@@ -180125,6 +180171,9 @@
     "brand": "Reolink",
     "model": "Argus PT 2K",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "wifi"
     ],
@@ -180229,7 +180278,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar optional"
@@ -180401,7 +180451,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Built-in rechargeable battery / solar panel optional"
@@ -182767,7 +182818,8 @@
       "range_m": 12
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "DC 5V USB"
@@ -184208,6 +184260,9 @@
     "brand": "Reolink",
     "model": "Go PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "4g"
     ],
@@ -184306,7 +184361,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "6000mAh rechargeable battery / solar optional / USB-C"
@@ -184401,7 +184457,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar panel"
@@ -184477,7 +184534,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "21.6Wh rechargeable battery / solar optional / USB-C"
@@ -184567,7 +184625,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar panel"
@@ -184702,6 +184761,9 @@
     "brand": "Reolink",
     "model": "Keen Ranger PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "4g"
     ],
@@ -185019,7 +185081,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (802.3at/PoE+, 48V, active) / DC 12V, 2A backup, <24W",
@@ -185073,7 +185136,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -185144,7 +185208,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "DC 12V, 2A, <24W (plug-in only, no battery)",
@@ -185193,7 +185258,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -185261,7 +185327,8 @@
       "range_m": 75
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE / DC 12V (exact PoE standard/class not yet published by Reolink)"
@@ -185304,7 +185371,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -189109,7 +189177,8 @@
       "range_m": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
@@ -189787,7 +189856,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -190829,7 +190899,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"
@@ -190922,7 +190993,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery (5100mAh) / solar panel"
@@ -191004,7 +191076,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -38546,7 +38546,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "amcrest",
@@ -39395,6 +39396,9 @@
     "brand": "Amcrest",
     "model": "IP8M-2899EW-AI",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -39467,7 +39471,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "notes": "Amcrest (Dahua OEM) RTSP. Enable RTSP in the Amcrest web UI; use the sub-stream (subtype=1) for Frigate detect. PTZ via ONVIF.",
-        "verified": false
+        "verified": false,
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76222,7 +76227,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
@@ -76267,7 +76273,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76314,7 +76321,8 @@
       "range_m": 550
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE++ (802.3bt) / AC 24V"
@@ -76362,7 +76370,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -76411,7 +76420,8 @@
       "min_lux_color": 0.001
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "DC 36V/2.23A (±25%)",
@@ -76456,7 +76466,8 @@
           "height": 360,
           "fps": 5
         },
-        "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE."
+        "notes": "Dual-channel — configure as TWO Frigate cameras: panoramic = channel=1 (3840x1080, 32:9 — set detect to 1280x360 to match), PTZ = channel=2 (2560x1440, rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=2&subtype=0, detect 1280x720). For ONVIF autotracking on the PTZ channel add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. ONVIF PTZ confirmed working — Channel 2 profiles have both VideoEncoderConfiguration and PTZConfiguration (no split-profile issue, unlike SDT4E series). Verified in frigate#22135. Note: powered by DC 36V, not PoE.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -91976,7 +91987,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at) / AC 24V"
@@ -92023,7 +92035,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92068,7 +92081,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92112,7 +92126,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92147,7 +92162,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE (802.3at)"
@@ -92199,7 +92215,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92247,7 +92264,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92291,7 +92309,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92338,7 +92357,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92382,7 +92402,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92429,7 +92450,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92474,7 +92496,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92518,7 +92541,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V"
@@ -92565,7 +92589,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'. Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92625,7 +92650,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "24VAC / PoE+ (802.3at)",
@@ -92687,7 +92713,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
-        "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs."
+        "notes": "ONVIF PTZ control supported (port 80). Standard Dahua realmonitor URLs.",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92723,7 +92750,8 @@
       "type": "hybrid"
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 12 VDC 3 A"
@@ -92774,7 +92802,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92813,7 +92842,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "Hi-PoE (802.3bt) / 24 VAC"
@@ -92863,7 +92893,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -92885,7 +92916,8 @@
     "model": "SDT8C842-8P-FA-APV-0280",
     "type": "ptz",
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "connectivity": [
       "ethernet"
@@ -92972,7 +93004,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150180,6 +150213,9 @@
     "brand": "Hikvision",
     "model": "DS-2DE3A404IWG-E",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -150244,7 +150280,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150283,6 +150320,9 @@
     "brand": "Hikvision",
     "model": "DS-2DE3A404IWG-E/W",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "wifi",
       "ethernet"
@@ -150349,7 +150389,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -178774,7 +178815,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery (20000mAh) / solar panel"
@@ -178850,7 +178892,8 @@
       "type": "color"
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Built-in 20000 mAh (72Wh) rechargeable battery / USB-C / optional Reolink Solar Panel 2 (6W) for continuous recording"
@@ -180045,6 +180088,9 @@
     "brand": "Reolink",
     "model": "Argus PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "wifi"
     ],
@@ -180125,6 +180171,9 @@
     "brand": "Reolink",
     "model": "Argus PT 2K",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "wifi"
     ],
@@ -180229,7 +180278,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar optional"
@@ -180401,7 +180451,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Built-in rechargeable battery / solar panel optional"
@@ -182767,7 +182818,8 @@
       "range_m": 12
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "DC 5V USB"
@@ -184208,6 +184260,9 @@
     "brand": "Reolink",
     "model": "Go PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "4g"
     ],
@@ -184306,7 +184361,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "6000mAh rechargeable battery / solar optional / USB-C"
@@ -184401,7 +184457,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar panel"
@@ -184477,7 +184534,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "21.6Wh rechargeable battery / solar optional / USB-C"
@@ -184567,7 +184625,8 @@
       "range_m": 10
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery / solar panel"
@@ -184702,6 +184761,9 @@
     "brand": "Reolink",
     "model": "Keen Ranger PT",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "absolute"
+    },
     "connectivity": [
       "4g"
     ],
@@ -185019,7 +185081,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (802.3at/PoE+, 48V, active) / DC 12V, 2A backup, <24W",
@@ -185073,7 +185136,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -185144,7 +185208,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "DC 12V, 2A, <24W (plug-in only, no battery)",
@@ -185193,7 +185258,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -185261,7 +185327,8 @@
       "range_m": 75
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE / DC 12V (exact PoE standard/class not yet published by Reolink)"
@@ -185304,7 +185371,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_main",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/h264Preview_01_sub",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "reolink",
@@ -189109,7 +189177,8 @@
       "range_m": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (IEEE 802.3at) / DC 12V",
@@ -189787,7 +189856,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -190829,7 +190899,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery 7.2V 5100mAh (36.72Wh) / Reolink Solar Panel 2 optional"
@@ -190922,7 +190993,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery (5100mAh) / solar panel"
@@ -191004,7 +191076,8 @@
       "range_m": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "absolute"
     },
     "power": {
       "method": "Rechargeable battery 10.8V 14400mAh (155.52Wh) / 66W solar panel (included)"


### PR DESCRIPTION
Part 2 of #124 — the ONVIF-move / Frigate-compat data, sourced from Frigate's **official** [autotracking](https://docs.frigate.video/configuration/autotracking/) and [ONVIF camera recommendations](https://docs.frigate.video/configuration/cameras/#onvif-ptz-camera-recommendations) docs.

**Re-verified requirement (unchanged):** Frigate autotracking needs ONVIF **FOV RelativeMove** (`RelativePanTiltTranslationSpace` → `TranslationSpaceFov`) **plus** a working `MoveStatus`.

Stamped **39 cameras** (conservative — high-confidence only):

| Set | onvif_ptz | frigate.autotracking | Basis |
|---|---|---|---|
| Reolink PT ×21 | `absolute` | `false` | Brand-level ❌ in Frigate's table (PTZ works, autotracking doesn't) |
| Dahua SD/SDT speed domes ×14 | `relative` | `true` | Dahua mid/high-end generally ✅; incl. **exact table match** `SD49825GB-HNR` |
| Hikvision `DS-2DE3A404IWG-E`/`-E-W` ×2 | `relative` | `true` | **Exact ✅** — the documented exception to Hikvision's brand-level `MoveStatus` failure |
| Amcrest `IP8M-2899EW-AI` | `relative` | `true` | Amcrest brand ✅ (newer model) |
| Amcrest `IP2M-841B` | — | `false` | **Exact ❌** (older model, no FOV relative) |

**Left undefined** (for a future pass): Hikvision general (brand ❌ MoveStatus bug, minus the exception above), Tapo & Foscam (brand ❌), fixed A180 multi-sensor panoramics (not motorized PTZ), and all undocumented models.

Coverage after this: `onvif_ptz` 56 (39 absolute + 17 relative), `frigate.autotracking` 41 (24 false + 17 true). No schema change (field added in Part 1); no camera-count change.