### PR TITLE
data: enrich data set with minimum illumination level (based on data from datasheet, specified in in sources)

### DIFF
--- a/cameras/abus/ipcb54511a.json
+++ b/cameras/abus/ipcb54511a.json
@@ -42,7 +42,8 @@
   "field_of_view_deg": "103 horizontal, 55 vertical",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (IEEE 802.3af) / 12V DC"

--- a/cameras/abus/ipcs28581a.json
+++ b/cameras/abus/ipcs28581a.json
@@ -42,7 +42,8 @@
   "field_of_view_deg": "180 horizontal, 44 vertical",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (IEEE 802.3af) / 12 V DC"

--- a/cameras/abus/ipcs34511a.json
+++ b/cameras/abus/ipcs34511a.json
@@ -32,7 +32,8 @@
   "field_of_view_deg": "108 H",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / 12V DC"

--- a/cameras/abus/ipcs34511b.json
+++ b/cameras/abus/ipcs34511b.json
@@ -32,7 +32,8 @@
   "field_of_view_deg": "95 H",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / 12V DC"

--- a/cameras/abus/ipcs34611a.json
+++ b/cameras/abus/ipcs34611a.json
@@ -51,7 +51,8 @@
   "field_of_view_deg": "108 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (IEEE 802.3af) or 12V DC"

--- a/cameras/abus/ipcs54511b.json
+++ b/cameras/abus/ipcs54511b.json
@@ -42,7 +42,8 @@
   "field_of_view_deg": "95 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) or 12V DC"

--- a/cameras/abus/ipcs54611a.json
+++ b/cameras/abus/ipcs54611a.json
@@ -51,7 +51,8 @@
   "field_of_view_deg": "108 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) or 12V DC"

--- a/cameras/abus/ipcs64611a.json
+++ b/cameras/abus/ipcs64611a.json
@@ -34,7 +34,8 @@
   "field_of_view_deg": "108 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / 12V DC"

--- a/cameras/amcrest/ip5m-t1273ew-ai.json
+++ b/cameras/amcrest/ip5m-t1273ew-ai.json
@@ -23,7 +23,8 @@
   "field_of_view_deg": "98",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "ip_rating": "IP67",
   "audio": {

--- a/cameras/annke/i81em.json
+++ b/cameras/annke/i81em.json
@@ -35,7 +35,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af, max 10W) / DC 12V"

