### PR TITLE
data: backfill video.streams[] — Tapo (21 cameras) (#177)

### DIFF
--- a/cameras/tapo/c100.json
+++ b/cameras/tapo/c100.json
@@ -82,7 +82,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "operating_temp_c": "0 to 40",

--- a/cameras/tapo/c207.json
+++ b/cameras/tapo/c207.json
@@ -50,7 +50,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "indoor",

--- a/cameras/tapo/c217.json
+++ b/cameras/tapo/c217.json
@@ -16,6 +16,14 @@
     "max_fps": 30,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 30,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",

--- a/cameras/tapo/c220.json
+++ b/cameras/tapo/c220.json
@@ -81,7 +81,14 @@
       "H.264"
     ],
     "max_fps": 30,
-    "streams": []
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan Non-Starlight Sensor",
   "operating_temp_c": "0 to 40",

--- a/cameras/tapo/c222-indoor.json
+++ b/cameras/tapo/c222-indoor.json
@@ -24,7 +24,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/tapo/c225.json
+++ b/cameras/tapo/c225.json
@@ -85,7 +85,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "0 to 40",

--- a/cameras/tapo/c250.json
+++ b/cameras/tapo/c250.json
@@ -15,6 +15,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.7\" CMOS",

--- a/cameras/tapo/c260.json
+++ b/cameras/tapo/c260.json
@@ -87,6 +87,14 @@
     "max_fps": 25,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",

--- a/cameras/tapo/c325wb-ca.json
+++ b/cameras/tapo/c325wb-ca.json
@@ -97,7 +97,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "148.7 x 104 x 70.6",

--- a/cameras/tapo/c325wb.json
+++ b/cameras/tapo/c325wb.json
@@ -90,7 +90,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/1.79\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/c400-kit.json
+++ b/cameras/tapo/c400-kit.json
@@ -48,7 +48,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/tapo/c403.json
+++ b/cameras/tapo/c403.json
@@ -61,6 +61,14 @@
     "max_fps": 15,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
     ]
   },
   "features": [

--- a/cameras/tapo/c410.json
+++ b/cameras/tapo/c410.json
@@ -61,6 +61,14 @@
     "max_fps": 15,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.264"
+      }
     ]
   },
   "features": [

--- a/cameras/tapo/c420.json
+++ b/cameras/tapo/c420.json
@@ -75,6 +75,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",

--- a/cameras/tapo/c460.json
+++ b/cameras/tapo/c460.json
@@ -79,7 +79,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "D64.8 x 114.6 mm",

--- a/cameras/tapo/c465.json
+++ b/cameras/tapo/c465.json
@@ -48,7 +48,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/tapo/c520ws.json
+++ b/cameras/tapo/c520ws.json
@@ -91,7 +91,14 @@
       "H.264"
     ],
     "max_fps": 30,
-    "streams": []
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-30 to 60",

--- a/cameras/tapo/c560ws.json
+++ b/cameras/tapo/c560ws.json
@@ -90,7 +90,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-30 to 60",

--- a/cameras/tapo/c660-kit.json
+++ b/cameras/tapo/c660-kit.json
@@ -77,7 +77,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/c710.json
+++ b/cameras/tapo/c710.json
@@ -16,6 +16,14 @@
     "max_fps": 30,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 30,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.8\" CMOS",

--- a/cameras/tapo/d130.json
+++ b/cameras/tapo/d130.json
@@ -19,7 +19,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -221289,7 +221289,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
@@ -221852,7 +221860,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "indoor",
@@ -222130,6 +222146,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
@@ -222300,7 +222324,14 @@
         "H.264"
       ],
       "max_fps": 30,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan Non-Starlight Sensor",
     "operating_temp_c": "0 to 40",
@@ -222337,7 +222368,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -222491,7 +222530,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "0 to 40",
@@ -222852,6 +222899,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.7\" CMOS",
@@ -223024,6 +223078,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
@@ -223328,7 +223390,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.79\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -223439,7 +223509,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
@@ -223602,7 +223680,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -223770,6 +223856,14 @@
       "max_fps": 15,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
       ]
     },
     "features": [
@@ -223857,6 +223951,14 @@
       "max_fps": 15,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.264"
+        }
       ]
     },
     "features": [
@@ -223960,6 +224062,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
@@ -224140,7 +224249,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
@@ -224198,7 +224315,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -224531,7 +224656,14 @@
         "H.264"
       ],
       "max_fps": 30,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -224829,7 +224961,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -225178,7 +225318,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -225307,6 +225455,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -225628,7 +225784,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -221289,7 +221289,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "operating_temp_c": "0 to 40",
@@ -221852,7 +221860,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "indoor",
@@ -222130,6 +222146,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
@@ -222300,7 +222324,14 @@
         "H.264"
       ],
       "max_fps": 30,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan Non-Starlight Sensor",
     "operating_temp_c": "0 to 40",
@@ -222337,7 +222368,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
     "lens": {
@@ -222491,7 +222530,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "0 to 40",
@@ -222852,6 +222899,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.7\" CMOS",
@@ -223024,6 +223078,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
@@ -223328,7 +223390,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.79\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -223439,7 +223509,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
@@ -223602,7 +223680,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -223770,6 +223856,14 @@
       "max_fps": 15,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
       ]
     },
     "features": [
@@ -223857,6 +223951,14 @@
       "max_fps": 15,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.264"
+        }
       ]
     },
     "features": [
@@ -223960,6 +224062,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
@@ -224140,7 +224249,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "D64.8 x 114.6 mm",
@@ -224198,7 +224315,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -224531,7 +224656,14 @@
         "H.264"
       ],
       "max_fps": 30,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -224829,7 +224961,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -225178,7 +225318,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -225307,6 +225455,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -225628,7 +225784,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "lens": {


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 21 Tapo consumer smart cameras (C-series + D130 doorbell) — part of the #177 lane.

## Method (deterministic derivation)
Tapo consumer cameras expose a **single HD stream** over RTSP (`stream1`); no fixed sub-stream resolution is published on the tp-link/tapo spec pages. Each record's `resolution`, `video.max_fps`, and `video.codecs` are already verified, so the main stream is a faithful reconstruction:
- main = `resolution.max_* @ max_fps`, codec = primary (`H.265` for C460/C465, else `H.264`).
- **C250 and C420** omit `fps` (not stated on their pages) rather than guessing.

Main stream only — no invented sub (same honest approach as Kedacom/ACTi/Bosch/Hanwha/Ajax).

## Hygiene
The 14 Tapo files touched by the codec PR (#182) are excluded to keep PRs conflict-free. Builds clean; no whole-file reformatting.