### PR TITLE
Add validation script to check if listed sources are still available

### DIFF
--- a/docs/check-sources.md
+++ b/docs/check-sources.md
@@ -1,0 +1,73 @@
+## Source URL Validation (`check-sources.js`)
+
+### Purpose
+Camera manufacturer websites frequently undergo redesigns, archive legacy spec sheets, or update CDN paths for technical documents. The `check-sources` script automatically verifies that all URLs listed in the `sources` field across camera database JSON files remain accessible and readable.
+
+To keep checks fast and minimize bandwidth usage, the script attempts a lightweight `HEAD` request first before falling back to a stream-canceled `GET` request (to handle CDNs or servers that block `HEAD` methods).
+
+---
+
+### Features
+* **PDF vs. Webpage Separation:** Distinguishes between `.pdf` spec sheets/manuals and general web pages for clearer status tracking.
+* **Smart Fallbacks:** Handles anti-scraping 403/405 responses from vendor CDNs using proper browser headers and fallback stream cancellations.
+* **Targeted Scanning:** Supports filtering by brand or filename pattern so you can test specific vendors without querying the entire database.
+* **CI-Friendly:** Exits with status code `0` when all links are healthy, or `1` when broken URLs are detected (suitable for automated GitHub Actions checks).
+
+---
+
+### Usage
+
+
+```bash
+
+# Run the validator against the entire database:
+npm run check-sources
+
+# Check only Reolink cameras
+npm run check-sources -- reolink
+
+# Check Hivision cameras using wildcards
+npm run check-sources -- "dahua/*g3*"
+
+# Check a specific model range across vendors
+npm run check-sources -- "*823*"
+```
+
+### Example Output
+
+```bash
+
+npm notice run cctv-camera-database@1.52.0 check-sources
+npm notice run node scripts/check-sources.js reolink/*argus*
+Scanning database folder: /home/frank/cctv-camera-database/cameras
+Applying filter pattern: "reolink/*argus*"
+Matched 17 file(s) across 1 brand(s).
+
+📦 Brand: reolink (27 total unique sources)
+  📄 PDF Documents (3):
+     ✓ ✓ ✓ 
+
+  📄 Web Pages & Other (24):
+     ✗ ✓ ✓ ✓ ✓ ✓ ✓ ✗ ✗ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✗ ✓ ✓ 
+
+--- VALIDATION REPORT ---
+❌ Found 4 dead/unreachable source URL(s):
+
+URL: https://reolink.com/au/product/argus-3-pro/
+  Reason : Status 404 (Not Found)
+  Used in: reolink-argus-3-pro-au
+---
+URL: https://reolink.com/us/product/argus-3-ultra/
+  Reason : Status 404 (Not Found)
+  Used in: reolink-argus-3-ultra
+---
+URL: https://reolink.com/at/product/argus-4-pro/
+  Reason : Status 404 (Not Found)
+  Used in: reolink-argus-4-pro-at
+---
+URL: https://reolink.com/de/product/argus-solar/
+  Reason : Status 404 (Not Found)
+  Used in: reolink-argus-solar
+---
+
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",
     "add": "node scripts/add-camera.js",
-    "add-camera": "node scripts/add-camera.js"
+    "add-camera": "node scripts/add-camera.js",
+    "check-sources": "node scripts/check-sources.js"
   },
   "license": "CC0-1.0",
   "homepage": "https://cctv-database.com",

--- a/scripts/check-sources.js
+++ b/scripts/check-sources.js
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * Generates a human-readable markdown doc for each camera JSON file into
+ * docs/cameras/<brand>/<model>.md (mirroring the cameras/ tree), so the docs
+ * never drift from the data and cameras/ stays pure source. These are a
+ * generated artifact — served via GitHub Pages and refreshed by CI; do not
+ * hand-edit and do not commit them from a contributor PR. Run after build.js.
+ *
+ * Usage: node scripts/check-sources.js
+ */
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const TIMEOUT_MS = 8000;
+const BATCH_SIZE = 5; // Concurrency per vendor batch
+
+/**
+ * Simple glob matcher to convert patterns like "reolink/*823*" into RegExp.
+ */
+function compilePattern(pattern) {
+  if (!pattern) return null;
+  // Normalize path separators
+  const normalized = pattern.replace(/\\/g, '/');
+  
+  // Convert standard glob wildcards (* and ?) into regex equivalents
+  const regexString = '^' + normalized
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape special regex chars (except * and ?)
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.') + '$';
+
+  return new RegExp(regexString, 'i');
+}
+
+/**
+ * Recursively scans directory for camera JSON files.
+ */
+async function findJsonFiles(dir, baseDir = dir) {
+  let results = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(await findJsonFiles(fullPath, baseDir));
+    } else if (entry.isFile() && entry.name.endsWith('.json')) {
+      // Calculate relative path for easy pattern matching (e.g., "reolink/rlc-823a.json")
+      const relativePath = path.relative(baseDir, fullPath).replace(/\\/g, '/');
+      results.push({ fullPath, relativePath });
+    }
+  }
+  return results;
+}
+
+/**
+ * Checks if a URL is accessible using HEAD with a GET fallback.
+ */
+async function checkUrl(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  const headers = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) CCTV-Database-Validator/1.0',
+  };
+
+  try {
+    let response = await fetch(url, {
+      method: 'HEAD',
+      headers,
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+
+    if (!response.ok && response.status !== 404) {
+      const getController = new AbortController();
+      const getTimer = setTimeout(() => getController.abort(), TIMEOUT_MS);
+
+      try {
+        response = await fetch(url, {
+          method: 'GET',
+          headers,
+          signal: getController.signal,
+          redirect: 'follow',
+        });
+        
+        if (response.body) {
+          await response.body.cancel();
+        }
+      } finally {
+        clearTimeout(getTimer);
+      }
+    }
+
+    return {
+      url,
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+    };
+  } catch (err) {
+    return {
+      url,
+      ok: false,
+      status: 0,
+      error: err.name === 'AbortError' ? 'Timeout' : err.message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function processInBatches(items, batchSize, fn) {
+  const results = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const chunk = items.slice(i, i + batchSize);
+    const chunkResults = await Promise.all(chunk.map(fn));
+    results.push(...chunkResults);
+  }
+  return results;
+}
+
+async function run() {
+  const relativeTargetDir = path.join('.', 'cameras');
+  const targetDir = path.resolve(relativeTargetDir);
+  const userFilter = process.argv[2]; // Capture command line argument
+  const filterRegex = compilePattern(userFilter);
+
+  console.log(`Scanning database folder: ${relativeTargetDir}`);
+  if (userFilter) {
+    console.log(`Applying filter pattern: "${userFilter}"`);
+  }
+
+  const files = await findJsonFiles(targetDir);
+  
+  // Filter files based on vendor folder / filename match
+  const matchedFiles = files.filter((f) => {
+    if (!filterRegex) return true;
+    const vendorDir = f.relativePath.split('/')[0];
+    return filterRegex.test(f.relativePath) || filterRegex.test(vendorDir);
+  });
+
+  if (matchedFiles.length === 0) {
+    console.log('\n❌ No camera files matched your search filter.');
+    process.exit(0);
+  }
+
+  // Group matched files by Brand / Vendor folder name
+  const vendorGroups = new Map();
+
+  for (const file of matchedFiles) {
+    const parts = file.relativePath.split('/');
+    const brand = parts.length > 1 ? parts[0] : 'Root';
+
+    if (!vendorGroups.has(brand)) {
+      vendorGroups.set(brand, []);
+    }
+
+    try {
+      const content = await fs.readFile(file.fullPath, 'utf8');
+      const json = JSON.parse(content);
+      const entries = Array.isArray(json) ? json : [json];
+
+      for (const entry of entries) {
+        if (Array.isArray(entry.sources) && entry.sources.length > 0) {
+          vendorGroups.get(brand).push({
+            file: file.relativePath,
+            id: entry.id || entry.model || file.relativePath,
+            sources: entry.sources,
+          });
+        }
+      }
+    } catch (e) {
+      console.warn(`Warning: Failed to parse ${file.relativePath}: ${e.message}`);
+    }
+  }
+
+  console.log(`Matched ${matchedFiles.length} file(s) across ${vendorGroups.size} brand(s).\n`);
+
+  const deadUrlsReport = [];
+
+  // Helper function to check a URL list and stream output
+  async function checkUrlGroup(urls, urlToEntriesMap, label) {
+    if (urls.length === 0) return;
+
+    console.log(`  📄 ${label} (${urls.length}):`);
+    process.stdout.write('     ');
+
+    const results = await processInBatches(urls, BATCH_SIZE, async (url) => {
+      const res = await checkUrl(url);
+      if (res.ok) {
+        process.stdout.write('✓ ');
+      } else {
+        process.stdout.write('✗ ');
+      }
+      return res;
+    });
+
+    process.stdout.write('\n\n');
+
+    for (const res of results) {
+      if (!res.ok) {
+        deadUrlsReport.push({
+          url: res.url,
+          status: res.status,
+          error: res.error || res.statusText,
+          usedIn: urlToEntriesMap.get(res.url),
+        });
+      }
+    }
+  }
+
+  // Process brand by brand
+  for (const [brand, entries] of vendorGroups.entries()) {
+    const urlToEntriesMap = new Map();
+    for (const item of entries) {
+      for (const url of item.sources) {
+        if (!urlToEntriesMap.has(url)) {
+          urlToEntriesMap.set(url, []);
+        }
+        urlToEntriesMap.get(url).push(item.id);
+      }
+    }
+
+    const allUrls = Array.from(urlToEntriesMap.keys());
+    if (allUrls.length === 0) continue;
+
+    // Split URLs into PDFs vs Non-PDFs
+    const pdfUrls = [];
+    const otherUrls = [];
+
+    for (const url of allUrls) {
+      // Strips query strings/anchors (e.g., .pdf?v=1.2) before checking extension
+      const cleanUrl = url.split('?')[0].split('#')[0];
+      if (cleanUrl.toLowerCase().endsWith('.pdf')) {
+        pdfUrls.push(url);
+      } else {
+        otherUrls.push(url);
+      }
+    }
+
+    console.log(`📦 Brand: ${brand} (${allUrls.length} total unique sources)`);
+
+    // Process PDF and Web Page batches separately
+    await checkUrlGroup(pdfUrls, urlToEntriesMap, 'PDF Documents');
+    await checkUrlGroup(otherUrls, urlToEntriesMap, 'Web Pages & Other');
+  }
+
+  // Final summary
+  console.log('--- VALIDATION REPORT ---');
+  if (deadUrlsReport.length === 0) {
+    console.log('🎉 All checked sources are valid and accessible!');
+    process.exit(0);
+  }
+
+  console.log(`❌ Found ${deadUrlsReport.length} dead/unreachable source URL(s):\n`);
+  for (const item of deadUrlsReport) {
+    console.log(`URL: ${item.url}`);
+    console.log(`  Reason : Status ${item.status || 'ERROR'} (${item.error})`);
+    console.log(`  Used in: ${item.usedIn.join(', ')}`);
+    console.log('---');
+  }
+
+  process.exit(1);
+}
+
+run().catch((err) => {
+  console.error('Script failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What does this PR do?

Add validation/check script which checks the accessibility/availability of the listed sources, and report any issues observed.

---

## Checklist

### For schema / tooling changes
- [X] Existing cameras still validate (`npm run build`)
- [ ] Updated `docs/glossary.md` if new fields were added

---

## Source(s)

N/A

---

## Notes

Camera manufacturer websites frequently undergo redesigns, archive legacy spec sheets, or update CDN paths for technical documents. The `check-sources` script automatically verifies that all URLs listed in the `sources` field across camera database JSON files remain accessible and readable.

To keep checks fast and minimize bandwidth usage, the script attempts a lightweight `HEAD` request first before falling back to a stream-canceled `GET` request (to handle CDNs or servers that block `HEAD` methods).

---

### Features
* **PDF vs. Webpage Separation:** Distinguishes between `.pdf` spec sheets/manuals and general web pages for clearer status tracking.
* **Smart Fallbacks:** Handles anti-scraping 403/405 responses from vendor CDNs using proper browser headers and fallback stream cancellations.
* **Targeted Scanning:** Supports filtering by brand or filename pattern so you can test specific vendors without querying the entire database.
* **CI-Friendly:** Exits with status code `0` when all links are healthy, or `1` when broken URLs are detected (suitable for automated GitHub Actions checks).

### Documentation

Documentation for using the script included in docs/check-sources.md  -- I have not included this in the general README.md or CONTRIBUTING.md as this is probably more a database maintenance tool instead of general contributor's tool.