--- a/cameras/annke/i91bh.json
+++ b/cameras/annke/i91bh.json
@@ -33,7 +33,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/i91bi.json
+++ b/cameras/annke/i91bi.json
@@ -33,7 +33,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/nc400-i81hc.json
+++ b/cameras/annke/nc400-i81hc.json
@@ -28,7 +28,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE / DC 12V"
@@ -60,7 +61,8 @@
     "ONVIF/RTSP"
   ],
   "sources": [
-    "https://www.annke.com/collections/nightchroma-series"
+    "https://www.annke.com/collections/nightchroma-series",
+    "https://web.archive.org/web/20210127143050/https://www.annke.com/products/nc400"
   ],
   "markets": [
     "global"

--- a/cameras/bosch/mic-550ir55-p.json
+++ b/cameras/bosch/mic-550ir55-p.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 120
+    "range_m": 120,
+    "min_lux": 0.0052
   },
   "power": {
     "method": "High PoE (802.3at) / AC 24V"

--- a/cameras/bosch/mic-7522-z30b.json
+++ b/cameras/bosch/mic-7522-z30b.json
@@ -45,7 +45,8 @@
   },
   "field_of_view_deg": "2.1-58.3",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0047
   },
   "power": {
     "method": "High Power-over-Ethernet (56 VDC nominal) or 24 VAC"

--- a/cameras/bosch/mic-7522-z30br.json
+++ b/cameras/bosch/mic-7522-z30br.json
@@ -54,7 +54,8 @@
   },
   "field_of_view_deg": "2.1-58.3",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.0047
   },
   "power": {
     "method": "High PoE (56 VDC nominal, 60W/95W midspan) or 21-30 VAC 50/60 Hz"

--- a/cameras/bosch/mic-7522-z30g.json
+++ b/cameras/bosch/mic-7522-z30g.json
@@ -42,7 +42,8 @@
   },
   "field_of_view_deg": "2.1° to 58.3°",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0053
   },
   "power": {
     "method": "High PoE (56 VDC nominal) or 21-30 VAC"

--- a/cameras/bosch/mic-7522-z30gr.json
+++ b/cameras/bosch/mic-7522-z30gr.json
@@ -33,7 +33,8 @@
   },
   "field_of_view_deg": "2.1-58.3",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0047
   },
   "power": {
     "method": "High PoE / 21-30 VAC / 56 VDC, 40-70W"

--- a/cameras/bosch/mic-7522-z30w.json
+++ b/cameras/bosch/mic-7522-z30w.json
@@ -48,7 +48,8 @@
   },
   "field_of_view_deg": "2.1-58.3",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0047
   },
   "power": {
     "method": "High Power-over-Ethernet (56 VDC nominal) or 24 VAC"

--- a/cameras/bosch/mic-7522-z30wr.json
+++ b/cameras/bosch/mic-7522-z30wr.json
@@ -41,7 +41,8 @@
   },
   "field_of_view_deg": "2.1-58.3",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0053
   },
   "power": {
     "method": "High PoE (56 VDC nominal) or 21-30 VAC"

--- a/cameras/bosch/mic-9502-z30bvs.json
+++ b/cameras/bosch/mic-9502-z30bvs.json
@@ -45,7 +45,8 @@
   },
   "night_vision": {
     "type": "none",
-    "range_m": 0
+    "range_m": 0,
+    "min_lux_color": 0.0077
   },
   "power": {
     "method": "High PoE / 24 VAC (21-30 VAC) / 56 VDC, ~72 W"

--- a/cameras/bosch/mic-9502-z30wvf.json
+++ b/cameras/bosch/mic-9502-z30wvf.json
@@ -48,7 +48,8 @@
   },
   "field_of_view_deg": "Thermal ~12 (50mm lens); visible 30x optical zoom (4.3-129mm)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.0077
   },
   "power": {
     "method": "24 VAC (21-30 VAC) and/or 95W High PoE"

--- a/cameras/bosch/nbi-7802-ax.json
+++ b/cameras/bosch/nbi-7802-ax.json
@@ -42,7 +42,8 @@
   },
   "field_of_view_deg": "103-49 (horizontal), 53-27 (vertical)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (IEEE 802.3at Type 1 Class 3, 12.95W), 24 VAC, 12-26 VDC",

--- a/cameras/bosch/nbi-7803-axt.json
+++ b/cameras/bosch/nbi-7803-axt.json
@@ -32,7 +32,8 @@
   },
   "field_of_view_deg": "9.3–41.6 (horizontal)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (IEEE 802.3at Type 1, Class 3, 12.95W); 24 VAC; 12–26 VDC",

--- a/cameras/bosch/nbi-7803s-axt.json
+++ b/cameras/bosch/nbi-7803s-axt.json
@@ -33,7 +33,8 @@
   },
   "field_of_view_deg": "H: 41.6°-9.3°, V: 23.9°-5.3°",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE IEEE 802.3at Type 1 (12.95W); 24 VAC; 12-26 VDC",

--- a/cameras/bosch/nbn-63023-b.json
+++ b/cameras/bosch/nbn-63023-b.json
@@ -37,7 +37,8 @@
   },
   "sensor": "1/2.8-inch CMOS",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.0069
   },
   "power": {
     "method": "PoE IEEE 802.3af (802.3at Type 1) or +12 VDC; 7.2 W max",

--- a/cameras/bosch/nbn-73023-ba.json
+++ b/cameras/bosch/nbn-73023-ba.json
@@ -36,7 +36,8 @@
     "varifocal": false
   },
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.0069
   },
   "power": {
     "method": "PoE (IEEE 802.3af / 802.3at Type 1) or +12 VDC",

--- a/cameras/bosch/nde-8702-rxt.json
+++ b/cameras/bosch/nde-8702-rxt.json
@@ -34,7 +34,8 @@
   },
   "field_of_view_deg": "36-12 (horizontal), 20-7 (vertical)",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0252
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1 Class 3; 24 VAC; 12-26 VDC",

