### PR TITLE
data: backfill video.streams[] — Kedacom (46 cameras) (#177)

### DIFF
--- a/cameras/kedacom/ipc121-ei7n.json
+++ b/cameras/kedacom/ipc121-ei7n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.264"], "max_fps": 25 },
+  "video": { "codecs": ["H.264"], "max_fps": 25, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 25, "codec": "H.264" }] },
   "sensor": "1/1.9\" progressive scan CMOS",
   "night_vision": { "type": "none" },
   "power": { "method": "DC 12V", "consumption_w": 6, "voltage": "DC 12V" },

--- a/cameras/kedacom/ipc123-ei7n.json
+++ b/cameras/kedacom/ipc123-ei7n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.264"], "max_fps": 25 },
+  "video": { "codecs": ["H.264"], "max_fps": 25, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 25, "codec": "H.264" }] },
   "sensor": "1/1.9\" progressive scan CMOS",
   "night_vision": { "type": "none" },
   "power": { "method": "DC 12V / PoE (802.3af)", "consumption_w": 6, "voltage": "DC 12V" },

--- a/cameras/kedacom/ipc123-fi4n.json
+++ b/cameras/kedacom/ipc123-fi4n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc", "ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 60 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 60, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.265" }] },
   "sensor": "1/2\" progressive scan CMOS",
   "night_vision": { "type": "none" },
   "power": { "method": "AC 24V / DC 12V / PoE (802.3af)", "consumption_w": 6, "voltage": "AC 24V / DC 12V" },

--- a/cameras/kedacom/ipc143-hn.json
+++ b/cameras/kedacom/ipc143-hn.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc", "ac-mains"],
   "resolution": { "megapixels": 4.0, "max_width": 2592, "max_height": 1520, "label": "4MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "2592x1520", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "field_of_view_deg": "depends on interchangeable C/CS lens",
   "night_vision": { "type": "none" },

--- a/cameras/kedacom/ipc2131-an-ir1.json
+++ b/cameras/kedacom/ipc2131-an-ir1.json
@@ -24,7 +24,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2131-an.json
+++ b/cameras/kedacom/ipc2131-an.json
@@ -27,7 +27,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2131-dn-l.json
+++ b/cameras/kedacom/ipc2131-dn-l.json
@@ -27,7 +27,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.264" }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2132-an.json
+++ b/cameras/kedacom/ipc2132-an.json
@@ -27,7 +27,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2150-an.json
+++ b/cameras/kedacom/ipc2150-an.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 1.3, "max_width": 1280, "max_height": 960, "label": "960p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "7-22", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "36.5-15.2",

--- a/cameras/kedacom/ipc2151-an-bn-d.json
+++ b/cameras/kedacom/ipc2151-an-bn-d.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 1.3, "max_width": 1280, "max_height": 960, "label": "960p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "47.7-89.4",

--- a/cameras/kedacom/ipc2151-an-bn.json
+++ b/cameras/kedacom/ipc2151-an-bn.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 1.3, "max_width": 1280, "max_height": 960, "label": "960p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "89.4-47.7",

--- a/cameras/kedacom/ipc2211-fn-dir.json
+++ b/cameras/kedacom/ipc2211-fn-dir.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6 / 8", "varifocal": false },
   "field_of_view_deg": "36.8-101.2",

--- a/cameras/kedacom/ipc2211-hn-pir.json
+++ b/cameras/kedacom/ipc2211-hn-pir.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6 / 8", "aperture": "F1.6", "varifocal": false },
   "field_of_view_deg": "36.8-101.2",

--- a/cameras/kedacom/ipc2231-dn-ir.json
+++ b/cameras/kedacom/ipc2231-dn-ir.json
@@ -25,7 +25,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.264" }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2231-en-l.json
+++ b/cameras/kedacom/ipc2231-en-l.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 60 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 60, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.264" }] },
   "sensor": "1/1.9\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.95", "varifocal": false },
   "field_of_view_deg": "142",

--- a/cameras/kedacom/ipc2231-fn-s.json
+++ b/cameras/kedacom/ipc2231-fn-s.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc", "ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": { "focal_length_mm": "2.8-12 (varifocal); 2.2 / 2.0 (fixed)", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "108-35 (varifocal); 126 (2.2mm); 151 (2mm)",

