### PR TITLE
chore: regenerate stale doc for ds-2cd2767g3-liptrzsy (fixes main build)

### DIFF
--- a/docs/cameras/hikvision/ds-2cd2767g3-liptrzsy.md
+++ b/docs/cameras/hikvision/ds-2cd2767g3-liptrzsy.md
@@ -33,7 +33,7 @@
 
 ## Sources
 
-- https://assets.hikvision.com/prd/normal/all/doc/sm000077890/DS-2CD2747G3-LIPTRZS2UY_SL_Datasheet_20260629.pdf
+- https://assets.hikvision.com/prd/normal/all/doc/sm000107013/DS-2CD2767G3-LIPTRZSY_Datasheet_20260629.pdf
 
 ---
 *Auto-generated from hikvision-ds-2cd2767g3-liptrzsy.json — do not edit by hand.*


### PR DESCRIPTION
The 1.54.0 release corrected this camera's source URL in the JSON (it pointed to a different model's datasheet), but its generated markdown doc wasn't re-run through `gen-docs.js`, leaving `docs/cameras/hikvision/ds-2cd2767g3-liptrzsy.md` stale by one line. The post-merge `build` job on main regenerated it and tried to auto-commit, but was blocked by branch protection — hence the red build. This PR syncs the doc so the check passes. No data change; `build.js` + `gen-docs.js` both run clean afterward.