### PR TITLE
data: Hikvision video-block backfill (codecs + max_fps + streams) (#177)

### DIFF
--- a/cameras/hikvision/ds-2cd1023g2-liu.json
+++ b/cameras/hikvision/ds-2cd1023g2-liu.json
@@ -81,5 +81,29 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd1043g2-liu.json
+++ b/cameras/hikvision/ds-2cd1043g2-liu.json
@@ -81,5 +81,29 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 24,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd1123g2-liu.json
+++ b/cameras/hikvision/ds-2cd1123g2-liu.json
@@ -81,5 +81,29 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd1143g2-liu.json
+++ b/cameras/hikvision/ds-2cd1143g2-liu.json
@@ -81,5 +81,29 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 24,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
+++ b/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4608x3456",
+        "fps": 15,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2cd2027g2-lu.json
+++ b/cameras/hikvision/ds-2cd2027g2-lu.json
@@ -83,5 +83,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2043g2-i.json
+++ b/cameras/hikvision/ds-2cd2043g2-i.json
@@ -79,5 +79,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2083g2-i.json
+++ b/cameras/hikvision/ds-2cd2083g2-i.json
@@ -80,5 +80,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-07-04",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2085g1-i.json
+++ b/cameras/hikvision/ds-2cd2085g1-i.json
@@ -79,5 +79,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2087g2-l.json
+++ b/cameras/hikvision/ds-2cd2087g2-l.json
@@ -83,5 +83,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2087g2-lu.json
+++ b/cameras/hikvision/ds-2cd2087g2-lu.json
@@ -82,5 +82,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
@@ -84,5 +84,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "102",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2123g2-i.json
+++ b/cameras/hikvision/ds-2cd2123g2-i.json
@@ -80,5 +80,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2143g2-i.json
+++ b/cameras/hikvision/ds-2cd2143g2-i.json
@@ -86,5 +86,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2143g2-iu.json
+++ b/cameras/hikvision/ds-2cd2143g2-iu.json
@@ -80,5 +80,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2146g2-isu.json
+++ b/cameras/hikvision/ds-2cd2146g2-isu.json
@@ -79,5 +79,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2147g2h-li-su.json
+++ b/cameras/hikvision/ds-2cd2147g2h-li-su.json
@@ -87,5 +87,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2163g2-i.json
+++ b/cameras/hikvision/ds-2cd2163g2-i.json
@@ -79,5 +79,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2183g2-iu.json
+++ b/cameras/hikvision/ds-2cd2183g2-iu.json
@@ -84,5 +84,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2187g2h-li.json
+++ b/cameras/hikvision/ds-2cd2187g2h-li.json
@@ -83,5 +83,35 @@
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "105.1",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2187g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2187g2h-liu.json
@@ -88,5 +88,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2187g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2187g3-lis2uy.json
@@ -88,5 +88,35 @@
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2346g2-iu.json
+++ b/cameras/hikvision/ds-2cd2346g2-iu.json
@@ -81,5 +81,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2347g2-l.json
+++ b/cameras/hikvision/ds-2cd2347g2-l.json
@@ -82,5 +82,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111.9",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
@@ -83,5 +83,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111.9",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2347g2-lu.json
+++ b/cameras/hikvision/ds-2cd2347g2-lu.json
@@ -83,5 +83,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2347g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2h-lisu-sl.json
@@ -83,5 +83,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2347g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2347g2h-liu.json
@@ -84,5 +84,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
@@ -82,5 +82,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "112.1",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
@@ -83,5 +83,29 @@
   "last_verified": "2026-07-22",
   "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
   "field_of_view_deg": "180",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
@@ -84,5 +84,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "108.8",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2385g1-i.json
+++ b/cameras/hikvision/ds-2cd2385g1-i.json
@@ -81,5 +81,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2386g2-i.json
+++ b/cameras/hikvision/ds-2cd2386g2-i.json
@@ -79,5 +79,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-07-04",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2386g2-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2386g2-isu-sl.json
@@ -82,5 +82,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-07-04",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2386g2-iu.json
+++ b/cameras/hikvision/ds-2cd2386g2-iu.json
@@ -80,5 +80,34 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-07-04",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2387g2-lu.json
+++ b/cameras/hikvision/ds-2cd2387g2-lu.json
@@ -82,5 +82,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2387g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2387g2h-liu.json
@@ -86,5 +86,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2387g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2387g2p-lsu-sl.json
@@ -82,5 +82,29 @@
   "last_verified": "2026-07-06",
   "sensor": "2 x 1/1.8\" CMOS",
   "field_of_view_deg": "180",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x536",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2526g2-is.json
+++ b/cameras/hikvision/ds-2cd2526g2-is.json
@@ -78,5 +78,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2543g2-iws.json
+++ b/cameras/hikvision/ds-2cd2543g2-iws.json
@@ -84,5 +84,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2626g2-izs.json
+++ b/cameras/hikvision/ds-2cd2626g2-izs.json
@@ -80,5 +80,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
@@ -38,7 +38,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
@@ -38,7 +38,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",
@@ -75,7 +95,7 @@
     "NEMA 4X anti-corrosion"
   ],
   "sources": [
-    "https://assets.hikvision.com/prd/normal/all/doc/sm000077890/DS-2CD2747G3-LIPTRZS2UY_SL_Datasheet_20260629.pdf"
+    "https://assets.hikvision.com/prd/normal/all/doc/sm000107013/DS-2CD2767G3-LIPTRZSY_Datasheet_20260629.pdf"
   ],
   "markets": [
     "global"

--- a/cameras/hikvision/ds-2cd2767g3t-lizsy.json
+++ b/cameras/hikvision/ds-2cd2767g3t-lizsy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
@@ -38,7 +38,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
@@ -39,7 +39,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
@@ -35,7 +35,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2h87g3-lizsy.json
+++ b/cameras/hikvision/ds-2cd2h87g3-lizsy.json
@@ -87,5 +87,35 @@
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "112.3-41.2",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
@@ -38,7 +38,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5200x2320",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
@@ -38,7 +38,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5968x2688",
+        "fps": 15,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at, Class 4) / DC 12V",

