### PR TITLE
data: backfill video.streams[] — Dahua (168 cameras, 9 batches) (#177)

### DIFF
--- a/cameras/dahua/ipc-hdbw2241r-zas.json
+++ b/cameras/dahua/ipc-hdbw2241r-zas.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2241r-zs.json
+++ b/cameras/dahua/ipc-hdbw2241r-zs.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2249e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2249e-s-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2249f-as-il.json
+++ b/cameras/dahua/ipc-hdbw2249f-as-il.json
@@ -32,7 +32,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2449e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2449e-s-il.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2449f-as-il.json
+++ b/cameras/dahua/ipc-hdbw2449f-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2541e-s.json
+++ b/cameras/dahua/ipc-hdbw2541e-s.json
@@ -35,7 +35,21 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdbw2541r-zs.json
+++ b/cameras/dahua/ipc-hdbw2541r-zs.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2649e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2649e-s-il.json
@@ -29,7 +29,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdbw2841e-s.json
+++ b/cameras/dahua/ipc-hdbw2841e-s.json
@@ -29,7 +29,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2841r-zas.json
+++ b/cameras/dahua/ipc-hdbw2841r-zas.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw2841r-zs.json
+++ b/cameras/dahua/ipc-hdbw2841r-zs.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdbw3467r-zas-il.json
+++ b/cameras/dahua/ipc-hdbw3467r-zas-il.json
@@ -34,11 +34,31 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 11.0
+    "consumption_w": 11
   },
   "storage": {
     "onboard": true,

--- a/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.json
+++ b/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.json
+++ b/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-hdw2241t-s.json
+++ b/cameras/dahua/ipc-hdw2241t-s.json
@@ -25,7 +25,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 30, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2241t-zs.json
+++ b/cameras/dahua/ipc-hdw2241t-zs.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2241tm-s.json
+++ b/cameras/dahua/ipc-hdw2241tm-s.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2249t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2249t-s-pro.json
@@ -35,7 +35,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 12V / PoE"

--- a/cameras/dahua/ipc-hdw2249t-s-pv.json
+++ b/cameras/dahua/ipc-hdw2249t-s-pv.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2249th-s-prox.json
+++ b/cameras/dahua/ipc-hdw2249th-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2249tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2249tm-s-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2441t-s.json
+++ b/cameras/dahua/ipc-hdw2441t-s.json
@@ -25,7 +25,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "2688x1520", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2441t-zs.json
+++ b/cameras/dahua/ipc-hdw2441t-zs.json
@@ -29,7 +29,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2441tm-s.json
+++ b/cameras/dahua/ipc-hdw2441tm-s.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2449t-s-il.json
+++ b/cameras/dahua/ipc-hdw2449t-s-il.json
@@ -27,7 +27,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "2688x1520", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2449t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2449t-s-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2449t-s-pv.json
+++ b/cameras/dahua/ipc-hdw2449t-s-pv.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE / DC 12V",

--- a/cameras/dahua/ipc-hdw2449th-s-prox.json
+++ b/cameras/dahua/ipc-hdw2449th-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2541t-s.json
+++ b/cameras/dahua/ipc-hdw2541t-s.json
@@ -34,11 +34,25 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1688",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 5.0
+    "consumption_w": 5
   },
   "storage": {
     "onboard": true,

--- a/cameras/dahua/ipc-hdw2541t-zs.json
+++ b/cameras/dahua/ipc-hdw2541t-zs.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2541tm-s.json
+++ b/cameras/dahua/ipc-hdw2541tm-s.json
@@ -29,11 +29,25 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1688",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",
-    "consumption_w": 5.0
+    "consumption_w": 5
   },
   "storage": {
     "onboard": true,

--- a/cameras/dahua/ipc-hdw2649t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2649t-s-pro.json
@@ -35,7 +35,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2841t-s.json
+++ b/cameras/dahua/ipc-hdw2841t-s.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2841tm-s.json
+++ b/cameras/dahua/ipc-hdw2841tm-s.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2849h-s-prox.json
+++ b/cameras/dahua/ipc-hdw2849h-s-prox.json
@@ -35,7 +35,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2849t-s-il.json
+++ b/cameras/dahua/ipc-hdw2849t-s-il.json
@@ -27,7 +27,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2849t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2849t-s-pro.json
@@ -27,7 +27,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw2849tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2849tm-s-il.json
@@ -26,7 +26,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw3449h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3449h-zas-pv-pro.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/dahua/ipc-hdw3649h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3649h-zas-pv-pro.json
@@ -22,7 +22,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hdw3841t-zs-s2.json
+++ b/cameras/dahua/ipc-hdw3841t-zs-s2.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hdw3849h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3849h-zas-pv-pro.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-hfw21249t-as-il.json
+++ b/cameras/dahua/ipc-hfw21249t-as-il.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4480x2512",
+        "fps": 15,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw21249t-s-il.json
+++ b/cameras/dahua/ipc-hfw21249t-s-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4480x2512",
+        "fps": 15,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2241t-as.json
+++ b/cameras/dahua/ipc-hfw2241t-as.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2241t-zas.json
+++ b/cameras/dahua/ipc-hfw2241t-zas.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2241t-zs.json
+++ b/cameras/dahua/ipc-hfw2241t-zs.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2249m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2249m-s-b-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE / DC 12V",

--- a/cameras/dahua/ipc-hfw2249s-s-il.json
+++ b/cameras/dahua/ipc-hfw2249s-s-il.json
@@ -29,7 +29,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2249t-as-il.json
+++ b/cameras/dahua/ipc-hfw2249t-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw2249t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2249t-zas-il.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2249tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2249tl-s-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw2249tl-s-prox.json
+++ b/cameras/dahua/ipc-hfw2249tl-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2249tl-s-pv.json
+++ b/cameras/dahua/ipc-hfw2249tl-s-pv.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2441t-as.json
+++ b/cameras/dahua/ipc-hfw2441t-as.json
@@ -29,7 +29,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2441t-zas.json
+++ b/cameras/dahua/ipc-hfw2441t-zas.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2441t-zs.json
+++ b/cameras/dahua/ipc-hfw2441t-zs.json
@@ -18,7 +18,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw2449dg-4g-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hfw2449dg-4g-zas-pv-pro.json
@@ -29,7 +29,15 @@
     "codecs": [
       "H.265"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/ipc-hfw2449tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2449tl-s-prox.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2449tl-s-pv.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-pv.json
@@ -22,7 +22,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw2541s-s.json
+++ b/cameras/dahua/ipc-hfw2541s-s.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2541t-as.json
+++ b/cameras/dahua/ipc-hfw2541t-as.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2541t-zas.json
+++ b/cameras/dahua/ipc-hfw2541t-zas.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2541t-zs.json
+++ b/cameras/dahua/ipc-hfw2541t-zs.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2549tl-s-pv.json
+++ b/cameras/dahua/ipc-hfw2549tl-s-pv.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1688",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2649m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2649m-s-b-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw2649s-s-il.json
+++ b/cameras/dahua/ipc-hfw2649s-s-il.json
@@ -33,7 +33,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2649tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2649tl-s-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2841s-s.json
+++ b/cameras/dahua/ipc-hfw2841s-s.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2841t-as.json
+++ b/cameras/dahua/ipc-hfw2841t-as.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2841t-zs.json
+++ b/cameras/dahua/ipc-hfw2841t-zs.json
@@ -21,7 +21,21 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw2849m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2849m-s-b-pro.json
@@ -35,7 +35,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2849tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2849tl-s-pro.json
@@ -14,7 +14,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw3449t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3449t1-as-pv.json
@@ -14,7 +14,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "2688x1520", "fps": 30, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw3549t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3549t1-as-pv.json
@@ -14,7 +14,11 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "2592x1944", "fps": 20, "codec": "H.265" },
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-hfw3667e-as-il.json
+++ b/cameras/dahua/ipc-hfw3667e-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw3867e-as-il.json
+++ b/cameras/dahua/ipc-hfw3867e-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw5849t1-ase-led.json
+++ b/cameras/dahua/ipc-hfw5849t1-ase-led.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.2\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-pdw2849-a180-s-pv.json
+++ b/cameras/dahua/ipc-pdw2849-a180-s-pv.json
@@ -29,7 +29,27 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.json
@@ -36,7 +36,27 @@
       "H.264B",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5000x2500",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4320x1944",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5000x2500",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4320x1944",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-pfw81642-a180.json
+++ b/cameras/dahua/ipc-pfw81642-a180.json
@@ -36,7 +36,27 @@
       "H.264B",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5520x2700",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x620",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x940",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V / AC 24V",

--- a/cameras/dahua/ipc-pfw83242-a180-s2.json
+++ b/cameras/dahua/ipc-pfw83242-a180-s2.json
@@ -24,7 +24,27 @@
       "H.264B",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "8192x3840",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x600",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "2304x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.json
+++ b/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/mptz1100-2030ra.json
+++ b/cameras/dahua/mptz1100-2030ra.json
@@ -30,7 +30,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/ptz1a225-hnr-gb.json
+++ b/cameras/dahua/ptz1a225-hnr-gb.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 12 VDC",

--- a/cameras/dahua/ptz37225-hnp-gb-a.json
+++ b/cameras/dahua/ptz37225-hnp-gb-a.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "36 VDC",

--- a/cameras/dahua/ptz4m231-hnr-ga.json
+++ b/cameras/dahua/ptz4m231-hnr-ga.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/ptz83440-hnr-ga-s.json
+++ b/cameras/dahua/ptz83440-hnr-ga-s.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/ptz85260-hnf-pa-fl.json
+++ b/cameras/dahua/ptz85260-hnf-pa-fl.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/ptz85260-hnf-pa.json
+++ b/cameras/dahua/ptz85260-hnf-pa.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "36 VDC, 5 A (±25%)",

--- a/cameras/dahua/ptz85448-hnf-pa-fl.json
+++ b/cameras/dahua/ptz85448-hnf-pa-fl.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 36V",

--- a/cameras/dahua/ptz85448-hnf-pa.json
+++ b/cameras/dahua/ptz85448-hnf-pa.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 36V",

--- a/cameras/dahua/ptz85848-hnf-pa-fl.json
+++ b/cameras/dahua/ptz85848-hnf-pa-fl.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 36V",

--- a/cameras/dahua/ptz85848-hnf-pa.json
+++ b/cameras/dahua/ptz85848-hnf-pa.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 36V",

--- a/cameras/dahua/sd49225db-hny.json
+++ b/cameras/dahua/sd49225db-hny.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd49425db-hny-gq.json
+++ b/cameras/dahua/sd49425db-hny-gq.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/sd4a216db-hny.json
+++ b/cameras/dahua/sd4a216db-hny.json
@@ -22,7 +22,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/dahua/sd4a425db-hny-r.json
+++ b/cameras/dahua/sd4a425db-hny-r.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4a425db-hny.json
+++ b/cameras/dahua/sd4a425db-hny.json
@@ -33,7 +33,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/sd4e225gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225gb-hnr-a-pv1.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e225mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225mb-hnr-a-pv1.json
@@ -26,7 +26,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e425gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425gb-hnr-a-pv1.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e425mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425mb-hnr-a-pv1.json
@@ -33,7 +33,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/sd4e825mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825mb-hnr-a-pv1.json
@@ -26,7 +26,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4f420da-hny.json
+++ b/cameras/dahua/sd4f420da-hny.json
@@ -35,7 +35,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/sd52c225db-hny.json
+++ b/cameras/dahua/sd52c225db-hny.json
@@ -24,7 +24,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd52c232gb-hnr.json
+++ b/cameras/dahua/sd52c232gb-hnr.json
@@ -24,7 +24,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd52c432gb-hnr.json
+++ b/cameras/dahua/sd52c432gb-hnr.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",

--- a/cameras/dahua/sd5a245gb-hnr.json
+++ b/cameras/dahua/sd5a245gb-hnr.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd5a425ma-hnr.json
+++ b/cameras/dahua/sd5a425ma-hnr.json
@@ -22,7 +22,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/dahua/sd5a425mb-hnr.json
+++ b/cameras/dahua/sd5a425mb-hnr.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd5a432mb-hnr.json
+++ b/cameras/dahua/sd5a432mb-hnr.json
@@ -33,7 +33,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",

--- a/cameras/dahua/sd5a445gb-hnr.json
+++ b/cameras/dahua/sd5a445gb-hnr.json
@@ -25,7 +25,27 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd5a445mb-hnr.json
+++ b/cameras/dahua/sd5a445mb-hnr.json
@@ -30,7 +30,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24V AC",

--- a/cameras/dahua/sd5a825gb-hnr.json
+++ b/cameras/dahua/sd5a825gb-hnr.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24V AC",

--- a/cameras/dahua/sd60432db-hny.json
+++ b/cameras/dahua/sd60432db-hny.json
@@ -35,7 +35,27 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 24V",

--- a/cameras/dahua/sd6al245gb-hnv.json
+++ b/cameras/dahua/sd6al245gb-hnv.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd6al445gb-hnv-ir.json
+++ b/cameras/dahua/sd6al445gb-hnv-ir.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd6al445gb-hnv.json
+++ b/cameras/dahua/sd6al445gb-hnv.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
@@ -26,7 +26,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" STARVIS CMOS",
   "lens": {

--- a/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
@@ -25,7 +25,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/dahua/sd6e232mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e232mb-hnr-a-pv1.json
@@ -31,7 +31,27 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24V DC",

--- a/cameras/dahua/sd6e245mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e245mb-hnr-a-pv1.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd6e425mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e425mb-hnr-a-pv1.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd6e432mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e432mb-hnr-a-pv1.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",

--- a/cameras/dahua/sd6e445mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e445mb-hnr-a-pv1.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd6e825ma-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e825ma-hnr-a-pv1.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd7a440fa-hnf-atc.json
+++ b/cameras/dahua/sd7a440fa-hnf-atc.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3bt) / DC 36V",

--- a/cameras/dahua/sd7a440fa-hnf.json
+++ b/cameras/dahua/sd7a440fa-hnf.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3bt) / 36 VDC",

