### PR TITLE
data: backfill video.streams[] — Xiaomi (23 cameras) (#177)

### DIFF
--- a/cameras/xiaomi/aw300.json
+++ b/cameras/xiaomi/aw300.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/bw500.json
+++ b/cameras/xiaomi/bw500.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c100.json
+++ b/cameras/xiaomi/c100.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/xiaomi/c200.json
+++ b/cameras/xiaomi/c200.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c201.json
+++ b/cameras/xiaomi/c201.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/xiaomi/c300-dual.json
+++ b/cameras/xiaomi/c300-dual.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c300.json
+++ b/cameras/xiaomi/c300.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c301.json
+++ b/cameras/xiaomi/c301.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c302.json
+++ b/cameras/xiaomi/c302.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/xiaomi/c400.json
+++ b/cameras/xiaomi/c400.json
@@ -25,6 +25,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c500-dual.json
+++ b/cameras/xiaomi/c500-dual.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c500-pro.json
+++ b/cameras/xiaomi/c500-pro.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1666",
+        "codec": "H.265"
+      }
     ]
   },
   "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",

--- a/cameras/xiaomi/c500.json
+++ b/cameras/xiaomi/c500.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.45\" BSI CMOS",

--- a/cameras/xiaomi/c700.json
+++ b/cameras/xiaomi/c700.json
@@ -21,6 +21,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/xiaomi/c701-pro.json
+++ b/cameras/xiaomi/c701-pro.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/c701.json
+++ b/cameras/xiaomi/c701.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",

--- a/cameras/xiaomi/cw300.json
+++ b/cameras/xiaomi/cw300.json
@@ -22,6 +22,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/xiaomi/cw400.json
+++ b/cameras/xiaomi/cw400.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/cw500-dual.json
+++ b/cameras/xiaomi/cw500-dual.json
@@ -25,6 +25,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/mi-360-2k-pro.json
+++ b/cameras/xiaomi/mi-360-2k-pro.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/mi-360-2k.json
+++ b/cameras/xiaomi/mi-360-2k.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/xiaomi/mi-camera-2k-magnetic-mount.json
+++ b/cameras/xiaomi/mi-camera-2k-magnetic-mount.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.265"
+      }
     ]
   },
   "field_of_view_deg": "125 (lens angle)",

--- a/cameras/xiaomi/mi-home-360-1080p.json
+++ b/cameras/xiaomi/mi-home-360-1080p.json
@@ -24,6 +24,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -236794,6 +236794,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -236998,6 +237005,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237064,6 +237078,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237133,6 +237154,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237219,6 +237247,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237285,6 +237320,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237351,6 +237393,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237421,6 +237470,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237493,6 +237549,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237566,6 +237629,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237630,6 +237700,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.45\" BSI CMOS",
@@ -237707,6 +237784,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237780,6 +237864,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1666",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",
@@ -237854,6 +237945,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237936,6 +238034,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",
@@ -238018,6 +238123,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238098,6 +238210,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -238169,6 +238288,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238246,6 +238372,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238316,6 +238449,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238393,6 +238533,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238526,6 +238673,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "125 (lens angle)",
@@ -238596,6 +238750,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -236794,6 +236794,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -236998,6 +237005,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237064,6 +237078,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237133,6 +237154,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237219,6 +237247,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237285,6 +237320,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237351,6 +237393,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237421,6 +237470,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237493,6 +237549,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237566,6 +237629,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237630,6 +237700,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.45\" BSI CMOS",
@@ -237707,6 +237784,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -237780,6 +237864,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1666",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 (horizontal), tilt 114 (vertical)",
@@ -237854,6 +237945,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -237936,6 +238034,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "pan 360 (horizontal), tilt 109 (vertical)",
@@ -238018,6 +238123,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238098,6 +238210,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -238169,6 +238288,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238246,6 +238372,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238316,6 +238449,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238393,6 +238533,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -238526,6 +238673,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.265"
+        }
       ]
     },
     "field_of_view_deg": "125 (lens angle)",
@@ -238596,6 +238750,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 23 Xiaomi/Mi consumer cameras — part of the #177 lane.

## Method (deterministic derivation)
main = `resolution.max_*` + primary codec (`H.265`, supported on all). **fps is omitted on all 23** — Xiaomi's consumer spec pages don't publish a reliable max framerate, so recording resolution + codec is the honest maximum rather than guessing fps. `fps` is an optional schema field.

Main stream only — Xiaomi consumer cameras expose a single stream. Builds clean; no reformatting.

Xiaomi `streams[]` coverage 0 → 23/26 (remaining 3 lack a `codecs` list).