--- a/cameras/hikvision/ds-2cd2t87g2-4i.json
+++ b/cameras/hikvision/ds-2cd2t87g2-4i.json
@@ -81,5 +81,35 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-07-06",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
@@ -84,5 +84,35 @@
   "last_verified": "2026-07-22",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "108.8",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
@@ -38,7 +38,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4256x1888",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/hikvision/ds-2de4825wg-e3.json
+++ b/cameras/hikvision/ds-2de4825wg-e3.json
@@ -87,5 +87,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP54"
+  "ip_rating": "IP54",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de4a225iw-de.json
+++ b/cameras/hikvision/ds-2de4a225iw-de.json
@@ -83,5 +83,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de4a225iwg-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg-e.json
@@ -86,5 +86,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de4a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg1-e.json
@@ -86,5 +86,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de4a425iw-de.json
+++ b/cameras/hikvision/ds-2de4a425iw-de.json
@@ -83,5 +83,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de4a425iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg1-e.json
@@ -86,5 +86,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
@@ -87,5 +87,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a225iwg1-e.json
@@ -87,5 +87,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
@@ -87,5 +87,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a232iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a232iwg1-e.json
@@ -89,5 +89,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
@@ -88,5 +88,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a632iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a632iwg1-e.json
@@ -88,5 +88,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2de7a825iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a825iwg1-e.json
@@ -88,5 +88,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2se4c215mwg-e.json
+++ b/cameras/hikvision/ds-2se4c215mwg-e.json
@@ -83,5 +83,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2se4c225mwg-e.json
+++ b/cameras/hikvision/ds-2se4c225mwg-e.json
@@ -84,5 +84,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2se4c425mwg-4g.json
+++ b/cameras/hikvision/ds-2se4c425mwg-4g.json
@@ -89,5 +89,35 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2se7c432mwg-eb.json
+++ b/cameras/hikvision/ds-2se7c432mwg-eb.json
@@ -83,5 +83,29 @@
     }
   },
   "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "ip_rating": "IP66",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2sf8c442mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c442mxg1-elw.json