--- a/cameras/dahua/sd7a840fa-hnf-atc.json
+++ b/cameras/dahua/sd7a840fa-hnf-atc.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3bt) / DC 36V",

--- a/cameras/dahua/sd7a840fa-hnf.json
+++ b/cameras/dahua/sd7a840fa-hnf.json
@@ -36,7 +36,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3bt) / DC 36V",

--- a/cameras/dahua/sd8a3440ga-hnv.json
+++ b/cameras/dahua/sd8a3440ga-hnv.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8a3833ga-hnv.json
+++ b/cameras/dahua/sd8a3833ga-hnv.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd8a440fa-hnp-aid.json
+++ b/cameras/dahua/sd8a440fa-hnp-aid.json
@@ -30,7 +30,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "onvif_ptz": "relative"

--- a/cameras/dahua/sd8a440fa-hnt.json
+++ b/cameras/dahua/sd8a440fa-hnt.json
@@ -33,7 +33,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "HI-PoE (36 VDC/2.23 A)",

--- a/cameras/dahua/sd8a440ga-hnv.json
+++ b/cameras/dahua/sd8a440ga-hnv.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8a440pa-hnf-5g.json
+++ b/cameras/dahua/sd8a440pa-hnf-5g.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8a840fa-hnt.json
+++ b/cameras/dahua/sd8a840fa-hnt.json
@@ -36,7 +36,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE (36 VDC)",

