### PR TITLE
data: backfill video.streams[] — Costar (3 cameras) (#177)

### DIFF
--- a/cameras/costar/av02cid-200.json
+++ b/cameras/costar/av02cid-200.json
@@ -25,6 +25,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/costar/av02cid-201.json
+++ b/cameras/costar/av02cid-201.json
@@ -25,6 +25,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/costar/av12cpd-236.json
+++ b/cameras/costar/av12cpd-236.json
@@ -26,7 +26,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 4,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -74181,6 +74181,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -74282,6 +74289,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -74873,7 +74887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 4,

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -74181,6 +74181,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -74282,6 +74289,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -74873,7 +74887,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 4,


### PR DESCRIPTION
Backfills the main stream for the 3 Costar records that have a pixel resolution (deterministic derivation from verified fields). **7 of 10 Costar records were skipped** — they have only `megapixels` and no `resolution.max_width`/`max_height`, so a stream resolution can't be derived: `av05cid-200`, `av05cid-201`, `av05cld-200`, `av10956dn-28`, `av12cfe-250`, `av16956dn-28`, `av4956dn-28`. These need a resolution backfill first (flagging for follow-up). Builds clean.