### PR TITLE
data: backfill video.streams[] — Bosch (15 cameras) (#177)

### DIFF
--- a/cameras/bosch/mic-7504-z12gr.json
+++ b/cameras/bosch/mic-7504-z12gr.json
@@ -23,7 +23,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1-inch CMOS",
   "lens": {

--- a/cameras/bosch/nbe-3702-al.json
+++ b/cameras/bosch/nbe-3702-al.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8-inch CMOS",
   "lens": {

--- a/cameras/bosch/nce-7703-fk.json
+++ b/cameras/bosch/nce-7703-fk.json
@@ -23,7 +23,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2816x2112",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8 inch CMOS",
   "lens": {

--- a/cameras/bosch/ndd-7802-al.json
+++ b/cameras/bosch/ndd-7802-al.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 2,

--- a/cameras/bosch/nde-3702-al.json
+++ b/cameras/bosch/nde-3702-al.json
@@ -21,6 +21,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" CMOS",

--- a/cameras/bosch/nde-5702-a.json
+++ b/cameras/bosch/nde-5702-a.json
@@ -22,7 +22,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8 inch CMOS",
   "lens": {

--- a/cameras/bosch/nde-8702-rx.json
+++ b/cameras/bosch/nde-8702-rx.json
@@ -23,7 +23,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/bosch/nde-8702-rxl.json
+++ b/cameras/bosch/nde-8702-rxl.json
@@ -22,7 +22,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/bosch/nde-8702-rxt.json
+++ b/cameras/bosch/nde-8702-rxt.json
@@ -23,6 +23,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" CMOS (4.1 µm, 2.10 MP)",

--- a/cameras/bosch/nde-8704-r.json
+++ b/cameras/bosch/nde-8704-r.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8-inch CMOS",

--- a/cameras/bosch/nde-8704-rx.json
+++ b/cameras/bosch/nde-8704-rx.json
@@ -23,7 +23,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.2-inch CMOS",
   "lens": {

--- a/cameras/bosch/ndi-3703-a.json
+++ b/cameras/bosch/ndi-3703-a.json
@@ -21,7 +21,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7 inch CMOS",
   "lens": {

--- a/cameras/bosch/ndi-3703-al.json
+++ b/cameras/bosch/ndi-3703-al.json
@@ -21,7 +21,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7-inch CMOS",
   "lens": {

--- a/cameras/bosch/nue-3703-f04.json
+++ b/cameras/bosch/nue-3703-f04.json
@@ -21,6 +21,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7 inch CMOS",

--- a/cameras/bosch/nuv-3703-f02.json
+++ b/cameras/bosch/nuv-3703-f02.json
@@ -21,6 +21,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7-inch CMOS",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -56241,7 +56241,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1-inch CMOS",
     "lens": {
@@ -60288,7 +60296,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8-inch CMOS",
     "lens": {
@@ -63600,7 +63616,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2816x2112",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8 inch CMOS",
     "lens": {
@@ -63800,7 +63824,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 2,
@@ -64156,6 +64188,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -64569,7 +64609,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8 inch CMOS",
     "lens": {
@@ -65369,7 +65417,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -65479,7 +65535,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -65587,6 +65651,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" CMOS (4.1 µm, 2.10 MP)",
@@ -66446,6 +66518,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8-inch CMOS",
@@ -66808,7 +66888,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.2-inch CMOS",
     "lens": {
@@ -67379,7 +67467,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7 inch CMOS",
     "lens": {
@@ -67484,7 +67580,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7-inch CMOS",
     "lens": {
@@ -72296,6 +72400,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7 inch CMOS",
@@ -72972,6 +73084,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7-inch CMOS",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -56241,7 +56241,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1-inch CMOS",
     "lens": {
@@ -60288,7 +60296,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8-inch CMOS",
     "lens": {
@@ -63600,7 +63616,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2816x2112",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8 inch CMOS",
     "lens": {
@@ -63800,7 +63824,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 2,
@@ -64156,6 +64188,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -64569,7 +64609,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8 inch CMOS",
     "lens": {
@@ -65369,7 +65417,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -65479,7 +65535,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -65587,6 +65651,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" CMOS (4.1 µm, 2.10 MP)",
@@ -66446,6 +66518,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8-inch CMOS",
@@ -66808,7 +66888,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.2-inch CMOS",
     "lens": {
@@ -67379,7 +67467,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7 inch CMOS",
     "lens": {
@@ -67484,7 +67580,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7-inch CMOS",
     "lens": {
@@ -72296,6 +72400,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7 inch CMOS",
@@ -72972,6 +73084,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7-inch CMOS",


### PR DESCRIPTION
Backfills `video.streams[]` for 15 Bosch FLEXIDOME/DINION/MIC cameras (3100i/5100i/7100i/8100i) that already had a `codecs` list — part of the #177 lane.

## Method & convention
Verified from official Bosch datasheets (`assets.catalog.boschbuildingtechnologies.com` and Bosch's Keenfinity asset host). **Main stream only**: Bosch datasheets describe streaming as "multiple / N independently-configurable streams" with a single stated resolution — they do **not** fix a distinct sub-stream resolution, so recording an invented `sub` would be guessing (same honest single-stream approach as the ACTi PR #184).

- main = full sensor resolution at max frame rate: **2/2.1 MP X-series @60 fps**, 5/6/8 MP @30 fps.
- codec `H.265` (HEVC per datasheet).
- Every main resolution cross-checked against the stored `resolution.max_*` (all 15 passed).

## Notes
- `nbi-7803-axt` skipped — no official datasheet located.
- A few values came from Bosch's Keenfinity host / identical mirrors where the primary asset URL 404'd; all are model-number-verified official Bosch datasheet content (sources field unchanged).
- The 79 Bosch files touched by the codec-normalization PR (#182) are **excluded** here to keep the two PRs conflict-free.

Bosch `streams[]` coverage 101 → 116. Builds clean (2,618 cameras).