### PR TITLE
data: backfill video.streams[] — Annke (34 cameras) (#177)

### DIFF
--- a/cameras/annke/c1200-i91dd.json
+++ b/cameras/annke/c1200-i91dd.json
@@ -32,7 +32,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 10
+    "max_fps": 10,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c1200-i91dn.json
+++ b/cameras/annke/c1200-i91dn.json
@@ -37,6 +37,13 @@
       "H.265",
       "H.264+",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "codec": "H.265"
+      }
     ]
   },
   "power": {

--- a/cameras/annke/c1200d-i91dg.json
+++ b/cameras/annke/c1200d-i91dg.json
@@ -34,7 +34,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 10
+    "max_fps": 10,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c500d-i51dn.json
+++ b/cameras/annke/c500d-i51dn.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/annke/c800-i91bd.json
+++ b/cameras/annke/c800-i91bd.json
@@ -32,6 +32,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91bl.json
+++ b/cameras/annke/c800-i91bl.json
@@ -32,6 +32,13 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91bm.json
+++ b/cameras/annke/c800-i91bm.json
@@ -32,13 +32,19 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {
     "type": "ir",
     "range_m": 30,
     "min_lux_color": 0.01
-
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91bn.json
+++ b/cameras/annke/c800-i91bn.json
@@ -32,6 +32,13 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91db.json
+++ b/cameras/annke/c800-i91db.json
@@ -33,7 +33,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91df.json
+++ b/cameras/annke/c800-i91df.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dl.json
+++ b/cameras/annke/c800-i91dl.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dm-28mm.json
+++ b/cameras/annke/c800-i91dm-28mm.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dm-40mm.json
+++ b/cameras/annke/c800-i91dm-40mm.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800x.json
+++ b/cameras/annke/c800x.json
@@ -30,6 +30,13 @@
       "H.265",
       "H.264+",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/cz425x-i81hb.json
+++ b/cameras/annke/cz425x-i81hb.json
@@ -34,7 +34,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz804-i91de.json
+++ b/cameras/annke/cz804-i91de.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz804-i91dq.json
+++ b/cameras/annke/cz804-i91dq.json
@@ -32,7 +32,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz825x-i91bw.json
+++ b/cameras/annke/cz825x-i91bw.json
@@ -30,7 +30,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd600-i51fs.json
+++ b/cameras/annke/fcd600-i51fs.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd800-i91et.json
+++ b/cameras/annke/fcd800-i91et.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd800-i91ev.json
+++ b/cameras/annke/fcd800-i91ev.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i51dx.json
+++ b/cameras/annke/i51dx.json
@@ -29,7 +29,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i51ex.json
+++ b/cameras/annke/i51ex.json
@@ -31,7 +31,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i81em.json
+++ b/cameras/annke/i81em.json
@@ -31,7 +31,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bh.json
+++ b/cameras/annke/i91bh.json
@@ -29,7 +29,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bi.json
+++ b/cameras/annke/i91bi.json
@@ -29,7 +29,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bk.json
+++ b/cameras/annke/i91bk.json
@@ -30,7 +30,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/annke/i91bv.json
+++ b/cameras/annke/i91bv.json
@@ -25,7 +25,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/nc500-i81hd.json
+++ b/cameras/annke/nc500-i81hd.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/nc500-i81he.json
+++ b/cameras/annke/nc500-i81he.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/ncbr800-i91dj.json
+++ b/cameras/annke/ncbr800-i91dj.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/ncbr800-i91du.json
+++ b/cameras/annke/ncbr800-i91du.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/nct425-i81el.json
+++ b/cameras/annke/nct425-i81el.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/slpr400-i81hy.json
+++ b/cameras/annke/slpr400-i81hy.json
@@ -32,7 +32,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -42262,7 +42262,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42367,6 +42375,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "codec": "H.265"
+        }
       ]
     },
     "power": {
@@ -42471,7 +42486,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42668,7 +42691,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -42766,6 +42797,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42869,6 +42907,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42980,6 +43025,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43086,6 +43138,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43198,7 +43257,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43303,7 +43370,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43408,7 +43483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43512,7 +43595,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43622,7 +43713,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43726,6 +43825,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43829,7 +43935,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43931,7 +44045,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44033,7 +44155,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44133,7 +44263,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44237,7 +44375,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44338,7 +44484,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44445,7 +44599,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44543,7 +44705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44641,7 +44811,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44831,7 +45009,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -44929,7 +45115,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45026,7 +45220,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45125,7 +45327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -45220,7 +45430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45418,7 +45636,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45521,7 +45747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45720,7 +45954,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45823,7 +46065,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45924,7 +46174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -46025,7 +46283,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -42262,7 +42262,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42367,6 +42375,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "codec": "H.265"
+        }
       ]
     },
     "power": {
@@ -42471,7 +42486,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42668,7 +42691,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -42766,6 +42797,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42869,6 +42907,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42980,6 +43025,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43086,6 +43138,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43198,7 +43257,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43303,7 +43370,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43408,7 +43483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43512,7 +43595,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43622,7 +43713,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43726,6 +43825,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43829,7 +43935,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43931,7 +44045,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44033,7 +44155,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44133,7 +44263,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44237,7 +44375,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44338,7 +44484,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44445,7 +44599,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44543,7 +44705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44641,7 +44811,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44831,7 +45009,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -44929,7 +45115,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45026,7 +45220,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45125,7 +45327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -45220,7 +45430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45418,7 +45636,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45521,7 +45747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45720,7 +45954,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45823,7 +46065,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45924,7 +46174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -46025,7 +46283,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",


### PR DESCRIPTION
Backfills the `video.streams[]` main stream for 34 Annke cameras — part of the #177 lane. Deterministic derivation from verified fields (main = `resolution.max_* @ max_fps`, codec `H.265`; 6 omit `fps`, not stored). Main stream only (OEM configurable multi-stream; sub resolutions not in verified fields). Codecs already canonical. Regenerated data/ + docs/; builds clean, no reformatting.