### PR TITLE
Frigate-compat for 32 new Dahua SD speed domes (#154)

### DIFF
--- a/cameras/dahua/sd3d216nb-gny.json
+++ b/cameras/dahua/sd3d216nb-gny.json
@@ -24,7 +24,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -72,7 +73,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd3d416nb-gny.json
+++ b/cameras/dahua/sd3d416nb-gny.json
@@ -30,7 +30,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -79,7 +80,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49216db-hny.json
+++ b/cameras/dahua/sd49216db-hny.json
@@ -3,6 +3,9 @@
   "brand": "Dahua",
   "model": "SD49216DB-HNY",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
   "connectivity": [
     "ethernet"
   ],
@@ -83,7 +86,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49225db-hny.json
+++ b/cameras/dahua/sd49225db-hny.json
@@ -30,7 +30,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -83,7 +84,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd49425db-hny-gq.json
+++ b/cameras/dahua/sd49425db-hny-gq.json
@@ -26,7 +26,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -88,7 +89,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4a216db-hny.json
+++ b/cameras/dahua/sd4a216db-hny.json
@@ -35,7 +35,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -85,7 +86,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4a425db-hny-r.json
+++ b/cameras/dahua/sd4a425db-hny-r.json
@@ -31,7 +31,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -85,7 +86,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4a425db-hny.json
+++ b/cameras/dahua/sd4a425db-hny.json
@@ -24,7 +24,8 @@
     "min_lux_color": 0.005
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -86,7 +87,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e225gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225gb-hnr-a-pv1.json
@@ -30,7 +30,8 @@
     "max_fps": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -84,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e225mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225mb-hnr-a-pv1.json
@@ -29,7 +29,8 @@
     "max_fps": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -83,7 +84,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e425gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425gb-hnr-a-pv1.json
@@ -30,7 +30,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",
@@ -80,7 +81,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e425mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425mb-hnr-a-pv1.json
@@ -22,7 +22,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -88,7 +89,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e825gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825gb-hnr-a-pv1.json
@@ -23,7 +23,8 @@
     "range_m": 100
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -88,7 +89,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4e825mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825mb-hnr-a-pv1.json
@@ -29,7 +29,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at)",
@@ -82,7 +83,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd4f420da-hny.json
+++ b/cameras/dahua/sd4f420da-hny.json
@@ -3,6 +3,9 @@
   "brand": "Dahua",
   "model": "SD4F420DA-HNY",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
   "connectivity": [
     "ethernet"
   ],
@@ -82,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd50432gb-hnr.json
+++ b/cameras/dahua/sd50432gb-hnr.json
@@ -36,7 +36,8 @@
     "min_lux": 0.005
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",
@@ -88,7 +89,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd52c225db-hny.json
+++ b/cameras/dahua/sd52c225db-hny.json
@@ -27,7 +27,8 @@
     "max_fps": 25
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / 24V DC",
@@ -80,7 +81,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd52c232gb-hnr.json
+++ b/cameras/dahua/sd52c232gb-hnr.json
@@ -27,7 +27,8 @@
     "max_fps": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",
@@ -79,7 +80,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd52c432gb-hnr.json
+++ b/cameras/dahua/sd52c432gb-hnr.json
@@ -23,7 +23,8 @@
     "min_lux_color": 0.005
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -83,7 +84,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a245gb-hnr.json
+++ b/cameras/dahua/sd5a245gb-hnr.json
@@ -31,7 +31,8 @@
     "max_fps": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",