--- a/cameras/bosch/nde-8703-r.json
+++ b/cameras/bosch/nde-8703-r.json
@@ -42,7 +42,8 @@
   },
   "field_of_view_deg": "117 - 44 (horizontal), 62 - 24 (vertical)",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.036
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1 Class 3; 24 VAC; 12-26 VDC",

--- a/cameras/bosch/nde-8703-rt.json
+++ b/cameras/bosch/nde-8703-rt.json
@@ -42,7 +42,8 @@
   },
   "field_of_view_deg": "12-36 (horizontal), 7-20 (vertical)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.0885
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1 Class 3; 12-26 VDC; 24 VAC",

--- a/cameras/bosch/nde-8703-rx.json
+++ b/cameras/bosch/nde-8703-rx.json
@@ -42,7 +42,8 @@
   },
   "field_of_view_deg": "110-48",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0252
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at Type 1 Class 3), 24 VAC, 12-26 VDC",

--- a/cameras/bosch/ndp-5522-z30.json
+++ b/cameras/bosch/ndp-5522-z30.json
@@ -46,7 +46,8 @@
   },
   "field_of_view_deg": "2.4-60.9",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0186
   },
   "power": {
     "method": "PoE+ (IEEE 802.3at) / 24 VAC",

--- a/cameras/bosch/ndp-5522-z30c.json
+++ b/cameras/bosch/ndp-5522-z30c.json
@@ -46,7 +46,8 @@
   },
   "field_of_view_deg": "2.4-60.9",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0186
   },
   "power": {
     "method": "PoE+ (IEEE 802.3at) or 24 VAC; 14-24 W",

--- a/cameras/bosch/ndp-5533-z30l.json
+++ b/cameras/bosch/ndp-5533-z30l.json
@@ -48,7 +48,8 @@
   "field_of_view_deg": "2.1 to 58.5",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 320
+    "range_m": 320,
+    "min_lux_color": 0.0101
   },
   "power": {
     "method": "PoE++ (IEEE 802.3bt Type 3) / PoE+ (IEEE 802.3at Type 2) / 24 VAC"

--- a/cameras/bosch/ndp-7802-z40.json
+++ b/cameras/bosch/ndp-7802-z40.json
@@ -34,7 +34,8 @@
   },
   "field_of_view_deg": "1.9-66.35",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.067
   },
   "power": {
     "method": "PoE (IEEE 802.3bt Type 3, Class 6, 60W) / 24 VAC / 36 VDC; 48.6W at PoE 54VDC, 46.8W at 36VDC, 43.2W at 24VAC",

--- a/cameras/bosch/ndv-5703-a.json
+++ b/cameras/bosch/ndv-5703-a.json
@@ -32,7 +32,8 @@
   },
   "field_of_view_deg": "22-96 (horizontal; wide 71-96, tele 22-29)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.06
   },
   "power": {
     "method": "PoE IEEE 802.3af Type 1, Class 3",

--- a/cameras/bosch/ndv-8503-r.json
+++ b/cameras/bosch/ndv-8503-r.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "44° to 117° horizontal (tele to wide)",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0509
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at Type 1, Class 3)",

--- a/cameras/bosch/ndv-8503-rx.json
+++ b/cameras/bosch/ndv-8503-rx.json
@@ -39,7 +39,8 @@
   },
   "field_of_view_deg": "56-110 (horizontal, tele to wide)",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0078
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at)"

--- a/cameras/bosch/ndv-8504-r.json
+++ b/cameras/bosch/ndv-8504-r.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "117 (wide) to 44 (tele) horizontal; 62 to 24 vertical",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.054
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1",

--- a/cameras/bosch/nue-3702-f02.json
+++ b/cameras/bosch/nue-3702-f02.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "137 (H) x 72.8 (V)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.1
   },
   "power": {
     "method": "PoE (IEEE 802.3af/802.3at Type 1)",

--- a/cameras/bosch/nue-3702-f04.json
+++ b/cameras/bosch/nue-3702-f04.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "106 (H) / 56 (V)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1, Class 3",

--- a/cameras/bosch/nue-3703-f06.json
+++ b/cameras/bosch/nue-3703-f06.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "56.1 (H) x 39.2 (V)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.015
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1",

--- a/cameras/bosch/nuv-3702-f02.json
+++ b/cameras/bosch/nuv-3702-f02.json
@@ -40,7 +40,8 @@
   },
   "field_of_view_deg": "137 (horizontal); 72.8 (vertical)",
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE IEEE 802.3af/802.3at Type 1, Class 3 (3.2W typ - 4.5W max)",

