### PR TITLE
frigate.autotracking=false for Hikvision/Tapo/Foscam PTZ (Part 2 cont., #124)

### DIFF
--- a/cameras/foscam/foscam-d4z.json
+++ b/cameras/foscam/foscam-d4z.json
@@ -60,8 +60,9 @@
   "status": "available",
   "configs": {
     "frigate": {
-      "notes": "Sourced from retailer pages rather than us.foscam.com/D4Z.html directly \u2014 resolution pixel dimensions, IP rating, and RTSP path not confirmed. Verify before publishing.",
-      "verified": false
+      "notes": "Sourced from retailer pages rather than us.foscam.com/D4Z.html directly — resolution pixel dimensions, IP rating, and RTSP path not confirmed. Verify before publishing.",
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-pd5.json
+++ b/cameras/foscam/foscam-pd5.json
@@ -72,7 +72,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
       "notes": "Not yet verified against a physical unit.",
-      "verified": false
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-pd8.json
+++ b/cameras/foscam/foscam-pd8.json
@@ -78,12 +78,13 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
-      "notes": "ONVIF is not listed in the official protocol table (only IP/TCP/UDP/SMTP/FTP/DHCP/RTSP) \u2014 do not assume ONVIF works on this model without testing. RTSP path not yet verified against a physical unit.",
-      "verified": false
+      "notes": "ONVIF is not listed in the official protocol table (only IP/TCP/UDP/SMTP/FTP/DHCP/RTSP) — do not assume ONVIF works on this model without testing. RTSP path not yet verified against a physical unit.",
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "ONVIF support not confirmed for this model (see frigate notes) \u2014 verify before relying on the generic ONVIF integration.",
+      "notes": "ONVIF support not confirmed for this model (see frigate notes) — verify before relying on the generic ONVIF integration.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/foscam/foscam-r8m.json
+++ b/cameras/foscam/foscam-r8m.json
@@ -71,7 +71,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
       "notes": "Not yet verified against a physical unit. Full native resolution/sensor numbers were not found in the official spec table snippet reviewed — confirm against us.foscam.com/R8M.html Tech Specs Table before publishing.",
-      "verified": false
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-sd4.json
+++ b/cameras/foscam/foscam-sd4.json
@@ -56,8 +56,9 @@
   "status": "available",
   "configs": {
     "frigate": {
-      "notes": "Thin data \u2014 sourced from retailer listings only, not the official us.foscam.com/SD4.html spec table. Resolution pixel dimensions, FOV, and pan/tilt angles not confirmed. RTSP path not researched.",
-      "verified": false
+      "notes": "Thin data — sourced from retailer listings only, not the official us.foscam.com/SD4.html spec table. Resolution pixel dimensions, FOV, and pan/tilt angles not confirmed. RTSP path not researched.",
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-sd4h.json
+++ b/cameras/foscam/foscam-sd4h.json
@@ -72,7 +72,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
       "notes": "Not yet verified against a physical unit.",
-      "verified": false
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-sd8ep.json
+++ b/cameras/foscam/foscam-sd8ep.json
@@ -85,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
       "notes": "videoMain/videoSub is Foscam's current-gen RTSP path convention; not yet verified against a physical unit. Confirm before setting verified: true. Older Foscam models used port 88 instead of 554.",
-      "verified": false
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/foscam/foscam-sd8p.json
+++ b/cameras/foscam/foscam-sd8p.json
@@ -81,7 +81,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
       "notes": "Sourced spec table lists 'Network: Ethernet, One 10/100Mbps RJ45 port' which looks like a copy-paste artifact from a PoE-model template reused by the retailer — SD8P is marketed as a WiFi camera. Cross-check against us.foscam.com/SD8P.html before publishing. RTSP path not yet verified.",
-      "verified": false
+      "verified": false,
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de2a204iw-de3-w.json
+++ b/cameras/hikvision/ds-2de2a204iw-de3-w.json
@@ -72,7 +72,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de2a404iw-de3-ws6.json
+++ b/cameras/hikvision/ds-2de2a404iw-de3-ws6.json
@@ -69,7 +69,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de2a404iw-de3s6.json
+++ b/cameras/hikvision/ds-2de2a404iw-de3s6.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de2c400iwg.json
+++ b/cameras/hikvision/ds-2de2c400iwg.json
@@ -63,7 +63,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3404w-det5.json
+++ b/cameras/hikvision/ds-2de3404w-det5.json
@@ -65,7 +65,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a400bw-de-wt5.json
+++ b/cameras/hikvision/ds-2de3a400bw-de-wt5.json
@@ -64,7 +64,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a400bw-de.json
+++ b/cameras/hikvision/ds-2de3a400bw-de.json
@@ -74,7 +74,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a400bw-det5.json
+++ b/cameras/hikvision/ds-2de3a400bw-det5.json
@@ -64,7 +64,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de3a400bwg-e.json
+++ b/cameras/hikvision/ds-2de3a400bwg-e.json
@@ -74,7 +74,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4215iw-det5.json
+++ b/cameras/hikvision/ds-2de4215iw-det5.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4225iw-det5.json
+++ b/cameras/hikvision/ds-2de4225iw-det5.json
@@ -66,7 +66,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4425iw-de-t5-india.json
+++ b/cameras/hikvision/ds-2de4425iw-de-t5-india.json
@@ -78,7 +78,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4425iw-de.json
+++ b/cameras/hikvision/ds-2de4425iw-de.json
@@ -78,7 +78,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4425iw-det5.json
+++ b/cameras/hikvision/ds-2de4425iw-det5.json
@@ -67,7 +67,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4825wg-e3.json
+++ b/cameras/hikvision/ds-2de4825wg-e3.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a225iw-de.json
+++ b/cameras/hikvision/ds-2de4a225iw-de.json
@@ -70,7 +70,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a225iw-des6.json
+++ b/cameras/hikvision/ds-2de4a225iw-des6.json
@@ -65,7 +65,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a225iwg-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg-e.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg1-e.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a404iwg-e.json
+++ b/cameras/hikvision/ds-2de4a404iwg-e.json
@@ -74,7 +74,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a425iw-de.json
+++ b/cameras/hikvision/ds-2de4a425iw-de.json
@@ -70,7 +70,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a425iwg-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg-e.json
@@ -73,7 +73,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de4a425iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg1-e.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de5225w-ae3t5.json
+++ b/cameras/hikvision/ds-2de5225w-ae3t5.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de5425iw-aet5.json
+++ b/cameras/hikvision/ds-2de5425iw-aet5.json
@@ -66,7 +66,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de5a425iwg-e.json
+++ b/cameras/hikvision/ds-2de5a425iwg-e.json
@@ -73,7 +73,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de5a425iwg-eb.json
+++ b/cameras/hikvision/ds-2de5a425iwg-eb.json
@@ -68,7 +68,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a225iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a225iw-aebt5.json
@@ -66,7 +66,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a225iwg1-e.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a232iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a232iw-aebt5.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
@@ -73,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a232iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a232iwg1-e.json
@@ -75,7 +75,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
@@ -74,7 +74,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a432iw-aeb.json
+++ b/cameras/hikvision/ds-2de7a432iw-aeb.json
@@ -75,7 +75,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+      "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a432iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a432iw-aebt5.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a632iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a632iwg1-e.json
@@ -74,7 +74,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2de7a825iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a825iwg1-e.json
@@ -74,7 +74,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2se4c215mwg-e.json
+++ b/cameras/hikvision/ds-2se4c215mwg-e.json
@@ -69,7 +69,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2se4c225mwg-e.json
+++ b/cameras/hikvision/ds-2se4c225mwg-e.json
@@ -70,7 +70,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2se4c425mwg-4g.json
+++ b/cameras/hikvision/ds-2se4c425mwg-4g.json
@@ -75,7 +75,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2se4c425mwg-e.json
+++ b/cameras/hikvision/ds-2se4c425mwg-e.json
@@ -65,7 +65,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+      "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2se4c430mwg-e.json
+++ b/cameras/hikvision/ds-2se4c430mwg-e.json
@@ -64,7 +64,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+      "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
+++ b/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
@@ -92,7 +92,8 @@
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-      "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed."
+      "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2sf8c442mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c442mxg1-elw.json
@@ -74,7 +74,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/hikvision/ds-2sf8c848mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c848mxg1-elw.json
@@ -75,7 +75,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
       "verified": false,
-      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+      "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/tapo/c200.json
+++ b/cameras/tapo/c200.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c207.json
+++ b/cameras/tapo/c207.json
@@ -79,7 +79,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
-      "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model."
+      "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c210.json
+++ b/cameras/tapo/c210.json
@@ -67,7 +67,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c216.json
+++ b/cameras/tapo/c216.json
@@ -72,7 +72,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c217.json
+++ b/cameras/tapo/c217.json
@@ -88,7 +88,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
-      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c220.json
+++ b/cameras/tapo/c220.json
@@ -64,7 +64,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c222-indoor.json
+++ b/cameras/tapo/c222-indoor.json
@@ -76,7 +76,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c225.json
+++ b/cameras/tapo/c225.json
@@ -69,7 +69,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c230.json
+++ b/cameras/tapo/c230.json
@@ -67,7 +67,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c245d.json
+++ b/cameras/tapo/c245d.json
@@ -96,7 +96,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
-      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c246d.json
+++ b/cameras/tapo/c246d.json
@@ -70,7 +70,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c250.json
+++ b/cameras/tapo/c250.json
@@ -83,7 +83,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
-      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c260.json
+++ b/cameras/tapo/c260.json
@@ -71,7 +71,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c500.json
+++ b/cameras/tapo/c500.json
@@ -68,7 +68,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c510w.json
+++ b/cameras/tapo/c510w.json
@@ -69,7 +69,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c520ws.json
+++ b/cameras/tapo/c520ws.json
@@ -74,7 +74,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c530ws.json
+++ b/cameras/tapo/c530ws.json
@@ -70,7 +70,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c545d.json
+++ b/cameras/tapo/c545d.json
@@ -81,7 +81,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
       "verified": false,
-      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+      "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/c560ws.json
+++ b/cameras/tapo/c560ws.json
@@ -74,7 +74,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/cameras/tapo/tc40.json
+++ b/cameras/tapo/tc40.json
@@ -71,7 +71,8 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+      "autotracking": false
     },
     "home_assistant": {
       "integration": "tapo",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -103708,7 +103708,8 @@
     "configs": {
       "frigate": {
         "notes": "Sourced from retailer pages rather than us.foscam.com/D4Z.html directly — resolution pixel dimensions, IP rating, and RTSP path not confirmed. Verify before publishing.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104027,7 +104028,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104122,7 +104124,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "ONVIF is not listed in the official protocol table (only IP/TCP/UDP/SMTP/FTP/DHCP/RTSP) — do not assume ONVIF works on this model without testing. RTSP path not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104209,7 +104212,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit. Full native resolution/sensor numbers were not found in the official spec table snippet reviewed — confirm against us.foscam.com/R8M.html Tech Specs Table before publishing.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104282,7 +104286,8 @@
     "configs": {
       "frigate": {
         "notes": "Thin data — sourced from retailer listings only, not the official us.foscam.com/SD4.html spec table. Resolution pixel dimensions, FOV, and pan/tilt angles not confirmed. RTSP path not researched.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104370,7 +104375,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104471,7 +104477,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "videoMain/videoSub is Foscam's current-gen RTSP path convention; not yet verified against a physical unit. Confirm before setting verified: true. Older Foscam models used port 88 instead of 554.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104568,7 +104575,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Sourced spec table lists 'Network: Ethernet, One 10/100Mbps RJ45 port' which looks like a copy-paste artifact from a PoE-model template reused by the retailer — SD8P is marketed as a WiFi camera. Cross-check against us.foscam.com/SD8P.html before publishing. RTSP path not yet verified.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149402,7 +149410,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149487,7 +149496,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149593,7 +149603,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149693,7 +149704,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149794,7 +149806,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149904,7 +149917,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149984,7 +149998,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150084,7 +150099,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150194,7 +150210,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150493,7 +150510,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150596,7 +150614,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150710,7 +150729,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150804,7 +150824,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150887,7 +150908,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150997,7 +151019,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151084,7 +151107,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151166,7 +151190,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151275,7 +151300,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151365,7 +151391,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151456,7 +151483,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151542,7 +151570,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151632,7 +151661,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151721,7 +151751,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151806,7 +151837,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151907,7 +151939,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152016,7 +152049,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152100,7 +152134,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152182,7 +152217,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152292,7 +152328,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152383,7 +152420,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152469,7 +152507,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152579,7 +152618,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152672,7 +152712,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152764,7 +152805,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152857,7 +152899,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152941,7 +152984,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153052,7 +153096,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153144,7 +153189,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153314,7 +153360,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153401,7 +153448,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153493,7 +153541,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153575,7 +153624,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153655,7 +153705,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153850,7 +153901,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed."
+        "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153967,7 +154019,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -154060,7 +154113,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -199589,7 +199643,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199704,7 +199759,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model."
+        "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199787,7 +199843,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199896,7 +199953,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200022,7 +200080,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200102,7 +200161,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200207,7 +200267,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200292,7 +200353,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200388,7 +200450,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200520,7 +200583,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200606,7 +200670,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200733,7 +200798,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200820,7 +200886,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202106,7 +202173,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202212,7 +202280,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202323,7 +202392,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202419,7 +202489,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202529,7 +202600,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202619,7 +202691,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -203845,7 +203918,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -103708,7 +103708,8 @@
     "configs": {
       "frigate": {
         "notes": "Sourced from retailer pages rather than us.foscam.com/D4Z.html directly — resolution pixel dimensions, IP rating, and RTSP path not confirmed. Verify before publishing.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104027,7 +104028,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104122,7 +104124,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "ONVIF is not listed in the official protocol table (only IP/TCP/UDP/SMTP/FTP/DHCP/RTSP) — do not assume ONVIF works on this model without testing. RTSP path not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104209,7 +104212,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit. Full native resolution/sensor numbers were not found in the official spec table snippet reviewed — confirm against us.foscam.com/R8M.html Tech Specs Table before publishing.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104282,7 +104286,8 @@
     "configs": {
       "frigate": {
         "notes": "Thin data — sourced from retailer listings only, not the official us.foscam.com/SD4.html spec table. Resolution pixel dimensions, FOV, and pan/tilt angles not confirmed. RTSP path not researched.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104370,7 +104375,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Not yet verified against a physical unit.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104471,7 +104477,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "videoMain/videoSub is Foscam's current-gen RTSP path convention; not yet verified against a physical unit. Confirm before setting verified: true. Older Foscam models used port 88 instead of 554.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -104568,7 +104575,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/videoMain",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/videoSub",
         "notes": "Sourced spec table lists 'Network: Ethernet, One 10/100Mbps RJ45 port' which looks like a copy-paste artifact from a PoE-model template reused by the retailer — SD8P is marketed as a WiFi camera. Cross-check against us.foscam.com/SD8P.html before publishing. RTSP path not yet verified.",
-        "verified": false
+        "verified": false,
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149402,7 +149410,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149487,7 +149496,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149593,7 +149603,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149693,7 +149704,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149794,7 +149806,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149904,7 +149917,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -149984,7 +149998,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150084,7 +150099,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150194,7 +150210,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150493,7 +150510,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150596,7 +150614,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150710,7 +150729,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150804,7 +150824,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150887,7 +150908,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -150997,7 +151019,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151084,7 +151107,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151166,7 +151190,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151275,7 +151300,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151365,7 +151391,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151456,7 +151483,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151542,7 +151570,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151632,7 +151661,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151721,7 +151751,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151806,7 +151837,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -151907,7 +151939,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152016,7 +152049,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152100,7 +152134,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152182,7 +152217,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152292,7 +152328,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152383,7 +152420,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152469,7 +152507,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152579,7 +152618,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152672,7 +152712,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152764,7 +152805,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152857,7 +152899,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'."
+        "notes": "ONVIF PTZ control supported (port 80, enable Integration Protocol/ONVIF in camera settings and create an ONVIF user). For Frigate autotracking add 'onvif: {host, port: 80, user, password, autotracking: {enabled: true}}'.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -152941,7 +152984,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153052,7 +153096,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153144,7 +153189,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153314,7 +153360,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153401,7 +153448,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). TandemVu units expose each channel separately — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153493,7 +153541,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153575,7 +153624,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153655,7 +153705,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2."
+        "notes": "TandemVu PTZ+bullet combo — bullet is channel 1 (Streaming/Channels/101), PTZ is channel 2 (Streaming/Channels/201). Configure as two Frigate cameras; ONVIF PTZ control on channel 2.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153850,7 +153901,8 @@
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
-        "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed."
+        "notes": "TandemVu has multiple channels — panoramic (channel 1) and PTZ (channel 2); add each as needed.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -153967,7 +154019,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -154060,7 +154113,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/101",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Streaming/Channels/102",
         "verified": false,
-        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI."
+        "notes": "Hikvision native RTSP (main 101 / sub 102). Multi-channel/TandemVu units expose each channel as 201/301 etc. — enable RTSP in the web UI.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "onvif",
@@ -199589,7 +199643,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199704,7 +199759,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model."
+        "notes": "Standard Tapo wired-camera RTSP scheme (stream1 main / stream2 sub); not individually bench-tested on this model.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199787,7 +199843,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -199896,7 +199953,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200022,7 +200080,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200102,7 +200161,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200207,7 +200267,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200292,7 +200353,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200388,7 +200450,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200520,7 +200583,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200606,7 +200670,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200733,7 +200798,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). /stream1 is the main stream, /stream2 the substream.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -200820,7 +200886,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202106,7 +202173,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202212,7 +202280,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202323,7 +202392,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202419,7 +202489,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202529,7 +202600,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
         "verified": false,
-        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup."
+        "notes": "Mains-powered Tapo cameras expose RTSP once a Camera Account is created in the Tapo app (Settings > Advanced > Camera Account). Dual-lens models: /stream1 and /stream2 map to the two lenses rather than main/sub — confirm per-lens mapping in your setup.",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -202619,7 +202691,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",
@@ -203845,7 +203918,8 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/stream1",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/stream2",
+        "autotracking": false
       },
       "home_assistant": {
         "integration": "tapo",


### PR DESCRIPTION
Follow-up to #152 — stamps `configs.frigate.autotracking: false` on the brands Frigate's [official docs](https://docs.frigate.video/configuration/cameras/#onvif-ptz-camera-recommendations) mark **❌ brand-level**:

| Brand | Count | Frigate's reason |
|---|---|---|
| Hikvision | 46 | `MoveStatus` won't update even on latest firmware (minus the `DS-2DE3A404IWG-E/-E-W` exception, already `true` in #152) |
| Tapo | 20 | PTZ controls work, autotracking does not |
| Foscam | 8 | Support PTZ but not FOV relative move |

**Scope guards:**
- Only **genuine motorized PTZ** stamped — `type: ptz` plus the 2 motorized TandemVu panoramics (which have `ptz.autotracking`). Fixed multi-sensor / dual-lens kits were **skipped**.
- Only cameras with an **existing frigate block** (no fabricated configs).
- `onvif_ptz` left **undefined** — Hikvision's failure is the `MoveStatus` bug (not move-type), and Tapo/Foscam move-type isn't cleanly documented, so no move-type is asserted.

Coverage after: `frigate.autotracking` **115** (98 false + 17 true). No schema/count change.