### PR TITLE
data: backfill video.streams[] — Ajax (22 cameras, brand complete) (#177)

### DIFF
--- a/cameras/ajax/bulletcam-hl-5mp-28mm.json
+++ b/cameras/ajax/bulletcam-hl-5mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/bulletcam-hl-5mp-4mm.json
+++ b/cameras/ajax/bulletcam-hl-5mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/bulletcam-hl-8mp-28mm.json
+++ b/cameras/ajax/bulletcam-hl-8mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/bulletcam-hl-8mp-4mm.json
+++ b/cameras/ajax/bulletcam-hl-8mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-hlvf-5mp.json
+++ b/cameras/ajax/domecam-hlvf-5mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-hlvf-8mp.json
+++ b/cameras/ajax/domecam-hlvf-8mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-5mp-28mm.json
+++ b/cameras/ajax/domecam-mini-5mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-5mp-4mm.json
+++ b/cameras/ajax/domecam-mini-5mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-8mp-28mm.json
+++ b/cameras/ajax/domecam-mini-8mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-8mp-4mm.json
+++ b/cameras/ajax/domecam-mini-8mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-hl-5mp-28mm.json
+++ b/cameras/ajax/domecam-mini-hl-5mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-hl-8mp-28mm.json
+++ b/cameras/ajax/domecam-mini-hl-8mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/domecam-mini-hl-8mp-4mm.json
+++ b/cameras/ajax/domecam-mini-hl-8mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/doorbell.json
+++ b/cameras/ajax/doorbell.json
@@ -13,7 +13,10 @@
     "label": "4MP"
   },
   "video": {
-    "codecs": ["H.264"]
+    "codecs": ["H.264"],
+    "streams": [
+      { "name": "main", "resolution": "2688x1520", "codec": "H.264" }
+    ]
   },
   "sensor": "4MP CMOS",
   "lens": {

--- a/cameras/ajax/superior-bulletcam-hlvf-4mp.json
+++ b/cameras/ajax/superior-bulletcam-hlvf-4mp.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/ajax/superior-bulletcam-hlvf-8mp.json
+++ b/cameras/ajax/superior-bulletcam-hlvf-8mp.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/ajax/superior-domecam-hlvf-4mp.json
+++ b/cameras/ajax/superior-domecam-hlvf-4mp.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/ajax/superior-domecam-hlvf-8mp.json
+++ b/cameras/ajax/superior-domecam-hlvf-8mp.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" CMOS",
   "lens": {

--- a/cameras/ajax/turretcam-5mp-28mm.json
+++ b/cameras/ajax/turretcam-5mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/turretcam-5mp-4mm.json
+++ b/cameras/ajax/turretcam-5mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/ajax/turretcam-8mp-28mm.json
+++ b/cameras/ajax/turretcam-8mp-28mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/ajax/turretcam-8mp-4mm.json
+++ b/cameras/ajax/turretcam-8mp-4mm.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -36314,7 +36314,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36406,7 +36414,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36498,7 +36514,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36590,7 +36614,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36682,7 +36714,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36775,7 +36815,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36868,7 +36916,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36958,7 +37014,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37048,7 +37112,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37138,7 +37210,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37228,7 +37308,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37320,7 +37408,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37412,7 +37508,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37506,6 +37610,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "4MP CMOS",
@@ -37599,7 +37710,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37694,7 +37813,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37789,7 +37916,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37884,7 +38019,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37978,7 +38121,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -38068,7 +38219,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -38158,7 +38317,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -38248,7 +38415,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -36314,7 +36314,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36406,7 +36414,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36498,7 +36514,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36590,7 +36614,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36682,7 +36714,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36775,7 +36815,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -36868,7 +36916,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -36958,7 +37014,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37048,7 +37112,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37138,7 +37210,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37228,7 +37308,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -37320,7 +37408,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37412,7 +37508,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -37506,6 +37610,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "4MP CMOS",
@@ -37599,7 +37710,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37694,7 +37813,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37789,7 +37916,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37884,7 +38019,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" CMOS",
     "lens": {
@@ -37978,7 +38121,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -38068,7 +38219,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -38158,7 +38317,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -38248,7 +38415,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {


### PR DESCRIPTION
Backfills `video.streams[]` for all 22 Ajax Systems cameras — **completes the Ajax brand** (22/22).

## Method & convention
Verified from official `ajax.systems/products/specs/` pages. **Main stream only**: each Ajax spec page lists a single configurable stream with selectable resolution options (no fixed distinct sub-stream), so recording a sub would be guessing (same honest approach as ACTi/Bosch/Hanwha/Kedacom).

- main = max resolution at max frame rate: 5 MP & 4 MP @25 fps, 8 MP mostly @20 fps (DomeCam HLVF 8MP is @25 per its page), codec `H.265`.
- **DoorBell**: H.264, and its `fps` is **omitted** — the spec page doesn't print a frame rate, so it was left out rather than guessed.
- All 22 main resolutions cross-checked against stored `resolution.max_*`.

Ajax `streams[]` coverage 0 → **22/22 (100%)**. Builds clean.