### PR TITLE
data: backfill video.streams[] — IMOU (46 cameras) (#177)

### DIFF
--- a/cameras/imou/a1-pro-4k.json
+++ b/cameras/imou/a1-pro-4k.json
@@ -23,6 +23,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/imou/aov-pt-4k.json
+++ b/cameras/imou/aov-pt-4k.json
@@ -21,7 +21,15 @@
     "codecs": [
       "H.265"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/aov-pt-5mp.json
+++ b/cameras/imou/aov-pt-5mp.json
@@ -26,7 +26,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/aov-pt-lite.json
+++ b/cameras/imou/aov-pt-lite.json
@@ -21,7 +21,15 @@
     "codecs": [
       "H.265"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/aov-pt-pro.json
+++ b/cameras/imou/aov-pt-pro.json
@@ -25,6 +25,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" Progressive CMOS",

--- a/cameras/imou/bullet-2-pro-4mp.json
+++ b/cameras/imou/bullet-2-pro-4mp.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/imou/bullet-2c-5mp.json
+++ b/cameras/imou/bullet-2c-5mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3.2\" progressive CMOS (3MP variant)",
   "lens": {

--- a/cameras/imou/bullet-2c-pro-5mp.json
+++ b/cameras/imou/bullet-2c-pro-5mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" progressive CMOS (3MP variant)",
   "lens": {

--- a/cameras/imou/bullet-2e-pro-5mp.json
+++ b/cameras/imou/bullet-2e-pro-5mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" progressive CMOS (3MP variant)",
   "lens": {

--- a/cameras/imou/bullet-3-5mp.json
+++ b/cameras/imou/bullet-3-5mp.json
@@ -26,7 +26,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" 5MP progressive CMOS",
   "lens": {

--- a/cameras/imou/bullet-3c-5mp.json
+++ b/cameras/imou/bullet-3c-5mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/imou/cell-2.json
+++ b/cameras/imou/cell-2.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" CMOS",
   "lens": {

--- a/cameras/imou/cell-3.json
+++ b/cameras/imou/cell-3.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/cell-3c-5mp.json
+++ b/cameras/imou/cell-3c-5mp.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/cell-3c-all-in-one-5mp.json
+++ b/cameras/imou/cell-3c-all-in-one-5mp.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/cell-go-full-color.json
+++ b/cameras/imou/cell-go-full-color.json
@@ -20,7 +20,15 @@
     "codecs": [
       "H.265"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/imou/cell-pt-2c-5mp.json
+++ b/cameras/imou/cell-pt-2c-5mp.json
@@ -20,6 +20,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/imou/cell-pt-4g-2nd.json
+++ b/cameras/imou/cell-pt-4g-2nd.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/cell-pt-lite.json
+++ b/cameras/imou/cell-pt-lite.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/imou/cell-pt.json
+++ b/cameras/imou/cell-pt.json
@@ -20,6 +20,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "field_of_view_deg": "pan 360 / tilt",

--- a/cameras/imou/cruiser-2c-5mp.json
+++ b/cameras/imou/cruiser-2c-5mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" 5MP progressive CMOS",
   "lens": {

--- a/cameras/imou/cruiser-dual-2.json
+++ b/cameras/imou/cruiser-dual-2.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3.06\" 5MP progressive CMOS (per lens)",
   "lens": {

--- a/cameras/imou/cruiser-dual-2c-4g.json
+++ b/cameras/imou/cruiser-dual-2c-4g.json
@@ -28,7 +28,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" 3MP progressive CMOS (per lens)",
   "lens": {

--- a/cameras/imou/cruiser-dual.json
+++ b/cameras/imou/cruiser-dual.json
@@ -26,7 +26,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" 3MP progressive CMOS (per lens)",
   "lens": {

--- a/cameras/imou/cruiser-pano-z.json
+++ b/cameras/imou/cruiser-pano-z.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "fixed 1/3\" 4MP CMOS x2; PT 1/3\" 5MP CMOS",
   "lens": {

--- a/cameras/imou/cruiser-sc-4g-5mp.json
+++ b/cameras/imou/cruiser-sc-4g-5mp.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" 5MP progressive CMOS",
   "lens": {

--- a/cameras/imou/cruiser-sc-8mp.json
+++ b/cameras/imou/cruiser-sc-8mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" progressive CMOS",
   "lens": {

--- a/cameras/imou/cruiser-triple.json
+++ b/cameras/imou/cruiser-triple.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "fixed 1/2.8\" 3MP CMOS x2; PT 1/3.06\" 5MP CMOS",
   "lens": {

--- a/cameras/imou/cruiser-z-5mp.json
+++ b/cameras/imou/cruiser-z-5mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" 5MP progressive CMOS",
   "lens": {

--- a/cameras/imou/cruiser.json
+++ b/cameras/imou/cruiser.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" progressive CMOS",
   "lens": {

--- a/cameras/imou/dk3-3mp.json
+++ b/cameras/imou/dk3-3mp.json
@@ -22,6 +22,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" CMOS",

--- a/cameras/imou/dk7-5mp.json
+++ b/cameras/imou/dk7-5mp.json
@@ -26,6 +26,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" CMOS",

--- a/cameras/imou/knight-8mp.json
+++ b/cameras/imou/knight-8mp.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" 8MP progressive CMOS",
   "lens": {

--- a/cameras/imou/ps2m-5mp.json
+++ b/cameras/imou/ps2m-5mp.json
@@ -22,6 +22,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/3\" progressive CMOS",

--- a/cameras/imou/ps3d-5mp.json
+++ b/cameras/imou/ps3d-5mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/imou/ps3e-8mp.json
+++ b/cameras/imou/ps3e-8mp.json
@@ -23,6 +23,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/3\" progressive scan CMOS",

--- a/cameras/imou/ps70f-10mp.json
+++ b/cameras/imou/ps70f-10mp.json
@@ -27,7 +27,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS (per lens)",
   "lens": {

--- a/cameras/imou/ps7f-5mp.json
+++ b/cameras/imou/ps7f-5mp.json
@@ -28,7 +28,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/imou/ps8d-5mp.json
+++ b/cameras/imou/ps8d-5mp.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS",
   "lens": {

--- a/cameras/imou/ranger-2-4mp.json
+++ b/cameras/imou/ranger-2-4mp.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/ranger-2-pro-4k.json
+++ b/cameras/imou/ranger-2-pro-4k.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/ranger-2c-pro-4k.json
+++ b/cameras/imou/ranger-2c-pro-4k.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/ranger-rc-r1.json
+++ b/cameras/imou/ranger-rc-r1.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive CMOS",
   "lens": {

--- a/cameras/imou/rex-3d-r1-5mp.json
+++ b/cameras/imou/rex-3d-r1-5mp.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1620",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/imou/titan-pro-6mp.json
+++ b/cameras/imou/titan-pro-6mp.json
@@ -24,6 +24,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x2048",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.8\" CMOS",

--- a/cameras/imou/versa-2mp.json
+++ b/cameras/imou/versa-2mp.json
@@ -23,6 +23,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" 2MP progressive CMOS",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -175614,6 +175614,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -175771,7 +175778,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -175854,7 +175869,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -175935,7 +175958,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -176018,6 +176049,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive CMOS",
@@ -176191,7 +176229,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -176282,7 +176328,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3.2\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176370,7 +176424,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176552,7 +176614,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176645,7 +176715,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -176737,7 +176815,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -176826,7 +176912,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -176912,7 +177006,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -176991,7 +177093,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177074,7 +177184,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177230,7 +177348,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -177306,6 +177432,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 / tilt",
@@ -177380,6 +177513,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -177456,7 +177596,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177534,7 +177682,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -177615,7 +177771,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive CMOS",
     "lens": {
@@ -177804,7 +177968,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -177964,7 +178136,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 3MP progressive CMOS (per lens)",
     "lens": {
@@ -178059,7 +178239,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3.06\" 5MP progressive CMOS (per lens)",
     "lens": {
@@ -178160,7 +178348,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 3MP progressive CMOS (per lens)",
     "lens": {
@@ -178254,7 +178450,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "fixed 1/3\" 4MP CMOS x2; PT 1/3\" 5MP CMOS",
     "lens": {
@@ -178353,7 +178557,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -178448,7 +178660,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive CMOS",
     "lens": {
@@ -178630,7 +178850,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "fixed 1/2.8\" 3MP CMOS x2; PT 1/3.06\" 5MP CMOS",
     "lens": {
@@ -178725,7 +178953,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -178815,6 +179051,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -178909,6 +179152,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -179081,7 +179331,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 8MP progressive CMOS",
     "lens": {
@@ -179173,6 +179431,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" progressive CMOS",
@@ -179262,7 +179527,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179351,6 +179624,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" progressive scan CMOS",
@@ -179445,7 +179725,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS (per lens)",
     "lens": {
@@ -179541,7 +179829,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179632,7 +179928,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179818,7 +180122,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -179908,7 +180220,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -180000,7 +180320,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -180088,7 +180416,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -180267,7 +180603,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -180358,6 +180702,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" CMOS",
@@ -180452,6 +180803,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -175614,6 +175614,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -175771,7 +175778,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -175854,7 +175869,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -175935,7 +175958,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -176018,6 +176049,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" Progressive CMOS",
@@ -176191,7 +176229,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -176282,7 +176328,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3.2\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176370,7 +176424,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176552,7 +176614,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" progressive CMOS (3MP variant)",
     "lens": {
@@ -176645,7 +176715,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -176737,7 +176815,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -176826,7 +176912,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -176912,7 +177006,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -176991,7 +177093,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177074,7 +177184,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177230,7 +177348,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -177306,6 +177432,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 / tilt",
@@ -177380,6 +177513,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -177456,7 +177596,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive CMOS",
     "lens": {
@@ -177534,7 +177682,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -177615,7 +177771,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive CMOS",
     "lens": {
@@ -177804,7 +177968,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -177964,7 +178136,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 3MP progressive CMOS (per lens)",
     "lens": {
@@ -178059,7 +178239,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3.06\" 5MP progressive CMOS (per lens)",
     "lens": {
@@ -178160,7 +178348,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 3MP progressive CMOS (per lens)",
     "lens": {
@@ -178254,7 +178450,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "fixed 1/3\" 4MP CMOS x2; PT 1/3\" 5MP CMOS",
     "lens": {
@@ -178353,7 +178557,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -178448,7 +178660,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" progressive CMOS",
     "lens": {
@@ -178630,7 +178850,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "fixed 1/2.8\" 3MP CMOS x2; PT 1/3.06\" 5MP CMOS",
     "lens": {
@@ -178725,7 +178953,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" 5MP progressive CMOS",
     "lens": {
@@ -178815,6 +179051,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -178909,6 +179152,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" CMOS",
@@ -179081,7 +179331,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 8MP progressive CMOS",
     "lens": {
@@ -179173,6 +179431,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" progressive CMOS",
@@ -179262,7 +179527,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179351,6 +179624,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/3\" progressive scan CMOS",
@@ -179445,7 +179725,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS (per lens)",
     "lens": {
@@ -179541,7 +179829,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179632,7 +179928,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS",
     "lens": {
@@ -179818,7 +180122,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -179908,7 +180220,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -180000,7 +180320,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive CMOS",
     "lens": {
@@ -180088,7 +180416,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive CMOS",
     "lens": {
@@ -180267,7 +180603,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1620",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -180358,6 +180702,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x2048",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.8\" CMOS",
@@ -180452,6 +180803,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 46 IMOU consumer cameras (Dahua's consumer sub-brand) — part of the #177 lane.

## Method (deterministic derivation)
Each record's `resolution`, `video.max_fps`, and `video.codecs` (already canonical, all support H.265) are verified, so the main stream is a faithful reconstruction:
- main = `resolution.max_* @ max_fps`, codec `H.265`.
- 10 cameras omit `fps` (not stored) rather than guessing.

Main stream only — IMOU consumer cameras expose a single stream; sub-stream resolutions aren't in the verified fields (same honest approach as Tapo/Kedacom/etc.).

IMOU `streams[]` coverage 0 → 46/56 (remaining 10 lack a `codecs` list — out of scope for streams-only). Builds clean; no reformatting.