--- a/cameras/kedacom/ipc2231-fn-sir40.json
+++ b/cameras/kedacom/ipc2231-fn-sir40.json
@@ -23,7 +23,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2231-hn-s.json
+++ b/cameras/kedacom/ipc2231-hn-s.json
@@ -28,7 +28,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2231-hn-sir40.json
+++ b/cameras/kedacom/ipc2231-hn-sir40.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc", "ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "35-108",

--- a/cameras/kedacom/ipc2232-an-dl.json
+++ b/cameras/kedacom/ipc2232-an-dl.json
@@ -20,7 +20,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.264" }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2233-fn-s.json
+++ b/cameras/kedacom/ipc2233-fn-s.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.1", "varifocal": false },
   "field_of_view_deg": "132",

--- a/cameras/kedacom/ipc2240-hn-p.json
+++ b/cameras/kedacom/ipc2240-hn-p.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.1 (L0210)", "varifocal": false },
   "field_of_view_deg": "143.3",

--- a/cameras/kedacom/ipc2240-hn-pir30.json
+++ b/cameras/kedacom/ipc2240-hn-pir30.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6", "aperture": "F1.6", "varifocal": false },
   "field_of_view_deg": "53.4-101.2",

--- a/cameras/kedacom/ipc2240-hn-s.json
+++ b/cameras/kedacom/ipc2240-hn-s.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.1 (L0210)", "varifocal": false },
   "field_of_view_deg": "143.3",

--- a/cameras/kedacom/ipc2240-hn-sir30.json
+++ b/cameras/kedacom/ipc2240-hn-sir30.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6", "varifocal": false },
   "field_of_view_deg": "53.4-101.2",

--- a/cameras/kedacom/ipc2250-an.json
+++ b/cameras/kedacom/ipc2250-an.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "7-22", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "40.3-17.3",

--- a/cameras/kedacom/ipc2251-hn.json
+++ b/cameras/kedacom/ipc2251-hn.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12 (-SIR40-Z3009) / 6-48 (-SIR80-Z6048)", "aperture": "F1.4", "varifocal": true },
   "field_of_view_deg": "37-90 (2.8-12mm) / 7.2-65 (6-48mm)",

--- a/cameras/kedacom/ipc2252-fn-dir.json
+++ b/cameras/kedacom/ipc2252-fn-dir.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "3.6 / 6 / 8 / 12 / 16", "varifocal": false },
   "field_of_view_deg": "17.8-78.6",

--- a/cameras/kedacom/ipc2252-hn-pir.json
+++ b/cameras/kedacom/ipc2252-hn-pir.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "3.6 / 6 / 8 / 12 / 16", "varifocal": false },
   "field_of_view_deg": "17.8-78.6",

--- a/cameras/kedacom/ipc2431-hn-s.json
+++ b/cameras/kedacom/ipc2431-hn-s.json
@@ -23,7 +23,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "2592x1520", "fps": 30, "codec": "H.265" }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2433-hn-sir40.json
+++ b/cameras/kedacom/ipc2433-hn-sir40.json
@@ -22,7 +22,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "2592x1520", "fps": 20, "codec": "H.265" }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2440-hn-s.json
+++ b/cameras/kedacom/ipc2440-hn-s.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 4.0, "max_width": 2592, "max_height": 1520, "label": "4MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "2592x1520", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.1 (L0210)", "varifocal": false },
   "field_of_view_deg": "143.3",

--- a/cameras/kedacom/ipc2451-fi4n-sir50.json
+++ b/cameras/kedacom/ipc2451-fi4n-sir50.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc", "ac-mains"],
   "resolution": { "megapixels": 4.0, "max_width": 2688, "max_height": 1520, "label": "4MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "2688x1520", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "2.8-12 (Z2812) / 8-32 (Z8032)", "varifocal": true },
   "field_of_view_deg": "45.5-91 (Z2812) / 15-38 (Z8032)",

--- a/cameras/kedacom/ipc2452-hn-hnb-sir50.json
+++ b/cameras/kedacom/ipc2452-hn-hnb-sir50.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 4.0, "max_width": 2592, "max_height": 1920, "label": "4MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20, "streams": [{ "name": "main", "resolution": "2592x1920", "fps": 20, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12", "aperture": "F1.6", "varifocal": true },
   "field_of_view_deg": "95-38",