--- a/cameras/dahua/sd8a840pa-hnf-5g.json
+++ b/cameras/dahua/sd8a840pa-hnf-5g.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8a840xa-hnp-wp.json
+++ b/cameras/dahua/sd8a840xa-hnp-wp.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / 36 VDC",

--- a/cameras/dahua/sd8a845qa-hnf.json
+++ b/cameras/dahua/sd8a845qa-hnf.json
@@ -29,7 +29,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8c260pa-hnf.json
+++ b/cameras/dahua/sd8c260pa-hnf.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd8c440fd-hnf.json
+++ b/cameras/dahua/sd8c440fd-hnf.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8c448pa-hnf.json
+++ b/cameras/dahua/sd8c448pa-hnf.json
@@ -30,7 +30,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sd8c448pa1-hnf.json
+++ b/cameras/dahua/sd8c448pa1-hnf.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8c848pa1-hnf.json
+++ b/cameras/dahua/sd8c848pa1-hnf.json
@@ -28,7 +28,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / 36 VDC",

--- a/cameras/dahua/sd8x442fa-hnf.json
+++ b/cameras/dahua/sd8x442fa-hnf.json
@@ -33,7 +33,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8x842fa-hnf.json
+++ b/cameras/dahua/sd8x842fa-hnf.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sdt3a400-ga-hnp-bx.json
+++ b/cameras/dahua/sdt3a400-ga-hnp-bx.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "DC 12V 2A",

