### PR TITLE
data: backfill video.streams[] main stream — ACTi (196 cameras) (#177)

### DIFF
--- a/cameras/acti/a213.json
+++ b/cameras/acti/a213.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a214.json
+++ b/cameras/acti/a214.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 40x optical zoom, 10x digital zoom",

--- a/cameras/acti/a313.json
+++ b/cameras/acti/a313.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a315.json
+++ b/cameras/acti/a315.json
@@ -42,7 +42,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a317.json
+++ b/cameras/acti/a317.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5968x2688",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/a371-p1.json
+++ b/cameras/acti/a371-p1.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a371-p2.json
+++ b/cameras/acti/a371-p2.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a371.json
+++ b/cameras/acti/a371.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a372-p1.json
+++ b/cameras/acti/a372-p1.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a372.json
+++ b/cameras/acti/a372.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a374-p1.json
+++ b/cameras/acti/a374-p1.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a374.json
+++ b/cameras/acti/a374.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a377.json
+++ b/cameras/acti/a377.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a412.json
+++ b/cameras/acti/a412.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.4x optical zoom, 10x digital zoom",

--- a/cameras/acti/a416.json
+++ b/cameras/acti/a416.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/a421.json
+++ b/cameras/acti/a421.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/a422.json
+++ b/cameras/acti/a422.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a424.json
+++ b/cameras/acti/a424.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/a426.json
+++ b/cameras/acti/a426.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/a427.json
+++ b/cameras/acti/a427.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a428.json
+++ b/cameras/acti/a428.json
@@ -36,7 +36,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a429.json
+++ b/cameras/acti/a429.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 120
+    "max_fps": 120,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 120,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a432-p1.json
+++ b/cameras/acti/a432-p1.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Basic WDR",

--- a/cameras/acti/a432.json
+++ b/cameras/acti/a432.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 3.6x optical zoom",

--- a/cameras/acti/a570-p1.json
+++ b/cameras/acti/a570-p1.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a570-p2.json
+++ b/cameras/acti/a570-p2.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a570.json
+++ b/cameras/acti/a570.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a573-p1.json
+++ b/cameras/acti/a573-p1.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a573-p2.json
+++ b/cameras/acti/a573-p2.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a573.json
+++ b/cameras/acti/a573.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/a711.json
+++ b/cameras/acti/a711.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/a76.json
+++ b/cameras/acti/a76.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a78.json
+++ b/cameras/acti/a78.json
@@ -46,7 +46,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a810.json
+++ b/cameras/acti/a810.json
@@ -43,7 +43,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/a811.json
+++ b/cameras/acti/a811.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a817.json
+++ b/cameras/acti/a817.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/a820.json
+++ b/cameras/acti/a820.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/a821.json
+++ b/cameras/acti/a821.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (150 dB)",

--- a/cameras/acti/a822.json
+++ b/cameras/acti/a822.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/a826.json
+++ b/cameras/acti/a826.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/a828.json
+++ b/cameras/acti/a828.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.4x optical zoom, 10x digital zoom",

--- a/cameras/acti/a88.json
+++ b/cameras/acti/a88.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 2.85x optical zoom",

--- a/cameras/acti/a912.json
+++ b/cameras/acti/a912.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/a952.json
+++ b/cameras/acti/a952.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 22x optical zoom, 10x digital zoom",

--- a/cameras/acti/a957.json
+++ b/cameras/acti/a957.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 40x optical zoom, 12x digital zoom",

--- a/cameras/acti/a959.json
+++ b/cameras/acti/a959.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 22x optical zoom, 12x digital zoom",

--- a/cameras/acti/a972.json
+++ b/cameras/acti/a972.json
@@ -52,7 +52,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 32x optical zoom",

--- a/cameras/acti/a973.json
+++ b/cameras/acti/a973.json
@@ -46,7 +46,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 32x optical zoom",

--- a/cameras/acti/a981.json
+++ b/cameras/acti/a981.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 30x optical zoom, 12x digital zoom",

--- a/cameras/acti/a982.json
+++ b/cameras/acti/a982.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 120
+    "max_fps": 120,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 60x optical zoom, 16x digital zoom",

--- a/cameras/acti/b412-k1.json
+++ b/cameras/acti/b412-k1.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 10x optical zoom",

--- a/cameras/acti/b416.json
+++ b/cameras/acti/b416.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 30x optical zoom",

--- a/cameras/acti/b511a.json
+++ b/cameras/acti/b511a.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 18
+    "max_fps": 18,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "fps": 18,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/b64.json
+++ b/cameras/acti/b64.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1280x960",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (88 dB)",

--- a/cameras/acti/b76a.json
+++ b/cameras/acti/b76a.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 18
+    "max_fps": 18,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "fps": 18,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/c11w.json
+++ b/cameras/acti/c11w.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1280x1024",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (75 dB)",

--- a/cameras/acti/e13a.json
+++ b/cameras/acti/e13a.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e14.json
+++ b/cameras/acti/e14.json
@@ -43,7 +43,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 7
+    "max_fps": 7,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3648x2736",
+        "fps": 7,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (70 dB)",

--- a/cameras/acti/e16.json
+++ b/cameras/acti/e16.json
@@ -43,7 +43,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 7
+    "max_fps": 7,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3648x2736",
+        "fps": 7,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (70 dB)",

--- a/cameras/acti/e19.json
+++ b/cameras/acti/e19.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (142 dB)",

--- a/cameras/acti/e33a.json
+++ b/cameras/acti/e33a.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e43b.json
+++ b/cameras/acti/e43b.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e54.json
+++ b/cameras/acti/e54.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e618.json
+++ b/cameras/acti/e618.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Superior WDR (110 dB)",

--- a/cameras/acti/e815.json
+++ b/cameras/acti/e815.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/e816.json
+++ b/cameras/acti/e816.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 7
+    "max_fps": 7,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3648x2736",
+        "fps": 7,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/e918.json
+++ b/cameras/acti/e918.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Superior WDR (110 dB)",

--- a/cameras/acti/e918m.json
+++ b/cameras/acti/e918m.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Superior WDR (110 dB)",

--- a/cameras/acti/e925m.json
+++ b/cameras/acti/e925m.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e93.json
+++ b/cameras/acti/e93.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/e96.json
+++ b/cameras/acti/e96.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/i47.json
+++ b/cameras/acti/i47.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Advanced WDR (75 dB)",

--- a/cameras/acti/i96.json
+++ b/cameras/acti/i96.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 30x optical zoom, 16x digital zoom",

--- a/cameras/acti/i98.json
+++ b/cameras/acti/i98.json
@@ -51,7 +51,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 33x optical zoom, 16x digital zoom",

--- a/cameras/acti/j41.json
+++ b/cameras/acti/j41.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/j71.json
+++ b/cameras/acti/j71.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/j72.json
+++ b/cameras/acti/j72.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/j73.json
+++ b/cameras/acti/j73.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/j81.json
+++ b/cameras/acti/j81.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/k31-p1.json
+++ b/cameras/acti/k31-p1.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k31.json
+++ b/cameras/acti/k31.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k32.json
+++ b/cameras/acti/k32.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k33.json
+++ b/cameras/acti/k33.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k372.json
+++ b/cameras/acti/k372.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/k41.json
+++ b/cameras/acti/k41.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k42.json
+++ b/cameras/acti/k42.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k43.json
+++ b/cameras/acti/k43.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k71.json
+++ b/cameras/acti/k71.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k72.json
+++ b/cameras/acti/k72.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k73.json
+++ b/cameras/acti/k73.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/k81.json
+++ b/cameras/acti/k81.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k82.json
+++ b/cameras/acti/k82.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k83.json
+++ b/cameras/acti/k83.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/k9001.json
+++ b/cameras/acti/k9001.json
@@ -43,7 +43,15 @@
     "outdoor"
   ],
   "video": {
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "11520x2700",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Multi-Imager PTZ: fixed 8-sensor 360 degree panoramic array (4MP x8) combined with an independent 42x optical/16x digital zoom PTZ detail camera on the same head",

--- a/cameras/acti/k953.json
+++ b/cameras/acti/k953.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 33x optical zoom, 16x digital zoom",

--- a/cameras/acti/k954.json
+++ b/cameras/acti/k954.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 42x optical zoom",

--- a/cameras/acti/k958.json
+++ b/cameras/acti/k958.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 25x optical zoom, 16x digital zoom",

--- a/cameras/acti/kcm-5611.json
+++ b/cameras/acti/kcm-5611.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "zoom lens: 18x optical zoom",

--- a/cameras/acti/l31-p1.json
+++ b/cameras/acti/l31-p1.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l31.json
+++ b/cameras/acti/l31.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l33-p1.json
+++ b/cameras/acti/l33-p1.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l33.json
+++ b/cameras/acti/l33.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l41.json
+++ b/cameras/acti/l41.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l43.json
+++ b/cameras/acti/l43.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l71.json
+++ b/cameras/acti/l71.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l73-p1.json
+++ b/cameras/acti/l73-p1.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l73.json
+++ b/cameras/acti/l73.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l81.json
+++ b/cameras/acti/l81.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/l83.json
+++ b/cameras/acti/l83.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/pcam-1600.json
+++ b/cameras/acti/pcam-1600.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "body-worn camera",

--- a/cameras/acti/q115.json
+++ b/cameras/acti/q115.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "features": [
     "Basic WDR (74 dB)",

--- a/cameras/acti/q120.json
+++ b/cameras/acti/q120.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "protocols": [
     "rtsp"

--- a/cameras/acti/q121.json
+++ b/cameras/acti/q121.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "protocols": [
     "rtsp"

--- a/cameras/acti/q170.json
+++ b/cameras/acti/q170.json
@@ -36,7 +36,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Basic WDR",

--- a/cameras/acti/q450.json
+++ b/cameras/acti/q450.json
@@ -43,7 +43,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/q550.json
+++ b/cameras/acti/q550.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/q711.json
+++ b/cameras/acti/q711.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/q75.json
+++ b/cameras/acti/q75.json
@@ -44,7 +44,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Advanced WDR (100 dB)",

--- a/cameras/acti/q83.json
+++ b/cameras/acti/q83.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 2.85x optical zoom, 10x digital zoom",

--- a/cameras/acti/q84.json
+++ b/cameras/acti/q84.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/q982-p1.json
+++ b/cameras/acti/q982-p1.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 60x optical zoom, 8x digital zoom",

--- a/cameras/acti/q982-p2.json
+++ b/cameras/acti/q982-p2.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 60x optical zoom, 16x digital zoom",

--- a/cameras/acti/q982.json
+++ b/cameras/acti/q982.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 56x optical zoom, 16x digital zoom",

--- a/cameras/acti/q992.json
+++ b/cameras/acti/q992.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 41x optical zoom, 16x digital zoom",

--- a/cameras/acti/vmgb-359-p1.json
+++ b/cameras/acti/vmgb-359-p1.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/vmgb-359.json
+++ b/cameras/acti/vmgb-359.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/vmgb-370.json
+++ b/cameras/acti/vmgb-370.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "protocols": [
     "rtsp"

--- a/cameras/acti/vmgb-371.json
+++ b/cameras/acti/vmgb-371.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/vmgb-601.json
+++ b/cameras/acti/vmgb-601.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/vmgb-602.json
+++ b/cameras/acti/vmgb-602.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/y31.json
+++ b/cameras/acti/y31.json
@@ -40,7 +40,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog bullet (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/y32.json
+++ b/cameras/acti/y32.json
@@ -40,7 +40,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog bullet (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/y35.json
+++ b/cameras/acti/y35.json
@@ -40,7 +40,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog bullet (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/y55.json
+++ b/cameras/acti/y55.json
@@ -42,7 +42,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog turret (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/y71.json
+++ b/cameras/acti/y71.json
@@ -42,7 +42,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog turret (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/y72.json
+++ b/cameras/acti/y72.json
@@ -40,7 +40,15 @@
   ],
   "video": {
     "codecs": [],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "analog turret (TVI/AHD/CVI/CVBS)",

--- a/cameras/acti/z310.json
+++ b/cameras/acti/z310.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z315.json
+++ b/cameras/acti/z315.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z316-p1.json
+++ b/cameras/acti/z316-p1.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z316.json
+++ b/cameras/acti/z316.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z317-p1.json
+++ b/cameras/acti/z317-p1.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z317.json
+++ b/cameras/acti/z317.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z318.json
+++ b/cameras/acti/z318.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z319.json
+++ b/cameras/acti/z319.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z322.json
+++ b/cameras/acti/z322.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z324.json
+++ b/cameras/acti/z324.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/z325.json
+++ b/cameras/acti/z325.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z330-p1.json
+++ b/cameras/acti/z330-p1.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z330.json
+++ b/cameras/acti/z330.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z331-p1.json
+++ b/cameras/acti/z331-p1.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z331.json
+++ b/cameras/acti/z331.json
@@ -38,7 +38,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z332.json
+++ b/cameras/acti/z332.json
@@ -48,7 +48,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z41.json
+++ b/cameras/acti/z41.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z411.json
+++ b/cameras/acti/z411.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 22x optical zoom, digital zoom via NVR server",

--- a/cameras/acti/z412.json
+++ b/cameras/acti/z412.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z413-p1.json
+++ b/cameras/acti/z413-p1.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z415.json
+++ b/cameras/acti/z415.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (145 dB)",

--- a/cameras/acti/z416.json
+++ b/cameras/acti/z416.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 12x optical zoom, 16x digital zoom",

--- a/cameras/acti/z419.json
+++ b/cameras/acti/z419.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z429.json
+++ b/cameras/acti/z429.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/z47.json
+++ b/cameras/acti/z47.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z49.json
+++ b/cameras/acti/z49.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z510.json
+++ b/cameras/acti/z510.json
@@ -48,7 +48,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z511.json
+++ b/cameras/acti/z511.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z512.json
+++ b/cameras/acti/z512.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z53.json
+++ b/cameras/acti/z53.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z54.json
+++ b/cameras/acti/z54.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/z56.json
+++ b/cameras/acti/z56.json
@@ -47,7 +47,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z64.json
+++ b/cameras/acti/z64.json
@@ -45,7 +45,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z714.json
+++ b/cameras/acti/z714.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z72.json
+++ b/cameras/acti/z72.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z721.json
+++ b/cameras/acti/z721.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/z722.json
+++ b/cameras/acti/z722.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z724.json
+++ b/cameras/acti/z724.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (135 dB)",

--- a/cameras/acti/z78.json
+++ b/cameras/acti/z78.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z79.json
+++ b/cameras/acti/z79.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z81.json
+++ b/cameras/acti/z81.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (120 dB)",

--- a/cameras/acti/z810.json
+++ b/cameras/acti/z810.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z812.json
+++ b/cameras/acti/z812.json
@@ -48,7 +48,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z813.json
+++ b/cameras/acti/z813.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z814.json
+++ b/cameras/acti/z814.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z818.json
+++ b/cameras/acti/z818.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 5x optical zoom",

--- a/cameras/acti/z819.json
+++ b/cameras/acti/z819.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z82.json
+++ b/cameras/acti/z82.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (120 dB)",

--- a/cameras/acti/z84.json
+++ b/cameras/acti/z84.json
@@ -44,7 +44,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z86.json
+++ b/cameras/acti/z86.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 4.3x optical zoom",

--- a/cameras/acti/z87.json
+++ b/cameras/acti/z87.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z910.json
+++ b/cameras/acti/z910.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z911.json
+++ b/cameras/acti/z911.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z913.json
+++ b/cameras/acti/z913.json
@@ -49,7 +49,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (130 dB)",

--- a/cameras/acti/z914.json
+++ b/cameras/acti/z914.json
@@ -42,7 +42,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Superior WDR (120 dB)",

--- a/cameras/acti/z953.json
+++ b/cameras/acti/z953.json
@@ -52,7 +52,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 40x optical zoom, 16x digital zoom",

--- a/cameras/acti/z954.json
+++ b/cameras/acti/z954.json
@@ -52,7 +52,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 25x optical zoom, 16x digital zoom",

--- a/cameras/acti/z957.json
+++ b/cameras/acti/z957.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (145 dB)",

--- a/cameras/acti/z958.json
+++ b/cameras/acti/z958.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "Extreme WDR (140 dB)",

--- a/cameras/acti/z959.json
+++ b/cameras/acti/z959.json
@@ -52,7 +52,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "features": [
     "zoom lens: 16x optical zoom",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -14928,7 +14928,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15016,7 +15024,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 10x digital zoom",
@@ -15181,7 +15197,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15363,7 +15387,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15453,7 +15485,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5968x2688",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -15543,7 +15583,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15634,7 +15682,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15721,7 +15777,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15787,7 +15851,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15851,7 +15923,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15917,7 +15997,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15989,7 +16077,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -16055,7 +16151,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -16223,7 +16327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.4x optical zoom, 10x digital zoom",
@@ -16403,7 +16515,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -16493,7 +16613,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -16573,7 +16701,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -16762,7 +16898,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -16932,7 +17076,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -17021,7 +17173,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17106,7 +17266,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17177,7 +17345,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 120
+      "max_fps": 120,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 120,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17267,7 +17443,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 3.6x optical zoom",
@@ -17327,7 +17511,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Basic WDR",
@@ -17395,7 +17587,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17482,7 +17682,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17552,7 +17760,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17626,7 +17842,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17717,7 +17941,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17808,7 +18040,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17899,7 +18139,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -18067,7 +18315,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18251,7 +18507,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18336,7 +18600,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18402,7 +18674,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18500,7 +18780,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -18589,7 +18877,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18671,7 +18967,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18769,7 +19073,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18851,7 +19163,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -18951,7 +19271,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.4x optical zoom, 10x digital zoom",
@@ -19211,7 +19539,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 2.85x optical zoom",
@@ -19288,7 +19624,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -19365,7 +19709,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, 10x digital zoom",
@@ -19631,7 +19983,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 12x digital zoom",
@@ -19719,7 +20079,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, 12x digital zoom",
@@ -20088,7 +20456,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 32x optical zoom",
@@ -20175,7 +20551,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 32x optical zoom",
@@ -20250,7 +20634,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom, 12x digital zoom",
@@ -20336,7 +20728,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 120
+      "max_fps": 120,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 16x digital zoom",
@@ -20510,7 +20910,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 10x optical zoom",
@@ -20599,7 +21007,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom",
@@ -20862,7 +21278,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 18
+      "max_fps": 18,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 18,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -21025,7 +21449,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (88 dB)",
@@ -21119,7 +21551,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 18
+      "max_fps": 18,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 18,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -21798,7 +22238,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x1024",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (75 dB)",
@@ -22035,7 +22483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22119,7 +22575,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (70 dB)",
@@ -22200,7 +22664,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (70 dB)",
@@ -22277,7 +22749,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (142 dB)",
@@ -22438,7 +22918,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22524,7 +23012,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22610,7 +23106,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22694,7 +23198,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -22788,7 +23300,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -22876,7 +23396,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -23039,7 +23567,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -23121,7 +23657,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -23203,7 +23747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23290,7 +23842,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23711,7 +24271,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23879,7 +24447,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Advanced WDR (75 dB)",
@@ -24063,7 +24639,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom, 16x digital zoom",
@@ -24154,7 +24738,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 33x optical zoom, 16x digital zoom",
@@ -24244,7 +24836,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -24325,7 +24925,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24414,7 +25022,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24503,7 +25119,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24593,7 +25217,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24691,7 +25323,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24781,7 +25421,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24871,7 +25519,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24961,7 +25617,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25041,7 +25705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -25138,7 +25810,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25227,7 +25907,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25318,7 +26006,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25409,7 +26105,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25498,7 +26202,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25587,7 +26299,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25675,7 +26395,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25764,7 +26492,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25855,7 +26591,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25940,7 +26684,15 @@
       "outdoor"
     ],
     "video": {
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "11520x2700",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Multi-Imager PTZ: fixed 8-sensor 360 degree panoramic array (4MP x8) combined with an independent 42x optical/16x digital zoom PTZ detail camera on the same head",
@@ -26033,7 +26785,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 33x optical zoom, 16x digital zoom",
@@ -26127,7 +26887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 42x optical zoom",
@@ -26221,7 +26989,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 25x optical zoom, 16x digital zoom",
@@ -26314,7 +27090,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 18x optical zoom",
@@ -26475,7 +27259,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26565,7 +27357,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26655,7 +27455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26745,7 +27553,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26835,7 +27651,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26925,7 +27749,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27015,7 +27847,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27105,7 +27945,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27195,7 +28043,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27285,7 +28141,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27375,7 +28239,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27464,7 +28336,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "body-worn camera",
@@ -27628,7 +28508,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -27788,7 +28676,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -27869,7 +28765,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -28115,7 +29019,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Basic WDR",
@@ -28347,7 +29259,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -28432,7 +29352,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -28518,7 +29446,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -28586,7 +29522,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Advanced WDR (100 dB)",
@@ -28659,7 +29603,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 2.85x optical zoom, 10x digital zoom",
@@ -28747,7 +29699,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -29074,7 +30034,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 56x optical zoom, 16x digital zoom",
@@ -29166,7 +30134,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 8x digital zoom",
@@ -29255,7 +30231,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 16x digital zoom",
@@ -29347,7 +30331,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 41x optical zoom, 16x digital zoom",
@@ -29440,7 +30432,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29530,7 +30530,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29616,7 +30624,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -29706,7 +30722,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29784,7 +30808,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -29852,7 +30884,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -29921,7 +30961,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -29984,7 +31032,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -30047,7 +31103,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -30112,7 +31176,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30178,7 +31250,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30242,7 +31322,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30314,7 +31402,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30393,7 +31489,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30483,7 +31587,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30573,7 +31685,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30663,7 +31783,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30753,7 +31881,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30852,7 +31988,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -30932,7 +32076,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31022,7 +32174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31110,7 +32270,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -31206,7 +32374,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31286,7 +32462,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31375,7 +32559,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31464,7 +32656,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31553,7 +32753,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31652,7 +32860,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31733,7 +32949,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31832,7 +33056,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, digital zoom via NVR server",
@@ -31915,7 +33147,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32009,7 +33249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32074,7 +33322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (145 dB)",
@@ -32174,7 +33430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 12x optical zoom, 16x digital zoom",
@@ -32256,7 +33520,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32354,7 +33626,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -32446,7 +33726,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32538,7 +33826,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32626,7 +33922,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32707,7 +34011,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32803,7 +34115,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32884,7 +34204,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32974,7 +34302,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33068,7 +34404,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -33155,7 +34499,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -33230,7 +34582,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -33309,7 +34669,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33398,7 +34766,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33497,7 +34873,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33588,7 +34972,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33668,7 +35060,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33757,7 +35157,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33934,7 +35342,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (120 dB)",
@@ -34033,7 +35449,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34123,7 +35547,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34203,7 +35635,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34292,7 +35732,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34390,7 +35838,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -34472,7 +35928,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -34562,7 +36026,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (120 dB)",
@@ -34656,7 +36128,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34744,7 +36224,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34823,7 +36311,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34981,7 +36477,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35070,7 +36574,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35259,7 +36771,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -35342,7 +36862,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35511,7 +37039,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 16x digital zoom",
@@ -35606,7 +37142,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 25x optical zoom, 16x digital zoom",
@@ -35780,7 +37324,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (145 dB)",
@@ -35874,7 +37426,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -35979,7 +37539,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 16x optical zoom",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -14928,7 +14928,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15016,7 +15024,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 10x digital zoom",
@@ -15181,7 +15197,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15363,7 +15387,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -15453,7 +15485,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5968x2688",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -15543,7 +15583,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15634,7 +15682,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15721,7 +15777,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15787,7 +15851,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15851,7 +15923,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15917,7 +15997,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -15989,7 +16077,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -16055,7 +16151,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -16223,7 +16327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.4x optical zoom, 10x digital zoom",
@@ -16403,7 +16515,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -16493,7 +16613,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -16573,7 +16701,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -16762,7 +16898,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -16932,7 +17076,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -17021,7 +17173,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17106,7 +17266,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17177,7 +17345,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 120
+      "max_fps": 120,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 120,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -17267,7 +17443,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 3.6x optical zoom",
@@ -17327,7 +17511,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Basic WDR",
@@ -17395,7 +17587,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17482,7 +17682,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17552,7 +17760,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17626,7 +17842,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17717,7 +17941,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17808,7 +18040,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -17899,7 +18139,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -18067,7 +18315,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18251,7 +18507,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18336,7 +18600,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18402,7 +18674,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18500,7 +18780,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -18589,7 +18877,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18671,7 +18967,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (150 dB)",
@@ -18769,7 +19073,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -18851,7 +19163,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -18951,7 +19271,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.4x optical zoom, 10x digital zoom",
@@ -19211,7 +19539,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 2.85x optical zoom",
@@ -19288,7 +19624,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -19365,7 +19709,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, 10x digital zoom",
@@ -19631,7 +19983,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 12x digital zoom",
@@ -19719,7 +20079,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, 12x digital zoom",
@@ -20088,7 +20456,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 32x optical zoom",
@@ -20175,7 +20551,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 32x optical zoom",
@@ -20250,7 +20634,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom, 12x digital zoom",
@@ -20336,7 +20728,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 120
+      "max_fps": 120,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 16x digital zoom",
@@ -20510,7 +20910,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 10x optical zoom",
@@ -20599,7 +21007,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom",
@@ -20862,7 +21278,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 18
+      "max_fps": 18,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 18,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -21025,7 +21449,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (88 dB)",
@@ -21119,7 +21551,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 18
+      "max_fps": 18,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 18,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -21798,7 +22238,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x1024",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (75 dB)",
@@ -22035,7 +22483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22119,7 +22575,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (70 dB)",
@@ -22200,7 +22664,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (70 dB)",
@@ -22277,7 +22749,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (142 dB)",
@@ -22438,7 +22918,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22524,7 +23012,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22610,7 +23106,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -22694,7 +23198,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -22788,7 +23300,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -22876,7 +23396,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 7
+      "max_fps": 7,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3648x2736",
+          "fps": 7,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -23039,7 +23567,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -23121,7 +23657,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Superior WDR (110 dB)",
@@ -23203,7 +23747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23290,7 +23842,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23711,7 +24271,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -23879,7 +24447,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Advanced WDR (75 dB)",
@@ -24063,7 +24639,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 30x optical zoom, 16x digital zoom",
@@ -24154,7 +24738,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 33x optical zoom, 16x digital zoom",
@@ -24244,7 +24836,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -24325,7 +24925,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24414,7 +25022,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24503,7 +25119,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24593,7 +25217,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -24691,7 +25323,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24781,7 +25421,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24871,7 +25519,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -24961,7 +25617,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25041,7 +25705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -25138,7 +25810,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25227,7 +25907,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25318,7 +26006,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25409,7 +26105,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25498,7 +26202,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25587,7 +26299,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -25675,7 +26395,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25764,7 +26492,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25855,7 +26591,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -25940,7 +26684,15 @@
       "outdoor"
     ],
     "video": {
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "11520x2700",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Multi-Imager PTZ: fixed 8-sensor 360 degree panoramic array (4MP x8) combined with an independent 42x optical/16x digital zoom PTZ detail camera on the same head",
@@ -26033,7 +26785,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 33x optical zoom, 16x digital zoom",
@@ -26127,7 +26887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 42x optical zoom",
@@ -26221,7 +26989,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 25x optical zoom, 16x digital zoom",
@@ -26314,7 +27090,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "zoom lens: 18x optical zoom",
@@ -26475,7 +27259,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26565,7 +27357,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26655,7 +27455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26745,7 +27553,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26835,7 +27651,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -26925,7 +27749,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27015,7 +27847,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27105,7 +27945,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27195,7 +28043,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27285,7 +28141,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27375,7 +28239,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -27464,7 +28336,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "body-worn camera",
@@ -27628,7 +28508,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "features": [
       "Basic WDR (74 dB)",
@@ -27788,7 +28676,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -27869,7 +28765,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -28115,7 +29019,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Basic WDR",
@@ -28347,7 +29259,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -28432,7 +29352,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -28518,7 +29446,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -28586,7 +29522,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Advanced WDR (100 dB)",
@@ -28659,7 +29603,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 2.85x optical zoom, 10x digital zoom",
@@ -28747,7 +29699,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -29074,7 +30034,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 56x optical zoom, 16x digital zoom",
@@ -29166,7 +30134,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 8x digital zoom",
@@ -29255,7 +30231,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 60x optical zoom, 16x digital zoom",
@@ -29347,7 +30331,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 41x optical zoom, 16x digital zoom",
@@ -29440,7 +30432,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29530,7 +30530,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29616,7 +30624,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "protocols": [
       "rtsp"
@@ -29706,7 +30722,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -29784,7 +30808,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -29852,7 +30884,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -29921,7 +30961,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -29984,7 +31032,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -30047,7 +31103,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog bullet (TVI/AHD/CVI/CVBS)",
@@ -30112,7 +31176,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30178,7 +31250,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30242,7 +31322,15 @@
     ],
     "video": {
       "codecs": [],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "analog turret (TVI/AHD/CVI/CVBS)",
@@ -30314,7 +31402,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30393,7 +31489,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30483,7 +31587,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30573,7 +31685,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30663,7 +31783,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30753,7 +31881,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -30852,7 +31988,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -30932,7 +32076,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31022,7 +32174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31110,7 +32270,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -31206,7 +32374,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31286,7 +32462,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31375,7 +32559,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31464,7 +32656,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31553,7 +32753,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31652,7 +32860,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -31733,7 +32949,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -31832,7 +33056,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 22x optical zoom, digital zoom via NVR server",
@@ -31915,7 +33147,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32009,7 +33249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32074,7 +33322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (145 dB)",
@@ -32174,7 +33430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 12x optical zoom, 16x digital zoom",
@@ -32256,7 +33520,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32354,7 +33626,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -32446,7 +33726,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32538,7 +33826,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -32626,7 +33922,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32707,7 +34011,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -32803,7 +34115,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32884,7 +34204,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -32974,7 +34302,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33068,7 +34404,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -33155,7 +34499,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -33230,7 +34582,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -33309,7 +34669,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33398,7 +34766,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33497,7 +34873,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33588,7 +34972,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (135 dB)",
@@ -33668,7 +35060,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33757,7 +35157,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -33934,7 +35342,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (120 dB)",
@@ -34033,7 +35449,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34123,7 +35547,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34203,7 +35635,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34292,7 +35732,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34390,7 +35838,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 5x optical zoom",
@@ -34472,7 +35928,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -34562,7 +36026,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (120 dB)",
@@ -34656,7 +36128,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34744,7 +36224,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 4.3x optical zoom",
@@ -34823,7 +36311,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -34981,7 +36477,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35070,7 +36574,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35259,7 +36771,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (130 dB)",
@@ -35342,7 +36862,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Superior WDR (120 dB)",
@@ -35511,7 +37039,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 40x optical zoom, 16x digital zoom",
@@ -35606,7 +37142,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 25x optical zoom, 16x digital zoom",
@@ -35780,7 +37324,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (145 dB)",
@@ -35874,7 +37426,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "Extreme WDR (140 dB)",
@@ -35979,7 +37539,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "features": [
       "zoom lens: 16x optical zoom",


### PR DESCRIPTION
Backfills the **`video.streams[]`** main stream for **196 ACTi cameras** (#177 lane), extracted deterministically — no LLM guessing — from ACTi's own spec API.

## Method
ACTi product pages render specs client-side via a JS widget, but the data is served by a hidden AJAX endpoint (`newPopupSpecifications_value.ashx`). A script hits that endpoint per model and parses the **"Maximum Frame Rate vs. Resolution"** field, taking the first row **not** tagged `(High Frame Mode)` as the main stream (res + fps). Codec comes from the Compression field.

## Conventions
- **Main stream only.** ACTi documents `Multi-Streaming: Simultaneous triple streams` but publishes no per-sub-stream resolution/fps, so only the documented main stream is recorded (recording invented sub-streams would be guessing).
- **codec**: `H.265` where the Compression field lists it (172 cameras), else `H.264` (24 older models that genuinely lack H.265).
- **Cross-checked**: every entry's parsed main resolution must equal the camera's stored `resolution.max_width × max_height`. All 196 written entries passed; **0 mismatches written**.

## Skipped for manual review (52 of 248)
Not written because the parsed main resolution disagreed with the stored max resolution (e.g. `A314`: parsed 3200x1800 vs stored 3864x2192; `A29`/`A425`: parsed 1920x1080 vs stored 1945x1097), or the model returned no spec data (`Z79-P1`, discontinued). These are flagged rather than guessed — a follow-up can reconcile whether the stored resolution or the spec-tab value is authoritative.

Builds clean (2,618 cameras). ACTi `streams[]` coverage **0 → 196**.