--- a/cameras/kedacom/ipc2452-hn-pir.json
+++ b/cameras/kedacom/ipc2452-hn-pir.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 4.0, "max_width": 2592, "max_height": 1520, "label": "4MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20, "streams": [{ "name": "main", "resolution": "2592x1520", "fps": 20, "codec": "H.265" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "3.6 / 6 / 8 / 12 / 16 (fixed, M12)", "varifocal": false },
   "field_of_view_deg": "78.6 (3.6mm) / 53.2 (6mm) / 36.8 (8mm) / 23.7 (12mm) / 17.8 (16mm)",

--- a/cameras/kedacom/ipc2511-fn-sir.json
+++ b/cameras/kedacom/ipc2511-fn-sir.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 5.0, "max_width": 2880, "max_height": 1620, "label": "5MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "2880x1620", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 (L0280) / 3.6 (L0360) / 6 (L0600)", "varifocal": false },
   "field_of_view_deg": "111.4 (2.8mm) / 91.5 (3.6mm) / 51.8 (6mm)",

--- a/cameras/kedacom/ipc2655-gi4n.json
+++ b/cameras/kedacom/ipc2655-gi4n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 6.0, "max_width": 3072, "max_height": 2048, "label": "6MP" },
-  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "3072x2048", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "15-50", "aperture": "F1.4", "varifocal": true },
   "night_vision": { "type": "ir", "range_m": 100 },

--- a/cameras/kedacom/ipc2655-gi7n.json
+++ b/cameras/kedacom/ipc2655-gi7n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 6.0, "max_width": 3072, "max_height": 2048, "label": "6MP" },
-  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "3072x2048", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "15-50", "aperture": "F1.4", "varifocal": true },
   "night_vision": { "type": "color", "range_m": 30 },

--- a/cameras/kedacom/ipc2833-fi4n-sir50-z6022.json
+++ b/cameras/kedacom/ipc2833-fi4n-sir50-z6022.json
@@ -22,7 +22,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2855-gi4n.json
+++ b/cameras/kedacom/ipc2855-gi4n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 8.0, "max_width": 3840, "max_height": 2160, "label": "4K" },
-  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "3840x2160", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "10-50", "aperture": "F1.4", "varifocal": true },
   "night_vision": { "type": "ir", "range_m": 100 },

--- a/cameras/kedacom/ipc425-f223-n.json
+++ b/cameras/kedacom/ipc425-f223-n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 60 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 60, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.265" }] },
   "sensor": "1/1.9\" progressive scan CMOS",
   "lens": { "focal_length_mm": "6-138", "aperture": "F1.5 (W) / F3.4 (T)", "varifocal": true },
   "night_vision": { "type": "ir", "range_m": 220 },

--- a/cameras/kedacom/ipc425-f233-n.json
+++ b/cameras/kedacom/ipc425-f233-n.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["ac-mains"],
   "resolution": { "megapixels": 2.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "4.5-148.5", "aperture": "F1.6 (W) / F4.4 (T)", "varifocal": true },
   "field_of_view_deg": "2.34-67.8 (tele-wide)",

--- a/cameras/kedacom/ipc425-g223-n.json
+++ b/cameras/kedacom/ipc425-g223-n.json
@@ -21,7 +21,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.265" }
+    ]
   },
   "sensor": "1/1.9\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc442-i405-np.json
+++ b/cameras/kedacom/ipc442-i405-np.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 4.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264"], "max_fps": 25 },
+  "video": { "codecs": ["H.265", "H.264"], "max_fps": 25, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 25, "codec": "H.265" }] },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": { "count": 1, "focal_length_mm": "2.7-13.5", "varifocal": true },
   "field_of_view_deg": "108.1-46.6 (wide-tele)",

