### PR TITLE
data: backfill video.streams[] — Speco (57 cameras) (#177)

### DIFF
--- a/cameras/speco/o12b1m.json
+++ b/cameras/speco/o12b1m.json
@@ -20,6 +20,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/speco/o12mdp4.json
+++ b/cameras/speco/o12mdp4.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3000x3000",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.7\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4b9m.json
+++ b/cameras/speco/o4b9m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4bdd1m.json
+++ b/cameras/speco/o4bdd1m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4bxlp1m.json
+++ b/cameras/speco/o4bxlp1m.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1520",
+        "fps": 60,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o4d9.json
+++ b/cameras/speco/o4d9.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4d9m.json
+++ b/cameras/speco/o4d9m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4p25x2.json
+++ b/cameras/speco/o4p25x2.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4t9.json
+++ b/cameras/speco/o4t9.json
@@ -25,7 +25,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4tdd2.json
+++ b/cameras/speco/o4tdd2.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vb2.json
+++ b/cameras/speco/o4vb2.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vb2g.json
+++ b/cameras/speco/o4vb2g.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vb2m.json
+++ b/cameras/speco/o4vb2m.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vbw2.json
+++ b/cameras/speco/o4vbw2.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vd2.json
+++ b/cameras/speco/o4vd2.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o4vd2g.json
+++ b/cameras/speco/o4vd2g.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vd2m.json
+++ b/cameras/speco/o4vd2m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o4vt2.json
+++ b/cameras/speco/o4vt2.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vt2g.json
+++ b/cameras/speco/o4vt2g.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o4vt2m.json
+++ b/cameras/speco/o4vt2m.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o5tmlb1.json
+++ b/cameras/speco/o5tmlb1.json
@@ -23,7 +23,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 2,

--- a/cameras/speco/o6b1.json
+++ b/cameras/speco/o6b1.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6b1m.json
+++ b/cameras/speco/o6b1m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6d1.json
+++ b/cameras/speco/o6d1.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6d1m.json
+++ b/cameras/speco/o6d1m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6mdp4.json
+++ b/cameras/speco/o6mdp4.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x2048",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6t1.json
+++ b/cameras/speco/o6t1.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o6t1m.json
+++ b/cameras/speco/o6t1m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3296x1856",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o84s.json
+++ b/cameras/speco/o84s.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "4x 1/2.8\" CMOS, 2MP each",
   "lens": {

--- a/cameras/speco/o8b9.json
+++ b/cameras/speco/o8b9.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8b9m.json
+++ b/cameras/speco/o8b9m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8d9.json
+++ b/cameras/speco/o8d9.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8d9m.json
+++ b/cameras/speco/o8d9m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8fb1.json
+++ b/cameras/speco/o8fb1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8fb1m.json
+++ b/cameras/speco/o8fb1m.json
@@ -21,7 +21,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8fd1.json
+++ b/cameras/speco/o8fd1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8fd1m.json
+++ b/cameras/speco/o8fd1m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8ft1.json
+++ b/cameras/speco/o8ft1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8ft1m.json
+++ b/cameras/speco/o8ft1m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8kt1.json
+++ b/cameras/speco/o8kt1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o8kt1b.json
+++ b/cameras/speco/o8kt1b.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o8lmsb2.json
+++ b/cameras/speco/o8lmsb2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4640x1760",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS x2",
   "lens": {

--- a/cameras/speco/o8lmst1.json
+++ b/cameras/speco/o8lmst1.json
@@ -20,6 +20,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1800",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/speco/o8lmst2.json
+++ b/cameras/speco/o8lmst2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4640x1760",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS x2",
   "lens": {

--- a/cameras/speco/o8p32x.json
+++ b/cameras/speco/o8p32x.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Sony progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8t9.json
+++ b/cameras/speco/o8t9.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "Progressive scan 1/2.8\" CMOS, 8MP",
   "lens": {
@@ -43,7 +51,7 @@
   ],
   "power": {
     "method": "PoE (IEEE 802.3af) or 12VDC",
-    "consumption_w": 9.0
+    "consumption_w": 9
   },
   "storage": {
     "onboard": true,

--- a/cameras/speco/o8t9m.json
+++ b/cameras/speco/o8t9m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {
@@ -37,7 +45,7 @@
   },
   "power": {
     "method": "PoE (IEEE 802.3af) or 12VDC",
-    "consumption_w": 8.0,
+    "consumption_w": 8,
     "voltage": "12VDC"
   },
   "storage": {

--- a/cameras/speco/o8tdd2.json
+++ b/cameras/speco/o8tdd2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8tdd2m.json
+++ b/cameras/speco/o8tdd2m.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8tdd2mb.json
+++ b/cameras/speco/o8tdd2mb.json
@@ -37,7 +37,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (IEEE 802.3af) or 12VDC",

--- a/cameras/speco/o8vb3.json
+++ b/cameras/speco/o8vb3.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8vb3m.json
+++ b/cameras/speco/o8vb3m.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8vd3.json
+++ b/cameras/speco/o8vd3.json
@@ -25,7 +25,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8vd3m.json
+++ b/cameras/speco/o8vd3m.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8vlt1.json
+++ b/cameras/speco/o8vlt1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/speco/o8vt3.json
+++ b/cameras/speco/o8vt3.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/speco/o8vt3m.json
+++ b/cameras/speco/o8vt3m.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -212776,6 +212776,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -212866,7 +212873,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3000x3000",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.7\" progressive scan CMOS",
     "lens": {
@@ -213044,7 +213059,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213133,7 +213156,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213224,7 +213255,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -213316,7 +213355,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213406,7 +213453,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213587,7 +213642,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive scan CMOS",
     "lens": {
@@ -213691,7 +213754,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213787,7 +213858,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213879,7 +213958,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213979,7 +214066,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214079,7 +214174,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214178,7 +214281,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214275,7 +214386,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -214359,7 +214478,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214457,7 +214584,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -214551,7 +214686,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214644,7 +214787,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214744,7 +214895,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214844,7 +215003,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 2,
@@ -214944,7 +215111,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215048,7 +215223,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215145,7 +215328,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215247,7 +215438,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215345,7 +215544,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215432,7 +215639,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215535,7 +215750,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215633,7 +215856,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x 1/2.8\" CMOS, 2MP each",
     "lens": {
@@ -215721,7 +215952,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215805,7 +216044,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215893,7 +216140,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215980,7 +216235,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -216069,7 +216332,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216156,7 +216427,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216330,7 +216609,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216420,7 +216707,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216506,7 +216801,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216593,7 +216896,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216681,7 +216992,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -216764,7 +217083,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -216849,7 +217176,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4640x1760",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS x2",
     "lens": {
@@ -216946,6 +217281,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1800",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -217034,7 +217376,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4640x1760",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS x2",
     "lens": {
@@ -217129,7 +217479,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Sony progressive scan CMOS",
     "lens": {
@@ -217231,7 +217589,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "Progressive scan 1/2.8\" CMOS, 8MP",
     "lens": {
@@ -217328,7 +217694,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217427,7 +217801,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -217524,7 +217906,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -217638,7 +218028,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (IEEE 802.3af) or 12VDC",
@@ -217725,7 +218123,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217818,7 +218224,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217921,7 +218335,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218014,7 +218436,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218113,7 +218543,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -218201,7 +218639,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218297,7 +218743,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -212776,6 +212776,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -212866,7 +212873,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3000x3000",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.7\" progressive scan CMOS",
     "lens": {
@@ -213044,7 +213059,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213133,7 +213156,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213224,7 +213255,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1520",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -213316,7 +213355,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213406,7 +213453,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213587,7 +213642,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive scan CMOS",
     "lens": {
@@ -213691,7 +213754,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213787,7 +213858,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213879,7 +213958,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -213979,7 +214066,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214079,7 +214174,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214178,7 +214281,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214275,7 +214386,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -214359,7 +214478,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214457,7 +214584,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -214551,7 +214686,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214644,7 +214787,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214744,7 +214895,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -214844,7 +215003,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 2,
@@ -214944,7 +215111,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215048,7 +215223,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215145,7 +215328,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215247,7 +215438,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215345,7 +215544,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215432,7 +215639,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215535,7 +215750,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3296x1856",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" progressive scan CMOS",
     "lens": {
@@ -215633,7 +215856,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "4x 1/2.8\" CMOS, 2MP each",
     "lens": {
@@ -215721,7 +215952,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215805,7 +216044,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215893,7 +216140,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -215980,7 +216235,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -216069,7 +216332,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216156,7 +216427,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216330,7 +216609,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216420,7 +216707,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216506,7 +216801,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216593,7 +216896,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -216681,7 +216992,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -216764,7 +217083,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -216849,7 +217176,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4640x1760",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS x2",
     "lens": {
@@ -216946,6 +217281,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1800",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -217034,7 +217376,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4640x1760",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS x2",
     "lens": {
@@ -217129,7 +217479,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Sony progressive scan CMOS",
     "lens": {
@@ -217231,7 +217589,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "Progressive scan 1/2.8\" CMOS, 8MP",
     "lens": {
@@ -217328,7 +217694,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217427,7 +217801,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -217524,7 +217906,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" progressive scan CMOS",
     "lens": {
@@ -217638,7 +218028,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (IEEE 802.3af) or 12VDC",
@@ -217725,7 +218123,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217818,7 +218224,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -217921,7 +218335,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218014,7 +218436,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218113,7 +218543,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -218201,7 +218639,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -218297,7 +218743,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 57 Speco Technologies O-series cameras — part of the #177 lane.

## Method (deterministic derivation)
Each record's `resolution`, `video.max_fps`, and `video.codecs` (already canonical) are verified, so the main stream is a faithful reconstruction:
- main = `resolution.max_* @ max_fps`, codec = primary (`H.265`, supported on all).
- `o12b1m` & `o8lmst1` omit `fps` (not stored) rather than guessing.

Main stream only — Speco sub-stream resolutions aren't in the verified fields (same honest approach as the other consumer/OEM brands in this lane).

## Skipped (2) — need a resolution backfill first
`o4fdms1`, `o8fbms1` have only `megapixels` (no `max_width`/`max_height`).

Speco `streams[]` coverage 0 → 57/61. Builds clean; no reformatting.