--- a/cameras/dahua/hac-hdw1249sm-a-pro.json
+++ b/cameras/dahua/hac-hdw1249sm-a-pro.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "101h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "DC 12V",
@@ -57,7 +58,8 @@
   "dimensions_mm": "94.0 x 83.7",
   "weight_g": 340,
   "sources": [
-    "https://www.dahuasecurity.com/products/All-Products/HDCVI-Cameras/Pro-Series/2MP/HAC-HDW1249SM-A-PRO"
+    "https://www.dahuasecurity.com/products/All-Products/HDCVI-Cameras/Pro-Series/2MP/HAC-HDW1249SM-A-PRO",
+    "https://materialfile.dahuasecurity.com/uploads/cpq/86618/datasheet/HAC-HDW1249SM-A-PRO_S0_datasheet_20260507.pdf"
   ],
   "markets": [
     "global"

--- a/cameras/dahua/hac-hdw1549sm-a-pro.json
+++ b/cameras/dahua/hac-hdw1549sm-a-pro.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "109.6h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/hac-hfw1549sm-a-pro.json
+++ b/cameras/dahua/hac-hfw1549sm-a-pro.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "109.6h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0047
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/ipc-hdw1239t1-led-s6.json
+++ b/cameras/dahua/ipc-hdw1239t1-led-s6.json
@@ -15,7 +15,8 @@
   "field_of_view_deg": "110",
   "night_vision": {
     "type": "color",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux": 0.005
   },
   "power": {
     "method": "PoE/DC12V"

--- a/cameras/dahua/ipc-hdw1439t-a-led-s4.json
+++ b/cameras/dahua/ipc-hdw1439t-a-led-s4.json
@@ -18,7 +18,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw1439t1-led.json
+++ b/cameras/dahua/ipc-hdw1439t1-led.json
@@ -15,7 +15,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux": 0.006
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2249t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2249t-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "101",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.0002
   },
   "video": {
     "codecs": [
@@ -67,7 +68,8 @@
   ],
   "operating_temp_c": "-40 to +60",
   "sources": [
-    "https://www.dahuasecurity.com/products/network-products/network-cameras/wizsense-2-series/wizcolor/ipc-hdw2249t-s-pro"
+    "https://www.dahuasecurity.com/products/network-products/network-cameras/wizsense-2-series/wizcolor/ipc-hdw2249t-s-pro",
+    "https://materialfile.dahuasecurity.com/uploads/cpq/82610/datasheet/DH-IPC-HDW2249T-S-PRO_S0_datasheet_20250912.pdf"
   ],
   "markets": [
     "global"

--- a/cameras/dahua/ipc-hdw2449t-s-il.json
+++ b/cameras/dahua/ipc-hdw2449t-s-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "95 (2.8mm) / 78 (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],

--- a/cameras/dahua/ipc-hdw2849t-s-il.json
+++ b/cameras/dahua/ipc-hdw2849t-s-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111 (2.8mm) / 87 (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],

--- a/cameras/dahua/ipc-hdw3849h-as-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3849h-as-pv-pro.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw1239s1-led-s6.json
+++ b/cameras/dahua/ipc-hfw1239s1-led-s6.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE/DC12V"

--- a/cameras/dahua/ipc-hfw1439s-led-s4.json
+++ b/cameras/dahua/ipc-hfw1439s-led-s4.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1439s1-led-s4.json
+++ b/cameras/dahua/ipc-hfw1439s1-led-s4.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1439s1-led.json
+++ b/cameras/dahua/ipc-hfw1439s1-led.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw3449t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3449t1-as-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "103 (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
@@ -38,7 +38,8 @@
   "field_of_view_deg": "55.8-2.3 (wide-tele)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt3e410-8p-mb-a-pv1.json
@@ -18,7 +18,8 @@
     "varifocal": true
   },
   "night_vision": {
-    "type": "hybrid"
+    "type": "hybrid",
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/ezviz/c8c.json
+++ b/cameras/ezviz/c8c.json
@@ -31,7 +31,8 @@
   "field_of_view_deg": "352 pan / 95 tilt",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.5
   },
   "ptz": {
     "autotracking": true

--- a/cameras/ezviz/c8pf.json
+++ b/cameras/ezviz/c8pf.json
@@ -29,7 +29,8 @@
   "field_of_view_deg": "340 pan / 80 tilt (wide + tele simultaneous)",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.05
   },
   "power": {
     "method": "DC 12V/1A (max 12W)"

--- a/cameras/ezviz/h8c-pro-4k.json
+++ b/cameras/ezviz/h8c-pro-4k.json
@@ -31,7 +31,8 @@
   "field_of_view_deg": "350 pan / 80 tilt",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.5
   },
   "power": {
     "method": "DC 12V"

--- a/cameras/hikvision/ds-2cd1023g2-liu.json
+++ b/cameras/hikvision/ds-2cd1023g2-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "107 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1023g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1023g2-liuf.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1027g2h-liu.json
+++ b/cameras/hikvision/ds-2cd1027g2h-liu.json
@@ -28,7 +28,8 @@
   "field_of_view_deg": "115 horizontal (2.8mm) / 94 horizontal (4mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af, Class 3) / DC 12V",

--- a/cameras/hikvision/ds-2cd1027g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1027g2h-liuf.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1043g2-liu.json
+++ b/cameras/hikvision/ds-2cd1043g2-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "106 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1043g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1043g2-liuf.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1047g0-luf.json
+++ b/cameras/hikvision/ds-2cd1047g0-luf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "96.5 (2.8mm)/75.8 (4mm) horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1047g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1047g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1067g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1067g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1123g2-liu.json
+++ b/cameras/hikvision/ds-2cd1123g2-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "107 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1123g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1123g2-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1127g0-luf-d.json
+++ b/cameras/hikvision/ds-2cd1127g0-luf-d.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "105 (2.8mm)/83 (4mm) horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1127g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1127g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1143g2-liu.json
+++ b/cameras/hikvision/ds-2cd1143g2-liu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "106 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1143g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1143g2-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1147g0-luf-d.json
+++ b/cameras/hikvision/ds-2cd1147g0-luf-d.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "96 (2.8mm)/76 (4mm) horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1147g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1147g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1167g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1167g2h-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1323g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1323g2-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1343g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1343g2-liuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd1t27g0-luf-c.json
+++ b/cameras/hikvision/ds-2cd1t27g0-luf-c.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "83.6 (4mm)/54.6 (6mm) horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2027g2-lu.json
+++ b/cameras/hikvision/ds-2cd2027g2-lu.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -56,7 +57,8 @@
     "budget ColorVu entry"
   ],
   "sources": [
-    "https://www.hikvision.com/en/products/"
+    "https://www.hikvision.com/en/products/",
+    "https://assets.hikvision.com/prd/public/all/doc/sm000058317/DS-2CD2027G2-LU-C_Datasheet_V5.5.113_20230418.pdf"
   ],
   "power_source": [
     "poe",

--- a/cameras/hikvision/ds-2cd2043g2-l.json
+++ b/cameras/hikvision/ds-2cd2043g2-l.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2043g2-li2u.json
+++ b/cameras/hikvision/ds-2cd2043g2-li2u.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2047g2-l.json
+++ b/cameras/hikvision/ds-2cd2047g2-l.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "109 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2047g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g2-l.json
+++ b/cameras/hikvision/ds-2cd2087g2-l.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "109 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2087g2h-liu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2087g3-li2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2087g3-li2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2147g2-su.json
+++ b/cameras/hikvision/ds-2cd2147g2-su.json
@@ -19,7 +19,8 @@
     "varifocal": false
   },
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2147g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2147g2h-lisu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2147g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2147g3-lis2uy.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2167g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2167g2h-lisu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2187g2-lsu.json
+++ b/cameras/hikvision/ds-2cd2187g2-lsu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2187g2h-li.json
+++ b/cameras/hikvision/ds-2cd2187g2h-li.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2187g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2187g2h-lisu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2187g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2187g3-lis2uy.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2327g2-lu.json
+++ b/cameras/hikvision/ds-2cd2327g2-lu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2347g2-l.json
+++ b/cameras/hikvision/ds-2cd2347g2-l.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2347g2-lu.json
+++ b/cameras/hikvision/ds-2cd2347g2-lu.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm) / 84 horizontal (4mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -56,7 +57,8 @@
     "H.265+ compression"
   ],
   "sources": [
-    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/Pro-Series-EasyIP-/ds-2cd2347g2-l-u-/"
+    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/Pro-Series-EasyIP-/ds-2cd2347g2-l-u-/",
+    "https://assets.hikvision.com/prd/public/all/doc/sm000058331/DS-2CD2347G2-LU-C_Datasheet_20240417.pdf"
   ],
   "power_source": [
     "poe",

--- a/cameras/hikvision/ds-2cd2347g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2p-lsu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2347g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2347g3-lis2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2367g2-l.json
+++ b/cameras/hikvision/ds-2cd2367g2-l.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "103 horizontal (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2367g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2367g2h-liu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af)"

--- a/cameras/hikvision/ds-2cd2387g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2387g2h-lisu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2387g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2387g3-lis2uy-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE+ (802.3at, Class 4, max 17 W) / 12 VDC"

--- a/cameras/hikvision/ds-2cd2387g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2387g3-lis2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2547g2-ls.json
+++ b/cameras/hikvision/ds-2cd2547g2-ls.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2647g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2647g2ht-lizs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2667g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2667g2ht-lizs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2687g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2687g2ht-lizs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE+ (802.3at, Class 4, max 18 W) / 12 VDC"

--- a/cameras/hikvision/ds-2cd2687g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2687g2t-lzs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2747g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2747g2ht-lizs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2747g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2747g2t-lzs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2767g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2767g2ht-lizs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2787g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2787g2ht-lizs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2787g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2787g2t-lzs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2h87g3-lizsy.json
+++ b/cameras/hikvision/ds-2cd2h87g3-lizsy.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE+ (802.3at, Class 4, max 20 W) / 12 VDC"

--- a/cameras/hikvision/ds-2cd2t27g2-l.json
+++ b/cameras/hikvision/ds-2cd2t27g2-l.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t67g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t67g2h-li.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t87g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t87g2h-li.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE+ (802.3at, Class 4, max 18 W) / 12 VDC"

--- a/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2ce16d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce16d0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce16d0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce16d0t-lpfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 25
+    "range_m": 25,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce16d0t-lxts.json
+++ b/cameras/hikvision/ds-2ce16d0t-lxts.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "105 horizontal (2.8mm) / 87 horizontal (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC",

--- a/cameras/hikvision/ds-2ce16k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce16k0t-lfs.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "104.9 (2.8mm) / 81.3 (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce16k0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce16k0t-lpfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 25
+    "range_m": 25,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce17d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce17d0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce17k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce17k0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce18k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce18k0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce76d0t-lmfs.json
+++ b/cameras/hikvision/ds-2ce76d0t-lmfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce76d0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce76d0t-lpfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce76k0t-lmfs.json
+++ b/cameras/hikvision/ds-2ce76k0t-lmfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce76k0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce76k0t-lpfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce78d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce78d0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2ce78k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce78k0t-lfs.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux": 0.01
   },
   "power": {
     "method": "12 VDC"

--- a/cameras/hikvision/ds-2de3a400bw-de-wt5.json
+++ b/cameras/hikvision/ds-2de3a400bw-de-wt5.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2de3a400bw-det5.json
+++ b/cameras/hikvision/ds-2de3a400bw-det5.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hikvision/ds-2de4825wg-e3.json
+++ b/cameras/hikvision/ds-2de4825wg-e3.json
@@ -18,7 +18,8 @@
     "varifocal": true
   },
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/hikvision/ds-2se4c215mwg-e.json
+++ b/cameras/hikvision/ds-2se4c215mwg-e.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE+ / 12 VDC"

--- a/cameras/hikvision/ds-2se4c225mwg-e.json
+++ b/cameras/hikvision/ds-2se4c225mwg-e.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE+ / 12 VDC"

--- a/cameras/hikvision/ds-2se4c425mwg-4g.json
+++ b/cameras/hikvision/ds-2se4c425mwg-4g.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/hikvision/ds-2se7c432mwg-eb.json
+++ b/cameras/hikvision/ds-2se7c432mwg-eb.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "Hi-PoE / 24 VAC"

--- a/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
+++ b/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
@@ -31,7 +31,8 @@
   "field_of_view_deg": "190 horizontal (panoramic) / 60.2-2.3 horizontal (PTZ)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 400
+    "range_m": 400,
+    "min_lux_color": 0.0005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/hikvision/ds-2sf8c442mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c442mxg1-elw.json
@@ -22,7 +22,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 300
+    "range_m": 300,
+    "min_lux_color": 0.0003
   },
   "power": {
     "method": "Hi-PoE (802.3bt) / 36 VDC"

--- a/cameras/hikvision/ds-2sf8c848mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c848mxg1-elw.json
@@ -22,7 +22,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 500
+    "range_m": 500,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "Hi-PoE (802.3bt Type4) / 36 VDC"

--- a/cameras/hilook/ipc-d140ha-lu.json
+++ b/cameras/hilook/ipc-d140ha-lu.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "107 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -58,7 +59,8 @@
     "Hikvision NVR compatible"
   ],
   "sources": [
-    "https://www.hikvision.com/en/products/HiLook-IP-Products/"
+    "https://www.hikvision.com/en/products/HiLook-IP-Products/",
+    "https://www.hilooksecurity.com/europe/products/hilook-ip-products/Network-Cameras/Value-Camera/ipc-d140ha-lu/"
   ],
   "power_source": [
     "poe",

--- a/cameras/hilook/ptz-n2c200m-de.json
+++ b/cameras/hilook/ptz-n2c200m-de.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "ptz": {
     "autotracking": true

--- a/cameras/hilook/ptz-n2c400m-de.json
+++ b/cameras/hilook/ptz-n2c400m-de.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/mobotix/s74-dual.json
+++ b/cameras/mobotix/s74-dual.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3at)"

--- a/cameras/speco/o8fd1.json
+++ b/cameras/speco/o8fd1.json
@@ -32,7 +32,8 @@
   "field_of_view_deg": "110 H",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux": 0.008
   },
   "power": {
     "method": "PoE (IEEE 802.3af)"

--- a/cameras/synology/cc400w.json
+++ b/cameras/synology/cc400w.json
@@ -7,8 +7,7 @@
   ],
   "type": "box",
   "connectivity": [
-    "wifi",
-    "ethernet"
+    "wifi"
   ],
   "release_year": 2024,
   "resolution": {
@@ -20,17 +19,17 @@
   "sensor": "CMOS",
   "lens": {
     "count": 1,
-    "focal_length_mm": "2.8 (fixed)",
+    "focal_length_mm": "2.12 (fixed)",
     "aperture": "F2.0",
     "varifocal": false
   },
   "field_of_view_deg": "125 horizontal",
   "night_vision": {
-    "type": "color",
+    "type": "ir",
     "range_m": 10
   },
   "power": {
-    "method": "DC 5V (USB) / WiFi"
+    "method": "DC 5V (USB)"
   },
   "storage": {
     "onboard": true,
@@ -41,11 +40,11 @@
   "protocols": [
     "rtsp"
   ],
-  "ip_rating": "IP67",
+  "ip_rating": "IP65",
   "audio": {
     "microphone": true,
-    "speaker": false,
-    "two_way": false
+    "speaker": true,
+    "two_way": true
   },
   "features": [
     "Synology Surveillance Station integrated",
@@ -54,11 +53,13 @@
     "magnetic mount",
     "compact indoor/outdoor design",
     "instant search",
-    "IP67",
+    "IP65",
     "license-free model"
   ],
   "sources": [
-    "https://nascompares.com/2023/11/29/new-synology-cc400w-camera-revealed/"
+    "https://nascompares.com/2023/11/29/new-synology-cc400w-camera-revealed/",
+    "https://global.synologydownload.com/download/Document/Hardware/ProductSpec/Camera/24-year/CC400W/enu/Product_Spec_CC400W_enu.pdf",
+    "https://global.synologydownload.com/download/Document/Hardware/DataSheet/Camera/24-year/CC400W/enu/Datasheet_CC400W_enu.pdf"
   ],
   "power_source": [
     "usb"
@@ -81,5 +82,5 @@
       "notes": "Use Generic/ONVIF profile via Surveillance Station RTSP output."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-25"
 }

--- a/cameras/uniview/ipc2224se-df40k-wl-i0.json
+++ b/cameras/uniview/ipc2224se-df40k-wl-i0.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "83 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/uniview/ipc2228se-df40k-wl-i0.json
+++ b/cameras/uniview/ipc2228se-df40k-wl-i0.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "89 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/uniview/ipc3612sb-adf28km-i0-wl.json
+++ b/cameras/uniview/ipc3612sb-adf28km-i0-wl.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "97 horizontal",
   "night_vision": {
     "type": "color",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/vigi/c540v.json
+++ b/cameras/vigi/c540v.json
@@ -53,7 +53,8 @@
   "field_of_view_deg": "Horizontal: 84°, Vertical: 46°, Diagonal: 100°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/vigi/insight-lpr345z.json
+++ b/cameras/vigi/insight-lpr345z.json
@@ -51,7 +51,8 @@
   },
   "field_of_view_deg": "Horizontal: 29.6-102.0°, Vertical: 16.8-53.8°, Diagonal: 34.1-122.8°",
   "night_vision": {
-    "type": "color"
+    "type": "color",
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s245.json
+++ b/cameras/vigi/insight-s245.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "2.8mm: H 100°, V 54°, D 118° / 4mm: H 80.4°, V 41.8°, D 98.7°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s285.json
+++ b/cameras/vigi/insight-s285.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "2.8mm: H 110°, V 58.1°, D 133.5° / 4mm: H 88°, V 46°, D 105.4°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s345-4g.json
+++ b/cameras/vigi/insight-s345-4g.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "Horizontal: 86°, Vertical: 43°, Diagonal: 95°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "DC",

--- a/cameras/vigi/insight-s345s.json
+++ b/cameras/vigi/insight-s345s.json
@@ -53,7 +53,8 @@
   "field_of_view_deg": "Horizontal: 95°, Vertical: 51°, Diagonal: 115°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s385.json
+++ b/cameras/vigi/insight-s385.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "Horizontal: 91.5°, Vertical: 46.1°, Diagonal: 109.6°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s385dps.json
+++ b/cameras/vigi/insight-s385dps.json
@@ -53,7 +53,8 @@
   "field_of_view_deg": "Horizontal: 180°, Vertical: 51°, Diagonal: 180°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s445.json
+++ b/cameras/vigi/insight-s445.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "2.8mm: H 100°, V 54°, D 118° / 4mm: H 80.4°, V 41.8°, D 98.7°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s445s.json
+++ b/cameras/vigi/insight-s445s.json
@@ -53,7 +53,8 @@
   "field_of_view_deg": "Horizontal: 112.5°, Vertical: 61.4°, Diagonal: 137°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s455.json
+++ b/cameras/vigi/insight-s455.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "2.8mm: H 111.4°, V 58.8°, D 134° / 4mm: H 88°, V 46°, D 105.4°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",

--- a/cameras/vigi/insight-s485.json
+++ b/cameras/vigi/insight-s485.json
@@ -52,7 +52,8 @@
   "field_of_view_deg": "Horizontal: 111.4°, Vertical: 58.8°, Diagonal: 134°",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE / DC",


### PR DESCRIPTION
## What does this PR do?

Enrich data set with minimum illumination level (based on data from datasheet, specified in in sources)
---

## Checklist

### For corrections
- [X] Include a source URL confirming the correct value
- [X] `npm run build` passes locally with no errors

---

## Source(s)

sources used are the datasheets listed in the camera.json sources

---

## Notes

Where a minimum illumination for color image has been specified this has been stored in the min_lux_color attribute; otherwise, if no mention of color image, or a black & white image has been specified, this has been stored in the generic "min_lux" attribute.

|Total cameras:                        |    2540   |             |
|--------------------------------|----------|----------| 
|Entries with 'night_vision':     |      2482 |              |
|Entries with 'min_lux':            |         31  |   1.25% |
|Entries with 'min_lux_color':  |       300  |  12.09% |