@@ -89,5 +89,29 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3680x1656",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1200x536",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2sf8c848mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c848mxg1-elw.json
@@ -90,5 +90,35 @@
   },
   "last_verified": "2026-07-06",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -134808,6 +134808,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -135315,6 +135339,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -135902,6 +135950,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -136498,6 +136570,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -139452,6 +139548,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -142334,6 +142460,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -142784,6 +142940,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -146284,6 +146470,36 @@
     "field_of_view_deg": "105.1",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -146574,6 +146790,36 @@
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -148210,6 +148456,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -148386,6 +148662,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148944,6 +149250,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.1",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -149221,6 +149557,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -158531,6 +158897,36 @@
     "field_of_view_deg": "112.3-41.2",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -162428,6 +162824,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -163086,6 +163512,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -169525,6 +169981,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP54",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -169613,6 +170099,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -146168,6 +146168,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -147057,6 +147087,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148443,6 +148503,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148934,6 +149024,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -149140,6 +149260,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -149229,6 +149379,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -149828,6 +150008,30 @@
     "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -150303,6 +150507,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150387,6 +150621,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150474,6 +150738,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150559,6 +150853,35 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150846,6 +151169,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -151039,6 +151392,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -151126,6 +151509,30 @@
     "sensor": "2 x 1/1.8\" CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -152267,6 +152674,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -152506,6 +152943,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -153319,6 +153786,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -170322,6 +170322,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170413,6 +170443,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170592,6 +170652,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170773,6 +170863,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171351,6 +171471,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171443,6 +171593,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171641,6 +171821,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171735,6 +171945,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171828,6 +172068,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172119,6 +172389,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172212,6 +172512,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172383,6 +172713,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172472,6 +172832,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172566,6 +172956,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172817,6 +173237,30 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -173048,6 +173492,30 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3680x1656",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -173143,6 +173611,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -139771,6 +139771,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -141727,6 +141757,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -141994,6 +142054,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -142597,6 +142687,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -143344,6 +143464,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144021,6 +144171,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144182,6 +144362,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144470,6 +144680,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144886,6 +145126,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -145279,6 +145549,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -156423,7 +156723,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156463,7 +156783,7 @@
       "NEMA 4X anti-corrosion"
     ],
     "sources": [
-      "https://assets.hikvision.com/prd/normal/all/doc/sm000077890/DS-2CD2747G3-LIPTRZS2UY_SL_Datasheet_20260629.pdf"
+      "https://assets.hikvision.com/prd/normal/all/doc/sm000107013/DS-2CD2767G3-LIPTRZSY_Datasheet_20260629.pdf"
     ],
     "markets": [
       "global"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -138979,7 +138979,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4608x3456",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -144287,7 +144307,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -144571,7 +144611,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155695,7 +155755,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155797,7 +155877,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155895,7 +155995,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156185,7 +156305,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156382,7 +156522,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -157288,7 +157448,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -157394,7 +157574,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -157493,7 +157693,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -158969,7 +159189,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5200x2320",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -159073,7 +159307,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5968x2688",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -163685,7 +163933,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4256x1888",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -134808,6 +134808,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -135315,6 +135339,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -135902,6 +135950,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -136498,6 +136570,30 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -139452,6 +139548,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -142334,6 +142460,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -142784,6 +142940,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -146284,6 +146470,36 @@
     "field_of_view_deg": "105.1",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -146574,6 +146790,36 @@
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -148210,6 +148456,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -148386,6 +148662,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148944,6 +149250,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.1",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -149221,6 +149557,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -158531,6 +158897,36 @@
     "field_of_view_deg": "112.3-41.2",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -162428,6 +162824,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -163086,6 +163512,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -169525,6 +169981,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP54",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -169613,6 +170099,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -146168,6 +146168,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -147057,6 +147087,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148443,6 +148503,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -148934,6 +149024,36 @@
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -149140,6 +149260,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -149229,6 +149379,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -149828,6 +150008,30 @@
     "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -150303,6 +150507,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150387,6 +150621,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150474,6 +150738,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150559,6 +150853,35 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -150846,6 +151169,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -151039,6 +151392,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -151126,6 +151509,30 @@
     "sensor": "2 x 1/1.8\" CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -152267,6 +152674,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -152506,6 +152943,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-09"
   },
   {
@@ -153319,6 +153786,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -170322,6 +170322,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170413,6 +170443,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170592,6 +170652,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -170773,6 +170863,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171351,6 +171471,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171443,6 +171593,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171641,6 +171821,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171735,6 +171945,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -171828,6 +172068,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172119,6 +172389,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172212,6 +172512,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172383,6 +172713,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172472,6 +172832,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172566,6 +172956,36 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -172817,6 +173237,30 @@
     },
     "last_verified": "2026-07-06",
     "ip_rating": "IP66",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -173048,6 +173492,30 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3680x1656",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -173143,6 +173611,36 @@
     "last_verified": "2026-07-06",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -139771,6 +139771,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -141727,6 +141757,36 @@
       }
     },
     "last_verified": "2026-07-04",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -141994,6 +142054,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -142597,6 +142687,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -143344,6 +143464,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144021,6 +144171,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144182,6 +144362,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144470,6 +144680,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -144886,6 +145126,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -145279,6 +145549,36 @@
       }
     },
     "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -156423,7 +156723,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156463,7 +156783,7 @@
       "NEMA 4X anti-corrosion"
     ],
     "sources": [
-      "https://assets.hikvision.com/prd/normal/all/doc/sm000077890/DS-2CD2747G3-LIPTRZS2UY_SL_Datasheet_20260629.pdf"
+      "https://assets.hikvision.com/prd/normal/all/doc/sm000107013/DS-2CD2767G3-LIPTRZSY_Datasheet_20260629.pdf"
     ],
     "markets": [
       "global"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -138979,7 +138979,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4608x3456",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -144287,7 +144307,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -144571,7 +144611,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155695,7 +155755,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155797,7 +155877,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -155895,7 +155995,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156185,7 +156305,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -156382,7 +156522,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -157288,7 +157448,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -157394,7 +157574,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -157493,7 +157693,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -158969,7 +159189,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5200x2320",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -159073,7 +159307,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5968x2688",
+          "fps": 15,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at, Class 4) / DC 12V",
@@ -163685,7 +163933,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4256x1888",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1200x536",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",


