### PR TITLE
data: backfill video.streams[] — Hanwha (23 cameras, brand complete) (#177)

### DIFF
--- a/cameras/hanwha/ano-l7082r.json
+++ b/cameras/hanwha/ano-l7082r.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/hanwha/anv-l7082r.json
+++ b/cameras/hanwha/anv-l7082r.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/hanwha/pnm-9000vq.json
+++ b/cameras/hanwha/pnm-9000vq.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "4x exchangeable CMOS lens modules (2MP or 5MP)",
   "lens": {

--- a/cameras/hanwha/pnm-9322vqp.json
+++ b/cameras/hanwha/pnm-9322vqp.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "4x exchangeable CMOS lens modules (2MP/5MP) + 1/2.8\" CMOS (PTZ channel)",
   "lens": {

--- a/cameras/hanwha/qnd-6082r.json
+++ b/cameras/hanwha/qnd-6082r.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3) / DC 12V",

--- a/cameras/hanwha/qnd-6082r1.json
+++ b/cameras/hanwha/qnd-6082r1.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hanwha/qnd-8020r.json
+++ b/cameras/hanwha/qnd-8020r.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af)"

--- a/cameras/hanwha/qnd-8080r-kr.json
+++ b/cameras/hanwha/qnd-8080r-kr.json
@@ -39,7 +39,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qne-8021r.json
+++ b/cameras/hanwha/qne-8021r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qno-6082r1.json
+++ b/cameras/hanwha/qno-6082r1.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3) / DC 12V",

--- a/cameras/hanwha/qno-8030r.json
+++ b/cameras/hanwha/qno-8030r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qno-8080r-mena.json
+++ b/cameras/hanwha/qno-8080r-mena.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qno-8080r.json
+++ b/cameras/hanwha/qno-8080r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qno-c9083r.json
+++ b/cameras/hanwha/qno-c9083r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qnv-6082r1.json
+++ b/cameras/hanwha/qnv-6082r1.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/hanwha/qnv-8030r.json
+++ b/cameras/hanwha/qnv-8030r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af)"

--- a/cameras/hanwha/qnv-8080r-mena.json
+++ b/cameras/hanwha/qnv-8080r-mena.json
@@ -40,7 +40,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qnv-8080r.json
+++ b/cameras/hanwha/qnv-8080r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qnv-8080rb.json
+++ b/cameras/hanwha/qnv-8080rb.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/qnv-c9083r.json
+++ b/cameras/hanwha/qnv-c9083r.json
@@ -38,7 +38,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af, Class 3)",

--- a/cameras/hanwha/xno-a9084r.json
+++ b/cameras/hanwha/xno-a9084r.json
@@ -31,7 +31,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/hanwha/xno-c7083r.json
+++ b/cameras/hanwha/xno-c7083r.json
@@ -30,7 +30,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/hanwha/xno-c9083r.json
+++ b/cameras/hanwha/xno-c9083r.json
@@ -30,7 +30,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -123366,7 +123366,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -123475,7 +123483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -123940,7 +123956,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x exchangeable CMOS lens modules (2MP or 5MP)",
     "lens": {
@@ -124171,7 +124195,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x exchangeable CMOS lens modules (2MP/5MP) + 1/2.8\" CMOS (PTZ channel)",
     "lens": {
@@ -124921,7 +124953,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -125028,7 +125068,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -125127,7 +125175,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af)"
@@ -125230,7 +125286,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125338,7 +125402,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125678,7 +125750,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -125788,7 +125868,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125897,7 +125985,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126008,7 +126104,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126118,7 +126222,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126228,7 +126340,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -126335,7 +126455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af)"
@@ -126439,7 +126567,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126551,7 +126687,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126662,7 +126806,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126769,7 +126921,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -127232,7 +127392,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -127349,7 +127517,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -127462,7 +127638,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -123366,7 +123366,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -123475,7 +123483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -123940,7 +123956,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x exchangeable CMOS lens modules (2MP or 5MP)",
     "lens": {
@@ -124171,7 +124195,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x exchangeable CMOS lens modules (2MP/5MP) + 1/2.8\" CMOS (PTZ channel)",
     "lens": {
@@ -124921,7 +124953,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -125028,7 +125068,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -125127,7 +125175,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af)"
@@ -125230,7 +125286,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125338,7 +125402,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125678,7 +125750,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -125788,7 +125868,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -125897,7 +125985,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126008,7 +126104,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126118,7 +126222,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126228,7 +126340,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -126335,7 +126455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af)"
@@ -126439,7 +126567,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126551,7 +126687,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126662,7 +126806,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -126769,7 +126921,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af, Class 3)",
@@ -127232,7 +127392,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -127349,7 +127517,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -127462,7 +127638,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",


### PR DESCRIPTION
Backfills `video.streams[]` for the **last 23 Hanwha Wisenet cameras** that lacked it — this **completes the Hanwha brand** (45/45).

## Method & convention
Verified from official Hanwha datasheets (Hanwha's `hvsgmpprdstorage` Azure blob store + model-number-verified mirrors where the primary URL was gated). **Main stream only**: Hanwha datasheets describe streaming as "up to N configurable profiles" with no fixed sub-stream resolution — recording an invented sub would be guessing (same honest approach as ACTi #184 and Bosch #187).

- main = max resolution at max framerate: **X-series 4MP @60 fps**, all others @30 fps.
- codec `H.265`.
- Multi-sensor **PNM-9000VQ / PNM-9322VQP** recorded per-imager (2560x1920@30), matching the stored per-sensor resolution.
- All 23 main resolutions cross-checked against stored `resolution.max_*` (all passed).

Hanwha `streams[]` coverage 22 → **45/45 (100%)**. Builds clean.