### PR TITLE
data: backfill video.streams[] — ABUS (68 cameras) (#177)

### DIFF
--- a/cameras/abus/ipca32500.json
+++ b/cameras/abus/ipca32500.json
@@ -16,6 +16,14 @@
     "max_fps": 30,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca33500.json
+++ b/cameras/abus/ipca33500.json
@@ -16,6 +16,14 @@
     "max_fps": 50,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 50,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca34512a.json
+++ b/cameras/abus/ipca34512a.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipca52000.json
+++ b/cameras/abus/ipca52000.json
@@ -16,6 +16,14 @@
     "max_fps": 25,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",

--- a/cameras/abus/ipca52010.json
+++ b/cameras/abus/ipca52010.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca53000.json
+++ b/cameras/abus/ipca53000.json
@@ -16,6 +16,14 @@
     "max_fps": 25,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca54572a.json
+++ b/cameras/abus/ipca54572a.json
@@ -22,7 +22,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/abus/ipca54581b.json
+++ b/cameras/abus/ipca54581b.json
@@ -22,7 +22,15 @@
       "H.265",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/abus/ipca62510.json
+++ b/cameras/abus/ipca62510.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca62515.json
+++ b/cameras/abus/ipca62515.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca62520.json
+++ b/cameras/abus/ipca62520.json
@@ -16,6 +16,14 @@
     "max_fps": 50,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 50,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca63500.json
+++ b/cameras/abus/ipca63500.json
@@ -16,6 +16,14 @@
     "max_fps": 50,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 50,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca64581d.json
+++ b/cameras/abus/ipca64581d.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",

--- a/cameras/abus/ipca66500.json
+++ b/cameras/abus/ipca66500.json
@@ -16,6 +16,14 @@
     "max_fps": 24,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x2048",
+        "fps": 24,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca68500.json
+++ b/cameras/abus/ipca68500.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca72500.json
+++ b/cameras/abus/ipca72500.json
@@ -16,6 +16,14 @@
     "max_fps": 25,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",

--- a/cameras/abus/ipca72510.json
+++ b/cameras/abus/ipca72510.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca72515.json
+++ b/cameras/abus/ipca72515.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipca72520.json
+++ b/cameras/abus/ipca72520.json
@@ -16,6 +16,14 @@
     "max_fps": 50,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 50,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca73500.json
+++ b/cameras/abus/ipca73500.json
@@ -16,6 +16,14 @@
     "max_fps": 50,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 50,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca76500.json
+++ b/cameras/abus/ipca76500.json
@@ -16,6 +16,14 @@
     "max_fps": 24,
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x2048",
+        "fps": 24,
+        "codec": "H.264"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipca78500.json
+++ b/cameras/abus/ipca78500.json
@@ -18,6 +18,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",

--- a/cameras/abus/ipcb38511b.json
+++ b/cameras/abus/ipcb38511b.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb44510a.json
+++ b/cameras/abus/ipcb44510a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.5\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb44510b.json
+++ b/cameras/abus/ipcb44510b.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.5\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb44510c.json
+++ b/cameras/abus/ipcb44510c.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.5\" CMOS",

--- a/cameras/abus/ipcb44561a.json
+++ b/cameras/abus/ipcb44561a.json
@@ -23,6 +23,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb44611a.json
+++ b/cameras/abus/ipcb44611a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb54611b.json
+++ b/cameras/abus/ipcb54611b.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb58611a.json
+++ b/cameras/abus/ipcb58611a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb62515a.json
+++ b/cameras/abus/ipcb62515a.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb62520.json
+++ b/cameras/abus/ipcb62520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcb64510a.json
+++ b/cameras/abus/ipcb64510a.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/abus/ipcb64510b.json
+++ b/cameras/abus/ipcb64510b.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/abus/ipcb64510c.json
+++ b/cameras/abus/ipcb64510c.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/abus/ipcb64515b.json
+++ b/cameras/abus/ipcb64515b.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcb64520.json
+++ b/cameras/abus/ipcb64520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcb64620.json
+++ b/cameras/abus/ipcb64620.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive CMOS",
   "lens": {

--- a/cameras/abus/ipcb68515a.json
+++ b/cameras/abus/ipcb68515a.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive CMOS",
   "lens": {

--- a/cameras/abus/ipcb68520.json
+++ b/cameras/abus/ipcb68520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcb68621.json
+++ b/cameras/abus/ipcb68621.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb72515a.json
+++ b/cameras/abus/ipcb72515a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcb72520.json
+++ b/cameras/abus/ipcb72520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb74520.json
+++ b/cameras/abus/ipcb74520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.5\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb78520.json
+++ b/cameras/abus/ipcb78520.json
@@ -18,6 +18,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.5\" Progressive Scan CMOS",

--- a/cameras/abus/ipcb78615a.json
+++ b/cameras/abus/ipcb78615a.json
@@ -17,6 +17,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/abus/ipcs24500.json
+++ b/cameras/abus/ipcs24500.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3072",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/1.7\" progressive CMOS",
   "lens": {

--- a/cameras/abus/ipcs34511a.json
+++ b/cameras/abus/ipcs34511a.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/abus/ipcs34511b.json
+++ b/cameras/abus/ipcs34511b.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/abus/ipcs54511a.json
+++ b/cameras/abus/ipcs54511a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs62120.json
+++ b/cameras/abus/ipcs62120.json
@@ -18,6 +18,14 @@
       "H.264",
       "MPEG-4",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 60,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs64531.json
+++ b/cameras/abus/ipcs64531.json
@@ -24,6 +24,14 @@
       "H.264+",
       "H.265+",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs64611a.json
+++ b/cameras/abus/ipcs64611a.json
@@ -22,6 +22,14 @@
       "H.264",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs82500.json
+++ b/cameras/abus/ipcs82500.json
@@ -17,6 +17,14 @@
     "codecs": [
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs82520.json
+++ b/cameras/abus/ipcs82520.json
@@ -17,6 +17,14 @@
     "codecs": [
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/1.9\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs82530.json
+++ b/cameras/abus/ipcs82530.json
@@ -17,6 +17,14 @@
     "codecs": [
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/1.9\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs83500.json
+++ b/cameras/abus/ipcs83500.json
@@ -17,6 +17,14 @@
     "codecs": [
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs84531.json
+++ b/cameras/abus/ipcs84531.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",

--- a/cameras/abus/ipcs84532.json
+++ b/cameras/abus/ipcs84532.json
@@ -22,6 +22,14 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",

--- a/cameras/abus/ppic31020.json
+++ b/cameras/abus/ppic31020.json
@@ -56,7 +56,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "indoor"

--- a/cameras/abus/ppic52520.json
+++ b/cameras/abus/ppic52520.json
@@ -56,7 +56,15 @@
       "H.264",
       "H.264+"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/abus/ppic52520b.json
+++ b/cameras/abus/ppic52520b.json
@@ -56,7 +56,15 @@
       "H.264",
       "H.264+"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/abus/ppic54520.json
+++ b/cameras/abus/ppic54520.json
@@ -58,7 +58,15 @@
       "H.264",
       "H.264+"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/abus/ppic54520b.json
+++ b/cameras/abus/ppic54520b.json
@@ -58,7 +58,15 @@
       "H.264",
       "H.264+"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/abus/tvip62562.json
+++ b/cameras/abus/tvip62562.json
@@ -23,7 +23,15 @@
       "H.265+",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/abus/tvip64511.json
+++ b/cameras/abus/tvip64511.json
@@ -23,6 +23,14 @@
       "H.264",
       "MJPEG",
       "H.265+"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",

--- a/cameras/abus/tvip82561.json
+++ b/cameras/abus/tvip82561.json
@@ -25,7 +25,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/abus/tvip83900.json
+++ b/cameras/abus/tvip83900.json
@@ -17,6 +17,14 @@
     "codecs": [
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2048x1536",
+        "fps": 25,
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/3\" Progressive Scan CMOS",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -234,6 +234,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -321,6 +329,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -402,6 +418,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -728,6 +752,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
@@ -803,6 +835,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -897,6 +937,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -1221,7 +1269,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
     "lens": {
@@ -1331,7 +1387,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "lens": {
@@ -1544,6 +1608,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -1650,6 +1722,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -1754,6 +1834,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -1831,6 +1919,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2149,6 +2245,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -2390,6 +2494,14 @@
       "max_fps": 24,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 24,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2470,6 +2582,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
@@ -2574,6 +2694,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
@@ -2655,6 +2783,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -2761,6 +2897,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -2865,6 +3009,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2941,6 +3093,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -3018,6 +3178,14 @@
       "max_fps": 24,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 24,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -3097,6 +3265,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
@@ -3693,6 +3869,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -4285,6 +4469,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -4382,6 +4574,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -4484,6 +4684,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" CMOS",
@@ -4828,6 +5036,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -4932,6 +5148,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -5393,6 +5617,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -5743,6 +5975,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -6214,6 +6454,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -6308,6 +6556,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -6418,7 +6674,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6513,7 +6777,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6607,7 +6879,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6698,6 +6978,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -6792,6 +7080,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -7029,7 +7325,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive CMOS",
     "lens": {
@@ -7583,7 +7887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive CMOS",
     "lens": {
@@ -7677,6 +7989,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -7917,6 +8237,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -8026,6 +8354,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -8119,6 +8455,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -8344,6 +8688,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -8786,6 +9138,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -9001,6 +9361,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -9093,7 +9460,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3072",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.7\" progressive CMOS",
     "lens": {
@@ -9557,7 +9932,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -9653,7 +10036,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -9876,6 +10267,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10333,6 +10732,14 @@
         "H.264",
         "MPEG-4",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10684,6 +11091,14 @@
         "H.264+",
         "H.265+",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10924,6 +11339,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -11121,6 +11544,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -11222,6 +11653,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.9\" Progressive Scan CMOS",
@@ -11324,6 +11763,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.9\" Progressive Scan CMOS",
@@ -11426,6 +11873,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
@@ -11905,6 +12360,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -12006,6 +12469,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -12415,7 +12886,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "indoor"
@@ -12919,7 +13398,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13005,7 +13492,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13095,7 +13590,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13179,7 +13682,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -14381,7 +14892,15 @@
         "H.265+",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -14489,6 +15008,14 @@
         "H.264",
         "MJPEG",
         "H.265+"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
@@ -14710,7 +15237,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -14810,6 +15345,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -234,6 +234,14 @@
       "max_fps": 30,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -321,6 +329,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -402,6 +418,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -728,6 +752,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
@@ -803,6 +835,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -897,6 +937,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -1221,7 +1269,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
     "lens": {
@@ -1331,7 +1387,15 @@
         "H.265",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "lens": {
@@ -1544,6 +1608,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -1650,6 +1722,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -1754,6 +1834,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -1831,6 +1919,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2149,6 +2245,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -2390,6 +2494,14 @@
       "max_fps": 24,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 24,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2470,6 +2582,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
@@ -2574,6 +2694,14 @@
       "max_fps": 25,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Sony Exmor CMOS (Sony Xarina DSP)",
@@ -2655,6 +2783,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -2761,6 +2897,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony Exmor R STARVIS CMOS",
@@ -2865,6 +3009,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -2941,6 +3093,14 @@
       "max_fps": 50,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 50,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -3018,6 +3178,14 @@
       "max_fps": 24,
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 24,
+          "codec": "H.264"
+        }
       ]
     },
     "lens": {
@@ -3097,6 +3265,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Sony Exmor R STARVIS CMOS",
@@ -3693,6 +3869,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -4285,6 +4469,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -4382,6 +4574,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -4484,6 +4684,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" CMOS",
@@ -4828,6 +5036,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -4932,6 +5148,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -5393,6 +5617,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
@@ -5743,6 +5975,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -6214,6 +6454,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -6308,6 +6556,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -6418,7 +6674,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6513,7 +6777,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6607,7 +6879,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -6698,6 +6978,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -6792,6 +7080,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -7029,7 +7325,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive CMOS",
     "lens": {
@@ -7583,7 +7887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive CMOS",
     "lens": {
@@ -7677,6 +7989,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -7917,6 +8237,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -8026,6 +8354,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -8119,6 +8455,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -8344,6 +8688,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -8786,6 +9138,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
@@ -9001,6 +9361,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -9093,7 +9460,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3072",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/1.7\" progressive CMOS",
     "lens": {
@@ -9557,7 +9932,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -9653,7 +10036,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -9876,6 +10267,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10333,6 +10732,14 @@
         "H.264",
         "MPEG-4",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10684,6 +11091,14 @@
         "H.264+",
         "H.265+",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -10924,6 +11339,14 @@
         "H.264",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive Scan CMOS",
@@ -11121,6 +11544,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -11222,6 +11653,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.9\" Progressive Scan CMOS",
@@ -11324,6 +11763,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/1.9\" Progressive Scan CMOS",
@@ -11426,6 +11873,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
@@ -11905,6 +12360,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -12006,6 +12469,14 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
@@ -12415,7 +12886,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "indoor"
@@ -12919,7 +13398,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13005,7 +13492,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13095,7 +13590,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -13179,7 +13682,15 @@
         "H.264",
         "H.264+"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -14381,7 +14892,15 @@
         "H.265+",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -14489,6 +15008,14 @@
         "H.264",
         "MJPEG",
         "H.265+"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",
@@ -14710,7 +15237,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS",
     "lens": {
@@ -14810,6 +15345,14 @@
       "codecs": [
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2048x1536",
+          "fps": 25,
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Progressive Scan CMOS",


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 68 ABUS network cameras (IPCA/IPCB/IPCS/TVIP) — part of the #177 lane.

## Method (deterministic derivation)
Each record's `resolution`, `video.max_fps`, and `video.codecs` are already verified (and codecs are already canonical — `H.264+`/`H.265+`/`MJPEG` per the #182 enum). The main stream is a faithful reconstruction:
- main = `resolution.max_* @ max_fps`, codec = primary (`H.265` if H.265/H.265+ supported, else `H.264`).
- `ipcb78615a` omits `fps` (not stored) rather than guessing.

Main stream only — ABUS sub-stream resolutions aren't in the verified fields (same honest approach as Kedacom/Tapo/ACTi/Bosch/Hanwha/Ajax).

## Skipped (5) — need a resolution backfill first
`ipcb74615b`, `ppic46520`, `ppic46520w`, `ppic91000`, `ppic91520` have only `megapixels` (no `max_width`/`max_height`), so a stream resolution can't be derived. Flagging for a separate resolution fill.

ABUS `streams[]` coverage 65 → 133/142. Builds clean; no reformatting.