--- a/cameras/dahua/sdt4a404-4f-qa.json
+++ b/cameras/dahua/sdt4a404-4f-qa.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/sdt4e225-4f-gb-a-pv1.json
+++ b/cameras/dahua/sdt4e225-4f-gb-a-pv1.json
@@ -38,7 +38,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
+++ b/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
@@ -32,7 +32,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.json
+++ b/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.json
@@ -38,7 +38,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1024x448",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "2048x928",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/sdt5x2425-4z4-fa.json
+++ b/cameras/dahua/sdt5x2425-4z4-fa.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / 36 VDC",

--- a/cameras/dahua/sdt5x425-4z4-fa-0832.json
+++ b/cameras/dahua/sdt5x425-4z4-fa-0832.json
@@ -36,7 +36,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sdt5x425-4z4-fa-2812.json
+++ b/cameras/dahua/sdt5x425-4z4-fa-2812.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sdt5x425-4z4-fajg-2812.json
+++ b/cameras/dahua/sdt5x425-4z4-fajg-2812.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.json
+++ b/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.json
@@ -36,7 +36,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/cameras/dahua/sdt6e425-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt6e425-8p-mb-a-pv1.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1024x448",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "2048x928",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE++ (802.3bt) / DC 36V",

--- a/cameras/dahua/sdt6e432-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt6e432-8p-mb-a-pv1.json
@@ -37,7 +37,27 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1024x448",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "2048x928",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE++ (802.3bt) / DC 36V",