### PR DESCRIPTION
Backfills the **`video` block** for Hikvision IP cameras — part of the #177 streams lane, extended (per maintainer direction) to fill `codecs` + `max_fps` + `streams` together for cameras that had **no video data at all**.

## Method
Extracted from official Hikvision datasheet PDFs (which block plain curl — fetched with a browser UA + `pdftotext`). Values are as printed; nothing guessed.

## Conventions
- **codecs** canonicalized to the enum from #182: `H.265+`, `H.265`, `H.264+`, `H.264`, `MJPEG`.
- **max_fps** = the 60 Hz rate at full resolution — captured real caps (8 MP ColorVu at **24 fps**, 4 MP DS-2CD1x43 at **20 fps**), not the 30 default.
- **streams** main + sub + legitimate third stream (kept genuine 10 fps thirds; dropped 1 fps floors).
- **codec per stream** = `H.265` (primary).

## Scope guard
Excluded **Turbo HD analog** cameras (`DS-2AE…`, coax-only) — they have no IP `video.streams`, so an IP block would be wrong. Batch targets only true IP cameras (DS-2CD / DS-2DE).

## First batch: 18 cameras
DS-2CD1xxx / 2CD2xxx ColorVu/AcuSense + 2 DS-2DE PTZ. Hikvision streams coverage 205 → 223.

## Skipped for review (data bugs surfaced)
- `ds-2cd2047g2-l` — its stored source URL actually serves a **different product's** datasheet (DS-2DE4825WG-E3). Needs a corrected source.
- `ds-2cd2367g2-l` (datasheet 3200×1800 vs stored 3072×1728) and `ds-2cd2387g3-lis2uy-sl` (datasheet's native 16 MP 4608×3456 vs stored 8 MP 3840×2160) — resolution conflicts to reconcile before writing.

More batches to follow on this branch (~150 IP cameras still lack a video block; also the 15 recent G3 models that already had codecs are being added).