### PR TITLE
data: backfill video.streams[] — INSTAR (12 cameras) (#177)

### DIFF
--- a/cameras/instar/in-8003-full-hd.json
+++ b/cameras/instar/in-8003-full-hd.json
@@ -22,6 +22,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "Panasonic WDR CMOS (1080p)",
@@ -61,7 +68,7 @@
   "last_verified": "2026-07-05",
   "configs": {
     "frigate": {
-      "notes": "Thin data \u2014 the wiki technical-specifications page exists but its detailed content (lens, FOV, exact resolution options) was not captured in the search snippets reviewed. ONVIF support not confirmed. RTSP path/ports not researched. Verify directly against the camera's web UI or full wiki page before publishing.",
+      "notes": "Thin data — the wiki technical-specifications page exists but its detailed content (lens, FOV, exact resolution options) was not captured in the search snippets reviewed. ONVIF support not confirmed. RTSP path/ports not researched. Verify directly against the camera's web UI or full wiki page before publishing.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-8015-full-hd.json
+++ b/cameras/instar/in-8015-full-hd.json
@@ -22,6 +22,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/3\" Panasonic WDR CMOS, OmniPixel3-HS 4.3-micron pixel, 115dB dynamic range",
@@ -65,7 +72,7 @@
   "last_verified": "2026-07-05",
   "configs": {
     "frigate": {
-      "notes": "ONVIF support not confirmed for this legacy model (only RTSP/H.264 confirmed). Pan/tilt is remote-controlled via INSTAR's own web UI/CGI commands rather than confirmed ONVIF PTZ \u2014 verify before assuming ONVIF PTZ control works. RTSP path/ports not researched.",
+      "notes": "ONVIF support not confirmed for this legacy model (only RTSP/H.264 confirmed). Pan/tilt is remote-controlled via INSTAR's own web UI/CGI commands rather than confirmed ONVIF PTZ — verify before assuming ONVIF PTZ control works. RTSP path/ports not researched.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-8401-2k-plus.json
+++ b/cameras/instar/in-8401-2k-plus.json
@@ -21,6 +21,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (2K+ line)",
@@ -46,7 +53,7 @@
   },
   "features": [
     "two IR LED types: 940nm invisible IR plus 850nm slightly-visible-red LEDs for stronger illumination when needed",
-    "speaker/two-way audio arrangement not fully confirmed for this specific model \u2014 verify before publishing",
+    "speaker/two-way audio arrangement not fully confirmed for this specific model — verify before publishing",
     "AI object detection",
     "compact indoor box form factor",
     "LAN or dual-band WiFi (2.4GHz/5GHz), WPA3 PSK and Enterprise",
@@ -68,7 +75,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "Not yet verified against a physical unit. This model's full tech-spec table (exact sensor, lens, FOV, ONVIF profile) was not located \u2014 only the marketing description page. Confirm before publishing.",
+      "notes": "Not yet verified against a physical unit. This model's full tech-spec table (exact sensor, lens, FOV, ONVIF profile) was not located — only the marketing description page. Confirm before publishing.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-8403-2k-plus.json
+++ b/cameras/instar/in-8403-2k-plus.json
@@ -22,6 +22,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (2K+ line, 1440p chipset)",
@@ -47,7 +54,7 @@
   },
   "features": [
     "two IR LEDs, switchable between infrared and white-light illumination; PIR-linked in recent firmware",
-    "audio hardware not fully confirmed for this specific model \u2014 verify before publishing",
+    "audio hardware not fully confirmed for this specific model — verify before publishing",
     "designed for recessed ceiling mounting (mini dome)",
     "integrated PIR sensor",
     "AI object detection",
@@ -69,7 +76,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "Not yet verified against a physical unit. Exact lens/FOV numbers not located \u2014 the wiki technical-specifications page exists but its content wasn't captured in the search snippet. Confirm before publishing.",
+      "notes": "Not yet verified against a physical unit. Exact lens/FOV numbers not located — the wiki technical-specifications page exists but its content wasn't captured in the search snippet. Confirm before publishing.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-8415-2k-plus.json
+++ b/cameras/instar/in-8415-2k-plus.json
@@ -22,6 +22,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (2K+ line)",

--- a/cameras/instar/in-8815-4k.json
+++ b/cameras/instar/in-8815-4k.json
@@ -22,6 +22,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (4K)",
@@ -69,7 +76,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "Not yet verified against a physical unit. Exact lens/FOV/zoom figures not located for this model. Dimensions/weight reused from the IN-8415 2K+ page's boilerplate copy \u2014 confirm they actually apply to the 4K unit rather than being a template carryover.",
+      "notes": "Not yet verified against a physical unit. Exact lens/FOV/zoom figures not located for this model. Dimensions/weight reused from the IN-8415 2K+ page's boilerplate copy — confirm they actually apply to the 4K unit rather than being a template carryover.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-9008-full-hd.json
+++ b/cameras/instar/in-9008-full-hd.json
@@ -23,6 +23,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "Panasonic WDR CMOS (1080p)",
@@ -76,12 +83,12 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/11",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/12",
-      "notes": "RTSP path confirmed via a community forum report for this camera generation (format rtsp://{address}:{port}/{stream}, e.g. /11 for the main stream) \u2014 this is a different, simpler numbering convention than the '/livestream/NN' pattern used on the newer 2K+/4K line. Exact substream number not independently confirmed. ONVIF support was not confirmed anywhere in the sources reviewed for this specific model (RTSP is confirmed, ONVIF is not); check the camera's own web UI before assuming ONVIF compatibility.",
+      "notes": "RTSP path confirmed via a community forum report for this camera generation (format rtsp://{address}:{port}/{stream}, e.g. /11 for the main stream) — this is a different, simpler numbering convention than the '/livestream/NN' pattern used on the newer 2K+/4K line. Exact substream number not independently confirmed. ONVIF support was not confirmed anywhere in the sources reviewed for this specific model (RTSP is confirmed, ONVIF is not); check the camera's own web UI before assuming ONVIF compatibility.",
       "verified": false
     },
     "home_assistant": {
       "integration": "generic_camera",
-      "notes": "ONVIF support unconfirmed for this legacy model (see frigate notes) \u2014 the generic RTSP/MJPEG camera integration is a safer starting point than assuming ONVIF works. MQTT is a well-documented alternative integration path INSTAR has supported since this camera's era.",
+      "notes": "ONVIF support unconfirmed for this legacy model (see frigate notes) — the generic RTSP/MJPEG camera integration is a safer starting point than assuming ONVIF works. MQTT is a well-documented alternative integration path INSTAR has supported since this camera's era.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/instar/in-9020-full-hd.json
+++ b/cameras/instar/in-9020-full-hd.json
@@ -24,7 +24,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Panasonic WDR CMOS (1080p)",
   "lens": {
@@ -56,7 +64,7 @@
     "two_way": false
   },
   "features": [
-    "4x optical zoom with autofocus \u2014 the only camera in the legacy Full HD line with true optical (not just digital) zoom",
+    "4x optical zoom with autofocus — the only camera in the legacy Full HD line with true optical (not just digital) zoom",
     "pan/tilt with PTZ controller for smooth movement",
     "integrated PIR sensor, 4 configurable alarm areas",
     "note: motion detection/PIR is disabled while the camera is actively panning/tilting/zooming",

--- a/cameras/instar/in-9408-2k-plus.json
+++ b/cameras/instar/in-9408-2k-plus.json
@@ -23,7 +23,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/3\" Sony STARVIS IMX335 CMOS",
   "lens": {
@@ -82,7 +90,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "INSTAR's own RTSP path convention uses numbered channel IDs (12 = main/full res, 13 = sub-stream) rather than named streams \u2014 confirm exact channel numbering against the camera's own web UI (Multimedia > Video) before publishing, as it has varied slightly across firmware versions.",
+      "notes": "INSTAR's own RTSP path convention uses numbered channel IDs (12 = main/full res, 13 = sub-stream) rather than named streams — confirm exact channel numbering against the camera's own web UI (Multimedia > Video) before publishing, as it has varied slightly across firmware versions.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-9420-2k-plus.json
+++ b/cameras/instar/in-9420-2k-plus.json
@@ -23,7 +23,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "Panasonic WQHD CMOS (STARVIS-class)",
   "lens": {
@@ -80,7 +88,7 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "Same numbered-channel RTSP convention as other INSTAR models; not yet verified against a physical unit. Pan/tilt/zoom position is not controllable via ONVIF PTZ commands on all firmware versions \u2014 check INSTAR's own CGI command API as an alternative if ONVIF PTZ control is flaky.",
+      "notes": "Same numbered-channel RTSP convention as other INSTAR models; not yet verified against a physical unit. Pan/tilt/zoom position is not controllable via ONVIF PTZ commands on all firmware versions — check INSTAR's own CGI command API as an alternative if ONVIF PTZ control is flaky.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/instar/in-9808-4k.json
+++ b/cameras/instar/in-9808-4k.json
@@ -22,6 +22,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (4K)",
@@ -66,12 +73,12 @@
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/livestream/12",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/livestream/13",
-      "notes": "Lens focal length/FOV and exact ONVIF profile could not be pinned down for this model \u2014 the product pages reviewed had copy-pasted description text from the IN-9408 2K+ page (mentioning a 4.3mm/90 degree lens that may or may not apply here), and two different IN-9808 listings disagreed on ONVIF Profile S vs Profile T. Confirm both the lens spec and ONVIF profile against the camera's own web UI before publishing.",
+      "notes": "Lens focal length/FOV and exact ONVIF profile could not be pinned down for this model — the product pages reviewed had copy-pasted description text from the IN-9408 2K+ page (mentioning a 4.3mm/90 degree lens that may or may not apply here), and two different IN-9808 listings disagreed on ONVIF Profile S vs Profile T. Confirm both the lens spec and ONVIF profile against the camera's own web UI before publishing.",
       "verified": false
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "ONVIF support confirmed in principle, but the exact profile (S vs T) is unconfirmed for this model \u2014 see frigate notes.",
+      "notes": "ONVIF support confirmed in principle, but the exact profile (S vs T) is unconfirmed for this model — see frigate notes.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/instar/in-9820-4k.json
+++ b/cameras/instar/in-9820-4k.json
@@ -22,6 +22,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "Sony STARVIS CMOS (4K)",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -180542,6 +180542,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Panasonic WDR CMOS (1080p)",
@@ -180620,6 +180627,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Panasonic WDR CMOS, OmniPixel3-HS 4.3-micron pixel, 115dB dynamic range",
@@ -180701,6 +180715,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line)",
@@ -180787,6 +180808,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line, 1440p chipset)",
@@ -180873,6 +180901,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line)",
@@ -180959,6 +180994,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",
@@ -181046,6 +181088,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Panasonic WDR CMOS (1080p)",
@@ -181140,7 +181189,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Panasonic WDR CMOS (1080p)",
     "lens": {
@@ -181233,7 +181290,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Sony STARVIS IMX335 CMOS",
     "lens": {
@@ -181332,7 +181397,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "Panasonic WQHD CMOS (STARVIS-class)",
     "lens": {
@@ -181428,6 +181501,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",
@@ -181511,6 +181591,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -180542,6 +180542,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Panasonic WDR CMOS (1080p)",
@@ -180620,6 +180627,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/3\" Panasonic WDR CMOS, OmniPixel3-HS 4.3-micron pixel, 115dB dynamic range",
@@ -180701,6 +180715,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line)",
@@ -180787,6 +180808,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line, 1440p chipset)",
@@ -180873,6 +180901,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (2K+ line)",
@@ -180959,6 +180994,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",
@@ -181046,6 +181088,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "Panasonic WDR CMOS (1080p)",
@@ -181140,7 +181189,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Panasonic WDR CMOS (1080p)",
     "lens": {
@@ -181233,7 +181290,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/3\" Sony STARVIS IMX335 CMOS",
     "lens": {
@@ -181332,7 +181397,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "Panasonic WQHD CMOS (STARVIS-class)",
     "lens": {
@@ -181428,6 +181501,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",
@@ -181511,6 +181591,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "Sony STARVIS CMOS (4K)",


### PR DESCRIPTION
Backfills the main stream for 12 INSTAR cameras (deterministic derivation from verified `resolution` + `max_fps` + primary codec). Main stream only; 9 omit `fps` (not stored). Builds clean; no reformatting.