--- a/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
+++ b/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5376x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE++ (802.3bt) / DC",

--- a/cameras/dahua/sdz4032-hnr-zb.json
+++ b/cameras/dahua/sdz4032-hnr-zb.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98023,7 +98023,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.2\" CMOS",
     "lens": {
@@ -99639,7 +99659,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -99820,7 +99854,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -100015,7 +100069,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 12 VDC",
@@ -100112,7 +100186,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "36 VDC",
@@ -100214,7 +100308,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100417,7 +100531,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100514,7 +100648,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "36 VDC, 5 A (±25%)",
@@ -100610,7 +100764,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100711,7 +100885,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -100807,7 +101001,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -100904,7 +101118,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -101002,7 +101236,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -111143,7 +111397,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -87375,7 +87375,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -87639,7 +87659,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -87752,7 +87792,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -88207,7 +88267,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -90271,7 +90351,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4480x2512",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90374,7 +90468,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4480x2512",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90547,7 +90655,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90643,7 +90765,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90740,7 +90876,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90839,7 +90989,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -90932,7 +91096,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91121,7 +91299,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91218,7 +91410,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91317,7 +91523,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91413,7 +91633,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91510,7 +91744,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91844,7 +92092,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91944,7 +92206,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -92026,7 +92302,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -92136,7 +92426,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -92604,7 +92902,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -78766,7 +78766,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -78868,7 +78882,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -78967,7 +78995,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79063,7 +79105,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79435,7 +79491,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79628,7 +79698,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79729,7 +79813,21 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -79923,7 +80021,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80017,7 +80129,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -80200,7 +80326,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80301,7 +80441,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80400,7 +80554,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80926,7 +81094,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -81118,7 +81306,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -81569,7 +81777,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -83312,7 +83540,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -83410,7 +83652,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -83506,7 +83762,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -93014,7 +93014,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93100,7 +93114,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -93210,7 +93238,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93305,7 +93347,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93405,7 +93461,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93502,7 +93572,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93602,7 +93686,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93702,7 +93800,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93799,7 +93911,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94073,7 +94199,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94518,7 +94658,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94619,7 +94773,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94780,7 +94948,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -94893,7 +95075,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95424,7 +95620,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -95685,7 +95895,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -95980,7 +96204,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -96184,7 +96422,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -97235,7 +97487,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -106536,7 +106536,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / 36 VDC",
@@ -106641,7 +106661,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106747,7 +106787,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106843,7 +106903,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106950,7 +107030,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107051,7 +107151,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -107254,7 +107374,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "onvif_ptz": "relative"
@@ -107354,7 +107494,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "HI-PoE (36 VDC/2.23 A)",
@@ -107451,7 +107611,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107554,7 +107734,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107760,7 +107960,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE (36 VDC)",
@@ -107856,7 +108076,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107964,7 +108204,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -108058,7 +108318,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108164,7 +108444,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -108367,7 +108667,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108470,7 +108790,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -108572,7 +108912,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108775,7 +109135,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -108881,7 +109261,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108984,7 +109384,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -83961,7 +83961,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V / PoE"
@@ -84060,7 +84074,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84247,7 +84275,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84342,7 +84384,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84518,7 +84574,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84611,7 +84681,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84713,7 +84797,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84814,7 +84912,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84912,7 +85024,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85009,7 +85135,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -85196,7 +85336,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85380,7 +85534,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85476,7 +85644,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85569,7 +85751,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85849,7 +86045,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86212,7 +86422,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86398,7 +86622,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86497,7 +86735,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86600,7 +86852,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86703,7 +86969,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86894,7 +87174,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98581,7 +98581,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -98685,7 +98705,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5000x2500",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -98787,7 +98827,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4320x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -99070,7 +99130,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5000x2500",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -99171,7 +99251,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4320x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -99366,7 +99466,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5520x2700",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x620",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x940",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V",
@@ -99458,7 +99578,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "8192x3840",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x600",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2304x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -109767,7 +109907,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V 2A",
@@ -109957,7 +110117,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110059,7 +110239,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110255,7 +110455,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -110370,7 +110590,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110563,7 +110803,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -110666,7 +110926,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110770,7 +111050,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110879,7 +111179,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110982,7 +111302,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -111085,7 +111425,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC 36V",
@@ -111190,7 +111550,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC 36V",
@@ -111296,7 +111676,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5376x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -101386,7 +101386,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -101687,7 +101707,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -101870,7 +101910,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -101983,7 +102043,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -102082,7 +102162,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102464,7 +102564,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102564,7 +102684,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102666,7 +102806,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102770,7 +102930,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -102974,7 +103154,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103083,7 +103283,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -103278,7 +103492,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103376,7 +103610,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103481,7 +103735,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -103578,7 +103852,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103675,7 +103969,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -103781,7 +104095,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103982,7 +104316,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -104079,7 +104433,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104185,7 +104559,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V AC",
@@ -104290,7 +104684,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V AC",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -105020,7 +105020,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -105118,7 +105138,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105220,7 +105260,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105325,7 +105385,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105429,7 +105509,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" STARVIS CMOS",
     "lens": {
@@ -105549,7 +105649,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -105667,7 +105787,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V DC",
@@ -105769,7 +105909,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -105878,7 +106038,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -105983,7 +106163,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -106089,7 +106289,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -106188,7 +106408,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98023,7 +98023,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.2\" CMOS",
     "lens": {
@@ -99639,7 +99659,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -99820,7 +99854,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -100015,7 +100069,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 12 VDC",
@@ -100112,7 +100186,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "36 VDC",
@@ -100214,7 +100308,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100417,7 +100531,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100514,7 +100648,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "36 VDC, 5 A (±25%)",
@@ -100610,7 +100764,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -100711,7 +100885,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -100807,7 +101001,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -100904,7 +101118,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -101002,7 +101236,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 36V",
@@ -111143,7 +111397,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -87375,7 +87375,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -87639,7 +87659,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -87752,7 +87792,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -88207,7 +88267,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -90271,7 +90351,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4480x2512",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90374,7 +90468,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4480x2512",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90547,7 +90655,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90643,7 +90765,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90740,7 +90876,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -90839,7 +90989,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -90932,7 +91096,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91121,7 +91299,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91218,7 +91410,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91317,7 +91523,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91413,7 +91633,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91510,7 +91744,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91844,7 +92092,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -91944,7 +92206,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -92026,7 +92302,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -92136,7 +92426,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -92604,7 +92902,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -78766,7 +78766,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -78868,7 +78882,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -78967,7 +78995,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79063,7 +79105,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79435,7 +79491,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79628,7 +79698,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -79729,7 +79813,21 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -79923,7 +80021,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80017,7 +80129,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -80200,7 +80326,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80301,7 +80441,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80400,7 +80554,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -80926,7 +81094,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -81118,7 +81306,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -81569,7 +81777,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -83312,7 +83540,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -83410,7 +83652,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -83506,7 +83762,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -93014,7 +93014,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93100,7 +93114,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -93210,7 +93238,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93305,7 +93347,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93405,7 +93461,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93502,7 +93572,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93602,7 +93686,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -93702,7 +93800,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93799,7 +93911,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94073,7 +94199,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94518,7 +94658,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94619,7 +94773,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -94780,7 +94948,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -94893,7 +95075,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95424,7 +95620,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -95685,7 +95895,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -95980,7 +96204,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -96184,7 +96422,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -97235,7 +97487,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -106536,7 +106536,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / 36 VDC",
@@ -106641,7 +106661,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106747,7 +106787,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106843,7 +106903,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3bt) / DC 36V",
@@ -106950,7 +107030,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107051,7 +107151,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -107254,7 +107374,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "onvif_ptz": "relative"
@@ -107354,7 +107494,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "HI-PoE (36 VDC/2.23 A)",
@@ -107451,7 +107611,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107554,7 +107734,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107760,7 +107960,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE (36 VDC)",
@@ -107856,7 +108076,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -107964,7 +108204,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -108058,7 +108318,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108164,7 +108444,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -108367,7 +108667,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108470,7 +108790,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -108572,7 +108912,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108775,7 +109135,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -108881,7 +109261,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -108984,7 +109384,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -83961,7 +83961,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V / PoE"
@@ -84060,7 +84074,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84247,7 +84275,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84342,7 +84384,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84518,7 +84574,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84611,7 +84681,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84713,7 +84797,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -84814,7 +84912,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84912,7 +85024,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85009,7 +85135,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -85196,7 +85336,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85380,7 +85534,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85476,7 +85644,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85569,7 +85751,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1688",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -85849,7 +86045,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86212,7 +86422,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86398,7 +86622,21 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86497,7 +86735,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86600,7 +86852,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86703,7 +86969,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -86894,7 +87174,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98581,7 +98581,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -98685,7 +98705,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5000x2500",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -98787,7 +98827,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4320x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -99070,7 +99130,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5000x2500",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -99171,7 +99251,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4320x1944",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -99366,7 +99466,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5520x2700",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x620",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x940",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V / AC 24V",
@@ -99458,7 +99578,27 @@
         "H.264B",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "8192x3840",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x600",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2304x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -109767,7 +109907,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V 2A",
@@ -109957,7 +110117,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110059,7 +110239,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110255,7 +110455,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -110370,7 +110590,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -110563,7 +110803,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / 36 VDC",
@@ -110666,7 +110926,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110770,7 +111050,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110879,7 +111179,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -110982,7 +111302,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -111085,7 +111425,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC 36V",
@@ -111190,7 +111550,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1024x448",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "2048x928",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC 36V",
@@ -111296,7 +111676,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5376x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE++ (802.3bt) / DC",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -101386,7 +101386,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -101687,7 +101707,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "DC 12V",
@@ -101870,7 +101910,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -101983,7 +102043,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -102082,7 +102162,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102464,7 +102564,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102564,7 +102684,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102666,7 +102806,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -102770,7 +102930,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -102974,7 +103154,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103083,7 +103283,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -103278,7 +103492,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103376,7 +103610,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103481,7 +103735,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -103578,7 +103852,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103675,7 +103969,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -103781,7 +104095,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -103982,7 +104316,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -104079,7 +104433,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104185,7 +104559,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V AC",
@@ -104290,7 +104684,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V AC",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -105020,7 +105020,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 24V",
@@ -105118,7 +105138,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105220,7 +105260,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105325,7 +105385,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",
@@ -105429,7 +105509,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" STARVIS CMOS",
     "lens": {
@@ -105549,7 +105649,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -105667,7 +105787,27 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24V DC",
@@ -105769,7 +105909,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -105878,7 +106038,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -105983,7 +106163,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -106089,7 +106289,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -106188,7 +106408,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,


### PR DESCRIPTION
Backfills **`video.streams[]`** (per-stream name/resolution/fps/codec) for **168 Dahua cameras** across 9 batches, all extracted from official Dahua **Stream Capability** tables (product pages + datasheet PDFs on materialfile.dahuasecurity.com). Part of the #177 lane.

## Coverage: Dahua 1 → 168 (of 335); dataset-wide streams 573 → 740

| Batch | Series | Cameras |
|-------|--------|---------|
| 1 | WizSense-2 HDBW domes + WizSense-3 | 18 |
| 2 | WizSense-2 HDW turrets | 21 |
| 3 | WizSense-2 HFW bullets + WizSense-3 | 21 |
| 4 | HFW fixed-lens bullets (5/6/8 MP) | 19 |
| 5 | SD4/SD5 PTZ speed domes | 21 |
| 6 | SD6 WizMind PTZ | 12 |
| 7 | SD7/SD8 WizMind PTZ (4G/5G/X) | 21 |
| 8 | PTZ positioning systems + 1 bullet | 14 |
| 9 | A180 panoramic + X-Spans/SDT thermal | 20 |

## Conventions (uniform across batches)
- **main** = the stream's actual output resolution at its full-res frame rate. This is the payoff of per-stream data vs the headline `max_fps`: fixed 5/6/8 MP cameras cap at **20 fps** at full res, while PTZ speed domes run **30/60 fps** — captured per datasheet, never assumed.
- **sub / sub2** = D1 (704×576) + 1080p/720p for standard cams; wide panoramic sub-streams for A180 models.
- **codec** = `H.265` on every stream (MJPEG/H.264 are selectable options, not the primary; canonical form matches the codec enum in #182).
- main resolution sourced from each file's `resolution.max_*` for internal consistency; every apply asserted main == stored max.

## Notable per-model accuracy
- **Stream-vs-sensor**: SD4F420DA / SD6C3432GB main streams top out *below* the sensor's max resolution — recorded the stream value, not the spec-sheet sensor row.
- **Thermal (X-Spans/SDT)**: recorded the **visible/optical** channel only; the radiometric thermal channel is intentionally omitted. Dual-visible "4z4"/"8p" combos use the detail/highest-res visible stream.
- **Panoramic (A180)**: stitched-panorama main stream (up to 8192×3840) + wide sub streams, PDF-verified.
- Dropped uncertain 1-fps "third" slots rather than record a doubtful value.

## Remaining
13 Dahua cameras with a `codecs` list but no `streams[]` were **intentionally excluded** — they overlap the codec-normalization set in **#182**, so they were held back to keep these two PRs conflict-free. They can be a trivial follow-up once #182 merges. The other ~154 lack a `video` block entirely (no codecs), which is out of scope for a streams-only backfill.

Builds clean (2,618 cameras).