--- a/cameras/kedacom/lc2110-bn-d.json
+++ b/cameras/kedacom/lc2110-bn-d.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 1.3, "max_width": 1280, "max_height": 960, "label": "960p" },
-  "video": { "codecs": ["H.264"], "max_fps": 30 },
+  "video": { "codecs": ["H.264"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6 / 8 / 12", "varifocal": false },
   "field_of_view_deg": "23-96.3",

--- a/cameras/kedacom/lc2150-an-d.json
+++ b/cameras/kedacom/lc2150-an-d.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["dc"],
   "resolution": { "megapixels": 1.3, "max_width": 1280, "max_height": 960, "label": "960p" },
-  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "1280x960", "fps": 30, "codec": "H.264" }] },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": { "focal_length_mm": "3.6 / 6 / 8 / 12 / 16", "aperture": "F1.6", "varifocal": false },
   "field_of_view_deg": "16.9-75.6",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -183048,7 +183048,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "night_vision": {
@@ -183129,7 +183137,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "night_vision": {
@@ -183212,7 +183228,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2\" progressive scan CMOS",
     "night_vision": {
@@ -183298,7 +183322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "field_of_view_deg": "depends on interchangeable C/CS lens",
@@ -183390,7 +183422,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183481,7 +183521,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183682,7 +183730,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183776,7 +183832,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -183873,7 +183937,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -183967,7 +184039,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184060,7 +184140,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184147,7 +184235,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -184338,7 +184434,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184533,7 +184637,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184623,7 +184735,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -184714,7 +184834,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -184809,7 +184937,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -184911,7 +185047,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185000,7 +185144,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185089,7 +185241,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185178,7 +185338,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185381,7 +185549,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185469,7 +185645,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185562,7 +185746,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185647,7 +185839,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185852,7 +186052,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185949,7 +186157,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -186050,7 +186266,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -186134,7 +186358,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186223,7 +186455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186318,7 +186558,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186416,7 +186664,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186616,7 +186872,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -186715,7 +186979,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186813,7 +187085,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186911,7 +187191,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -187309,7 +187597,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187401,7 +187697,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187495,7 +187799,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -187790,7 +188102,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187884,7 +188204,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -187981,7 +188309,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -188082,7 +188418,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -188183,7 +188527,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -188379,7 +188731,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -188459,7 +188819,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -183048,7 +183048,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "night_vision": {
@@ -183129,7 +183137,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "night_vision": {
@@ -183212,7 +183228,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2\" progressive scan CMOS",
     "night_vision": {
@@ -183298,7 +183322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "field_of_view_deg": "depends on interchangeable C/CS lens",
@@ -183390,7 +183422,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183481,7 +183521,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183682,7 +183730,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -183776,7 +183832,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -183873,7 +183937,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -183967,7 +184039,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184060,7 +184140,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184147,7 +184235,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -184338,7 +184434,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184533,7 +184637,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -184623,7 +184735,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -184714,7 +184834,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -184809,7 +184937,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -184911,7 +185047,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185000,7 +185144,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185089,7 +185241,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185178,7 +185338,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185381,7 +185549,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185469,7 +185645,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185562,7 +185746,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185647,7 +185839,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -185852,7 +186052,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -185949,7 +186157,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -186050,7 +186266,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -186134,7 +186358,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186223,7 +186455,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186318,7 +186558,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186416,7 +186664,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186616,7 +186872,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -186715,7 +186979,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1920",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186813,7 +187085,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -186911,7 +187191,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -187309,7 +187597,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187401,7 +187697,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187495,7 +187799,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -187790,7 +188102,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -187884,7 +188204,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -187981,7 +188309,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -188082,7 +188418,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.9\" progressive scan CMOS",
     "lens": {
@@ -188183,7 +188527,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -188379,7 +188731,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -188459,7 +188819,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 46 Kedacom IPC/LC cameras — part of the #177 lane.

## Method (deterministic derivation)
Kedacom's `.jhtml` spec pages are JS-walled and unreliable to fetch, but each record's `resolution`, `video.max_fps`, and `video.codecs` are **already datasheet-verified** from prior Kedacom audits. Kedacom's `max_fps` is the frame rate *at max resolution* (4/8 MP models cap at 20; 2 MP at 30/60), so the main stream is a **faithful reconstruction** of verified data, not a guess:
- main = `resolution.max_* @ max_fps`, codec = primary (`H.265` if supported, else `H.264`).

## Main stream only
Kedacom supports dual/triple streaming, but the sub-stream resolutions aren't in the verified fields, so recording a sub would be guessing (same honest approach as ACTi/Bosch/Hanwha). Only `main` recorded.

## Hygiene
Style-preserving text insertion (compact vs expanded per file) keeps diffs to the added lines only — no whole-file reformatting. The 4 Kedacom files touched by the codec PR (#182) are excluded to keep PRs conflict-free.

Kedacom `streams[]` coverage 8 → 54/58. Builds clean.