@@ -85,7 +86,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a425ma-hnr.json
+++ b/cameras/dahua/sd5a425ma-hnr.json
@@ -34,7 +34,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",
@@ -84,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a425mb-hnr.json
+++ b/cameras/dahua/sd5a425mb-hnr.json
@@ -30,7 +30,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",
@@ -83,7 +84,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a432mb-hnr.json
+++ b/cameras/dahua/sd5a432mb-hnr.json
@@ -22,7 +22,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -87,7 +88,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a445gb-hnr.json
+++ b/cameras/dahua/sd5a445gb-hnr.json
@@ -28,7 +28,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",
@@ -83,7 +84,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a445mb-hnr.json
+++ b/cameras/dahua/sd5a445mb-hnr.json
@@ -21,7 +21,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -84,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a825gb-hnr.json
+++ b/cameras/dahua/sd5a825gb-hnr.json
@@ -25,7 +25,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -88,7 +89,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd5a825ma-hnr.json
+++ b/cameras/dahua/sd5a825ma-hnr.json
@@ -22,7 +22,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "video": {
     "codecs": [
@@ -86,7 +87,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
@@ -38,7 +38,8 @@
     "range_m": 150
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "12V DC",

--- a/cameras/dahua/sd8a440pa-hnf-5g.json
+++ b/cameras/dahua/sd8a440pa-hnf-5g.json
@@ -31,7 +31,8 @@
     "max_fps": 60
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "36 VDC (3A)",
@@ -84,7 +85,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sd8a840pa-hnf-5g.json
+++ b/cameras/dahua/sd8a840pa-hnf-5g.json
@@ -32,7 +32,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "36 VDC",
@@ -85,7 +86,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
+++ b/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
@@ -35,7 +35,8 @@
     "max_fps": 30
   },
   "ptz": {
-    "autotracking": true
+    "autotracking": true,
+    "onvif_ptz": "relative"
   },
   "power": {
     "method": "DC 12V",
@@ -92,7 +93,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/cameras/dahua/sdz4032-hnr-zb.json
+++ b/cameras/dahua/sdz4032-hnr-zb.json
@@ -3,6 +3,9 @@
   "brand": "Dahua",
   "model": "SDZ4032-HNR-ZB",
   "type": "ptz",
+  "ptz": {
+    "onvif_ptz": "relative"
+  },
   "connectivity": [
     "ethernet"
   ],
@@ -80,7 +83,8 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
       "verified": false,
-      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+      "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+      "autotracking": true
     },
     "home_assistant": {
       "integration": "onvif",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -93257,7 +93257,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93305,7 +93306,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93351,7 +93353,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93400,7 +93403,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93418,6 +93422,9 @@
     "brand": "Dahua",
     "model": "SD49216DB-HNY",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -93498,7 +93505,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93543,7 +93551,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93596,7 +93605,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93830,7 +93840,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -93892,7 +93903,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94033,7 +94045,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94083,7 +94096,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94122,7 +94136,8 @@
       "min_lux_color": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -94184,7 +94199,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94231,7 +94247,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94285,7 +94302,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94611,7 +94629,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94665,7 +94684,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94709,7 +94729,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94763,7 +94784,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94809,7 +94831,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94859,7 +94882,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94897,7 +94921,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -94963,7 +94988,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95001,7 +95027,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -95066,7 +95093,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95111,7 +95139,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at)",
@@ -95164,7 +95193,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95183,6 +95213,9 @@
     "brand": "Dahua",
     "model": "SD4F420DA-HNY",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -95262,7 +95295,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95313,7 +95347,8 @@
       "min_lux": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95365,7 +95400,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95407,7 +95443,8 @@
       "max_fps": 25
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V DC",
@@ -95460,7 +95497,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95503,7 +95541,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95555,7 +95594,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95594,7 +95634,8 @@
       "min_lux_color": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -95654,7 +95695,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95701,7 +95743,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -95755,7 +95798,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95805,7 +95849,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -95855,7 +95900,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95900,7 +95946,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95953,7 +96000,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96085,7 +96133,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96150,7 +96199,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96194,7 +96244,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -96249,7 +96300,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96286,7 +96338,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96349,7 +96402,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96389,7 +96443,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96452,7 +96507,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96490,7 +96546,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96554,7 +96611,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96728,7 +96786,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12V DC",
@@ -96832,7 +96891,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "36 VDC (3A)",
@@ -96885,7 +96945,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96932,7 +96993,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "36 VDC",
@@ -96985,7 +97047,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -97128,7 +97191,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "DC 12V",
@@ -97185,7 +97249,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -97402,6 +97467,9 @@
     "brand": "Dahua",
     "model": "SDZ4032-HNR-ZB",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -97479,7 +97547,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -93257,7 +93257,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93305,7 +93306,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93351,7 +93353,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93400,7 +93403,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93418,6 +93422,9 @@
     "brand": "Dahua",
     "model": "SD49216DB-HNY",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -93498,7 +93505,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93543,7 +93551,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -93596,7 +93605,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -93830,7 +93840,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -93892,7 +93903,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94033,7 +94045,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94083,7 +94096,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94122,7 +94136,8 @@
       "min_lux_color": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -94184,7 +94199,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94231,7 +94247,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94285,7 +94302,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94611,7 +94629,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94665,7 +94684,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94709,7 +94729,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94763,7 +94784,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94809,7 +94831,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -94859,7 +94882,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -94897,7 +94921,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -94963,7 +94988,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95001,7 +95027,8 @@
       "range_m": 100
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -95066,7 +95093,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95111,7 +95139,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at)",
@@ -95164,7 +95193,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95183,6 +95213,9 @@
     "brand": "Dahua",
     "model": "SD4F420DA-HNY",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -95262,7 +95295,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95313,7 +95347,8 @@
       "min_lux": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95365,7 +95400,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95407,7 +95443,8 @@
       "max_fps": 25
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V DC",
@@ -95460,7 +95497,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95503,7 +95541,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95555,7 +95594,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95594,7 +95634,8 @@
       "min_lux_color": 0.005
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -95654,7 +95695,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95701,7 +95743,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -95755,7 +95798,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95805,7 +95849,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -95855,7 +95900,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -95900,7 +95946,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -95953,7 +96000,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96085,7 +96133,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96150,7 +96199,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96194,7 +96244,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -96249,7 +96300,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96286,7 +96338,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96349,7 +96402,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96389,7 +96443,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96452,7 +96507,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96490,7 +96546,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "video": {
       "codecs": [
@@ -96554,7 +96611,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96728,7 +96786,8 @@
       "range_m": 150
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "12V DC",
@@ -96832,7 +96891,8 @@
       "max_fps": 60
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "36 VDC (3A)",
@@ -96885,7 +96945,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -96932,7 +96993,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "36 VDC",
@@ -96985,7 +97047,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -97128,7 +97191,8 @@
       "max_fps": 30
     },
     "ptz": {
-      "autotracking": true
+      "autotracking": true,
+      "onvif_ptz": "relative"
     },
     "power": {
       "method": "DC 12V",
@@ -97185,7 +97249,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",
@@ -97402,6 +97467,9 @@
     "brand": "Dahua",
     "model": "SDZ4032-HNR-ZB",
     "type": "ptz",
+    "ptz": {
+      "onvif_ptz": "relative"
+    },
     "connectivity": [
       "ethernet"
     ],
@@ -97479,7 +97547,8 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
         "verified": false,
-        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin)."
+        "notes": "Dahua native RTSP path; enable RTSP in the web UI (default admin).",
+        "autotracking": true
       },
       "home_assistant": {
         "integration": "onvif",


### PR DESCRIPTION
Follow-up to the +45 Dahua PTZ (#156), applying the #124 Frigate-compat convention (tracked in #154).

The 45 new PTZ split cleanly:
- **32 SD-series motorized speed domes** (SD3D / SD4 / SD5 / SDZ + the 4G/5G SD variants) → `onvif_ptz: relative`, `configs.frigate.autotracking: true`. Dahua is brand-level ✅ in Frigate's docs for mid/high-end speed domes, and these are the same platform as the wired siblings already stamped in #152.
- **14 positioning / laser systems** (`PTZ85xxx`, `PTZ83440`, `PTZ19245U`, `MPTZ1100`, `PTZ4M231`, `PTZ37225`, `PTZ1A225`, + pre-existing `IPC-PTS2249B`) → **left undefined** (undocumented in Frigate's list, atypical Frigate targets).

Coverage after: `onvif_ptz` **88** (49 relative + 39 absolute), `configs.frigate.autotracking` **147** (49 true + 98 false). No schema/count change.