### PR TITLE
release: 1.54.1 — video.streams[] backfill continued (+112 cameras, 17 brands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.54.1] — 2026-07-29
+
+**`video.streams[]` backfill, continued (#177).** +112 cameras across 17 (mostly small) brands — dataset-wide streams coverage **1,349 → 1,461**. Main stream derived from each record's already-verified `resolution` / `max_fps` / `codecs`; main-stream-only (these OEM/consumer brands document configurable multi-profile streaming with no fixed sub-stream).
+
+- **Annke (+34), CP Plus (+22), Tapo (+10), Kasa (+9), Foscam (+6), SV3C (+5), Kedacom (+4), LTS (+4), Uniarch (+4), Amcrest (+3), Aqara (+2), Arlo (+2), Canon (+2), Eufy (+2), EZVIZ (+1), Longse (+1), Reolink (+1).**
+
+Includes the Tapo/Kedacom records that were held back from 1.54.0 to avoid conflicting with the codec-normalization branch (now merged).
+
 ## [1.54.0] — 2026-07-29
 
 **`video.streams[]` backfill (#177) + codec normalization & enum (#180).**

--- a/cameras/amcrest/ip5m-t1273ew-ai.json
+++ b/cameras/amcrest/ip5m-t1273ew-ai.json
@@ -13,7 +13,10 @@
   },
   "video": {
     "codecs": ["H.265", "H.264"],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      { "name": "main", "resolution": "2592x1944", "fps": 20, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/amcrest/ip8m-2899ew-ai.json
+++ b/cameras/amcrest/ip8m-2899ew-ai.json
@@ -24,7 +24,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/amcrest/ip8m-vt2879ew-ai.json
+++ b/cameras/amcrest/ip8m-vt2879ew-ai.json
@@ -13,7 +13,10 @@
   },
   "video": {
     "codecs": ["H.265", "H.264"],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      { "name": "main", "resolution": "3840x2160", "fps": 15, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/annke/c1200-i91dd.json
+++ b/cameras/annke/c1200-i91dd.json
@@ -32,7 +32,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 10
+    "max_fps": 10,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c1200-i91dn.json
+++ b/cameras/annke/c1200-i91dn.json
@@ -37,6 +37,13 @@
       "H.265",
       "H.264+",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "codec": "H.265"
+      }
     ]
   },
   "power": {

--- a/cameras/annke/c1200d-i91dg.json
+++ b/cameras/annke/c1200d-i91dg.json
@@ -34,7 +34,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 10
+    "max_fps": 10,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x3072",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c500d-i51dn.json
+++ b/cameras/annke/c500d-i51dn.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2592x1944",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/annke/c800-i91bd.json
+++ b/cameras/annke/c800-i91bd.json
@@ -32,6 +32,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91bl.json
+++ b/cameras/annke/c800-i91bl.json
@@ -32,6 +32,13 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91bm.json
+++ b/cameras/annke/c800-i91bm.json
@@ -32,13 +32,19 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {
     "type": "ir",
     "range_m": 30,
     "min_lux_color": 0.01
-
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/annke/c800-i91bn.json
+++ b/cameras/annke/c800-i91bn.json
@@ -32,6 +32,13 @@
       "H.265+",
       "H.265",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/c800-i91db.json
+++ b/cameras/annke/c800-i91db.json
@@ -33,7 +33,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91df.json
+++ b/cameras/annke/c800-i91df.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dl.json
+++ b/cameras/annke/c800-i91dl.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dm-28mm.json
+++ b/cameras/annke/c800-i91dm-28mm.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800-i91dm-40mm.json
+++ b/cameras/annke/c800-i91dm-40mm.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/c800x.json
+++ b/cameras/annke/c800x.json
@@ -30,6 +30,13 @@
       "H.265",
       "H.264+",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "night_vision": {

--- a/cameras/annke/cz425x-i81hb.json
+++ b/cameras/annke/cz425x-i81hb.json
@@ -34,7 +34,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz804-i91de.json
+++ b/cameras/annke/cz804-i91de.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz804-i91dq.json
+++ b/cameras/annke/cz804-i91dq.json
@@ -32,7 +32,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/cz825x-i91bw.json
+++ b/cameras/annke/cz825x-i91bw.json
@@ -30,7 +30,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd600-i51fs.json
+++ b/cameras/annke/fcd600-i51fs.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd800-i91et.json
+++ b/cameras/annke/fcd800-i91et.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/fcd800-i91ev.json
+++ b/cameras/annke/fcd800-i91ev.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x1860",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i51dx.json
+++ b/cameras/annke/i51dx.json
@@ -29,7 +29,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3632x1632",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i51ex.json
+++ b/cameras/annke/i51ex.json
@@ -31,7 +31,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/i81em.json
+++ b/cameras/annke/i81em.json
@@ -31,7 +31,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bh.json
+++ b/cameras/annke/i91bh.json
@@ -29,7 +29,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bi.json
+++ b/cameras/annke/i91bi.json
@@ -29,7 +29,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "5120x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/i91bk.json
+++ b/cameras/annke/i91bk.json
@@ -30,7 +30,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/annke/i91bv.json
+++ b/cameras/annke/i91bv.json
@@ -25,7 +25,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/nc500-i81hd.json
+++ b/cameras/annke/nc500-i81hd.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/nc500-i81he.json
+++ b/cameras/annke/nc500-i81he.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "color",

--- a/cameras/annke/ncbr800-i91dj.json
+++ b/cameras/annke/ncbr800-i91dj.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/ncbr800-i91du.json
+++ b/cameras/annke/ncbr800-i91du.json
@@ -35,7 +35,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/nct425-i81el.json
+++ b/cameras/annke/nct425-i81el.json
@@ -33,7 +33,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "hybrid",

--- a/cameras/annke/slpr400-i81hy.json
+++ b/cameras/annke/slpr400-i81hy.json
@@ -32,7 +32,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "night_vision": {
     "type": "ir",

--- a/cameras/aqara/camera-g100.json
+++ b/cameras/aqara/camera-g100.json
@@ -34,6 +34,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "codec": "H.264"
+      }
     ]
   },
   "power": {

--- a/cameras/aqara/doorbell-camera-g400-wired.json
+++ b/cameras/aqara/doorbell-camera-g400-wired.json
@@ -29,6 +29,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1600x1200",
+        "codec": "H.264"
+      }
     ]
   },
   "power": {

--- a/cameras/arlo/q-plus.json
+++ b/cameras/arlo/q-plus.json
@@ -14,7 +14,10 @@
   },
   "video": {
     "codecs": ["H.264"],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.264" }
+    ]
   },
   "field_of_view_deg": "130 diagonal",
   "night_vision": {

--- a/cameras/arlo/q.json
+++ b/cameras/arlo/q.json
@@ -14,7 +14,10 @@
   },
   "video": {
     "codecs": ["H.264"],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 30, "codec": "H.264" }
+    ]
   },
   "field_of_view_deg": "130 diagonal",
   "night_vision": {

--- a/cameras/canon/vb-h47.json
+++ b/cameras/canon/vb-h47.json
@@ -13,7 +13,10 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      { "name": "main", "resolution": "1920x1080", "fps": 60, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/canon/vb-m46.json
+++ b/cameras/canon/vb-m46.json
@@ -13,7 +13,10 @@
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      { "name": "main", "resolution": "1280x960", "fps": 60, "codec": "H.265" }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-e35q.json
+++ b/cameras/cp-plus/cp-e35q.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-e45q-india.json
+++ b/cameras/cp-plus/cp-e45q-india.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-be51e-vmd-q.json
+++ b/cameras/cp-plus/cp-unc-be51e-vmd-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 5MP progressive CMOS",
   "power": {

--- a/cameras/cp-plus/cp-unc-da21l3b-lq.json
+++ b/cameras/cp-plus/cp-unc-da21l3b-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 2MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-da21l3c-q.json
+++ b/cameras/cp-plus/cp-unc-da21l3c-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" 2MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-da41l3c-d-lq2.json
+++ b/cameras/cp-plus/cp-unc-da41l3c-d-lq2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-da41l3c-d-q2.json
+++ b/cameras/cp-plus/cp-unc-da41l3c-d-q2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-da41l3c-lq.json
+++ b/cameras/cp-plus/cp-unc-da41l3c-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ee61l2c-vmd-q.json
+++ b/cameras/cp-plus/cp-unc-ee61l2c-vmd-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x2560",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" 6MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ta21l3c-q.json
+++ b/cameras/cp-plus/cp-unc-ta21l3c-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" 2MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ta21l6c-q.json
+++ b/cameras/cp-plus/cp-unc-ta21l6c-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 2MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ta41l3c-d-lq.json
+++ b/cameras/cp-plus/cp-unc-ta41l3c-d-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ta41l3c-d-q2.json
+++ b/cameras/cp-plus/cp-unc-ta41l3c-d-q2.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-ta41l3c-lq.json
+++ b/cameras/cp-plus/cp-unc-ta41l3c-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" 4MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-tc21l5c-vmd-lq.json
+++ b/cameras/cp-plus/cp-unc-tc21l5c-vmd-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 2MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-tc61l5c-vmd-lq.json
+++ b/cameras/cp-plus/cp-unc-tc61l5c-vmd-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 6MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-tc81l5c-vmd-lq.json
+++ b/cameras/cp-plus/cp-unc-tc81l5c-vmd-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 8MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-tc81zl6c-vmd-lq.json
+++ b/cameras/cp-plus/cp-unc-tc81zl6c-vmd-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 8MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-te81zl6c-vmds-q.json
+++ b/cameras/cp-plus/cp-unc-te81zl6c-vmds-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 8MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-vc61l5c-vmd-lq.json
+++ b/cameras/cp-plus/cp-unc-vc61l5c-vmd-lq.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3288x1850",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 6MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-unc-vc81zl5c-vmd-q.json
+++ b/cameras/cp-plus/cp-unc-vc81zl5c-vmd-q.json
@@ -22,7 +22,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.7\" 8MP progressive CMOS",
   "lens": {

--- a/cameras/cp-plus/cp-z43q.json
+++ b/cameras/cp-plus/cp-z43q.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.9\" CMOS",
   "lens": {

--- a/cameras/eufy/eufycam-s3-pro.json
+++ b/cameras/eufy/eufycam-s3-pro.json
@@ -97,7 +97,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/eufy/eufycam-s4.json
+++ b/cameras/eufy/eufycam-s4.json
@@ -77,7 +77,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/ezviz/hb90x-dual-4g.json
+++ b/cameras/ezviz/hb90x-dual-4g.json
@@ -37,7 +37,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Rechargeable battery (10,400mAh); 8W monocrystalline solar panel; DC 5V/2A adapter (sold separately); Nano SIM card required for 4G",

--- a/cameras/foscam/foscam-c8m.json
+++ b/cameras/foscam/foscam-c8m.json
@@ -20,7 +20,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "CMOS",
   "field_of_view_deg": "Horizontal 108, Vertical 59.8",
@@ -63,7 +71,7 @@
   "status": "available",
   "configs": {
     "frigate": {
-      "notes": "Sourced from a single retailer listing rather than us.foscam.com/C8M.html directly \u2014 verify against the official spec table before publishing. RTSP path/ports not researched for this model.",
+      "notes": "Sourced from a single retailer listing rather than us.foscam.com/C8M.html directly — verify against the official spec table before publishing. RTSP path/ports not researched for this model.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/foscam/foscam-pd8.json
+++ b/cameras/foscam/foscam-pd8.json
@@ -20,7 +20,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "High Definition Color CMOS",
   "lens": {

--- a/cameras/foscam/foscam-sd8ep.json
+++ b/cameras/foscam/foscam-sd8ep.json
@@ -22,7 +22,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "High Definition Color CMOS",
   "lens": {

--- a/cameras/foscam/foscam-sd8p.json
+++ b/cameras/foscam/foscam-sd8p.json
@@ -20,7 +20,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "High Definition Color CMOS",
   "lens": {

--- a/cameras/foscam/foscam-v5ep.json
+++ b/cameras/foscam/foscam-v5ep.json
@@ -21,7 +21,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 25,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "High Definition Color CMOS",
   "lens": {

--- a/cameras/foscam/foscam-v8ep.json
+++ b/cameras/foscam/foscam-v8ep.json
@@ -22,7 +22,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "High Definition Color CMOS",
   "lens": {
@@ -84,7 +92,7 @@
     },
     "home_assistant": {
       "integration": "onvif",
-      "notes": "No native Foscam integration in HA core; use the generic ONVIF integration. ONVIF support stated on Foscam's site but not itemized in this model's spec table \u2014 confirm before publishing.",
+      "notes": "No native Foscam integration in HA core; use the generic ONVIF integration. ONVIF support stated on Foscam's site but not itemized in this model's spec table — confirm before publishing.",
       "connection_type": "local"
     },
     "blue_iris": {

--- a/cameras/kasa/ec60.json
+++ b/cameras/kasa/ec60.json
@@ -30,7 +30,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "5V DC 1.0A via included AC adapter",

--- a/cameras/kasa/ec70.json
+++ b/cameras/kasa/ec70.json
@@ -37,7 +37,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "storage": {
     "onboard": true,

--- a/cameras/kasa/ec71.json
+++ b/cameras/kasa/ec71.json
@@ -33,7 +33,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "5VDC power adapter (100-240VAC input) via USB cable",

--- a/cameras/kasa/kc120.json
+++ b/cameras/kasa/kc120.json
@@ -33,7 +33,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "5V DC 1.0A power adapter (Micro USB)",

--- a/cameras/kasa/kc400.json
+++ b/cameras/kasa/kc400.json
@@ -27,7 +27,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "5V DC 1.0A via AC power adapter"

--- a/cameras/kasa/kc401.json
+++ b/cameras/kasa/kc401.json
@@ -32,7 +32,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "5V DC 1.0A power adapter",

--- a/cameras/kasa/kc410s.json
+++ b/cameras/kasa/kc410s.json
@@ -34,7 +34,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "power": {
     "method": "DC power adapter (5.0 VDC, 1.0A)",

--- a/cameras/kasa/kc411s.json
+++ b/cameras/kasa/kc411s.json
@@ -36,7 +36,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "storage": {
     "onboard": true,

--- a/cameras/kasa/kd110.json
+++ b/cameras/kasa/kd110.json
@@ -33,7 +33,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "storage": {
     "onboard": true,

--- a/cameras/kedacom/ipc2533-fn-sir50-z2812.json
+++ b/cameras/kedacom/ipc2533-fn-sir50-z2812.json
@@ -7,7 +7,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 5.0, "max_width": 3072, "max_height": 1728, "label": "5MP" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 30, "streams": [{ "name": "main", "resolution": "3072x1728", "fps": 30, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8-12", "aperture": "F1.6-F3.3", "varifocal": true },
   "field_of_view_deg": "30.3-107",

--- a/cameras/kedacom/ipc2552-fn-sir50-z2812.json
+++ b/cameras/kedacom/ipc2552-fn-sir50-z2812.json
@@ -26,7 +26,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3072x1728",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/kedacom/ipc2833-fn-sir50-l.json
+++ b/cameras/kedacom/ipc2833-fn-sir50-l.json
@@ -6,7 +6,7 @@
   "connectivity": ["ethernet"],
   "power_source": ["poe", "dc"],
   "resolution": { "megapixels": 8.0, "max_width": 3840, "max_height": 2160, "label": "4K" },
-  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20 },
+  "video": { "codecs": ["H.265", "H.264", "MJPEG"], "max_fps": 20, "streams": [{ "name": "main", "resolution": "3840x2160", "fps": 20, "codec": "H.265" }] },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": { "focal_length_mm": "2.8 / 3.6 / 6", "aperture": "F1.0", "varifocal": false },
   "field_of_view_deg": "54.5-105.5",

--- a/cameras/kedacom/ipc2852-fn-sir50-z.json
+++ b/cameras/kedacom/ipc2852-fn-sir50-z.json
@@ -28,7 +28,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" progressive scan CMOS",
   "lens": {

--- a/cameras/longse/longse-lbf30sv800.json
+++ b/cameras/longse/longse-lbf30sv800.json
@@ -23,7 +23,15 @@
       "H.264+",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3864x2218",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/1.8\" OmniVision CMOS",
   "lens": {
@@ -44,7 +52,7 @@
     "max_microsd_gb": 512,
     "nvr_compatible": true,
     "cloud": true,
-    "notes": "microSD slot supports up to 512GB per some retailer listings, though another listing states 128GB \u2014 confirm exact firmware-dependent limit before publishing."
+    "notes": "microSD slot supports up to 512GB per some retailer listings, though another listing states 128GB — confirm exact firmware-dependent limit before publishing."
   },
   "protocols": [
     "onvif",

--- a/cameras/lts/lts-ltcmip9783nw-sz.json
+++ b/cameras/lts/lts-ltcmip9783nw-sz.json
@@ -28,7 +28,15 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.5\" Progressive Scan CMOS",
   "lens": {
@@ -71,7 +79,7 @@
   "environment": [
     "outdoor"
   ],
-  "release_notes": "LTS (LT Security Inc.) is a US-based distributor selling Hikvision OEM hardware under its own model numbering (Platinum, Pro-X, Sapphire, Pro-VS series). Note: Hikvision-derived firmware has shipped with ONVIF disabled by default since v5.5.0 \u2014 it must be manually enabled under Configuration > Network > Advanced Settings > Integration Protocol before use with Frigate/Home Assistant/third-party NVRs.",
+  "release_notes": "LTS (LT Security Inc.) is a US-based distributor selling Hikvision OEM hardware under its own model numbering (Platinum, Pro-X, Sapphire, Pro-VS series). Note: Hikvision-derived firmware has shipped with ONVIF disabled by default since v5.5.0 — it must be manually enabled under Configuration > Network > Advanced Settings > Integration Protocol before use with Frigate/Home Assistant/third-party NVRs.",
   "sources": [
     "https://ltsecurityinc.com/8-mp-ir-varifocal-bullet-network-camera.html"
   ],

--- a/cameras/lts/lts-ptzip688x36.json
+++ b/cameras/lts/lts-ptzip688x36.json
@@ -25,7 +25,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4096x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "2/3\" Progressive Scan CMOS",
   "lens": {

--- a/cameras/lts/lts-vsip3442w-28ma.json
+++ b/cameras/lts/lts-vsip3442w-28ma.json
@@ -26,7 +26,10 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      { "name": "main", "resolution": "2688x1520", "fps": 30, "codec": "H.265" }
+    ]
   },
   "sensor": "CMOS",
   "lens": {

--- a/cameras/lts/lts-vsip75122f-se.json
+++ b/cameras/lts/lts-vsip75122f-se.json
@@ -25,6 +25,13 @@
       "H.265",
       "H.264",
       "MJPEG"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "4000x3000",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/1.7\" CMOS",

--- a/cameras/reolink/rlc-811wa.json
+++ b/cameras/reolink/rlc-811wa.json
@@ -88,7 +88,15 @@
     "codecs": [
       "H.265"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 15,
+        "codec": "H.265"
+      }
+    ]
   },
   "environment": [
     "outdoor"

--- a/cameras/sv3c/b04poe.json
+++ b/cameras/sv3c/b04poe.json
@@ -39,6 +39,13 @@
   "video": {
     "codecs": [
       "H.265"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "codec": "H.265"
+      }
     ]
   },
   "features": [

--- a/cameras/sv3c/b06w.json
+++ b/cameras/sv3c/b06w.json
@@ -22,6 +22,13 @@
   "video": {
     "codecs": [
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "codec": "H.264"
+      }
     ]
   },
   "sensor": "1/2.9\" CMOS",

--- a/cameras/sv3c/c22-4k.json
+++ b/cameras/sv3c/c22-4k.json
@@ -22,6 +22,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "lens": {

--- a/cameras/sv3c/hx03.json
+++ b/cameras/sv3c/hx03.json
@@ -22,6 +22,13 @@
     "codecs": [
       "H.265",
       "H.264"
+    ],
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "codec": "H.265"
+      }
     ]
   },
   "sensor": "1/2.8\" Sony IMX415 CMOS",

--- a/cameras/sv3c/ptz-poe-36x.json
+++ b/cameras/sv3c/ptz-poe-36x.json
@@ -23,7 +23,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "lens": {
     "count": 1,

--- a/cameras/tapo/c120.json
+++ b/cameras/tapo/c120.json
@@ -86,7 +86,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-25 to 45",

--- a/cameras/tapo/c121.json
+++ b/cameras/tapo/c121.json
@@ -81,7 +81,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
   "field_of_view_deg": "120 (diagonal), 103 (horizontal), 55 (vertical)",

--- a/cameras/tapo/c320ws.json
+++ b/cameras/tapo/c320ws.json
@@ -86,7 +86,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/c325wb-india.json
+++ b/cameras/tapo/c325wb-india.json
@@ -94,7 +94,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "operating_temp_c": "-20 to 45",
   "dimensions_mm": "148.7 x 104 x 70.6",

--- a/cameras/tapo/c402.json
+++ b/cameras/tapo/c402.json
@@ -67,7 +67,14 @@
       "H.264"
     ],
     "max_fps": 15,
-    "streams": []
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/c530ws.json
+++ b/cameras/tapo/c530ws.json
@@ -86,7 +86,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2880x1620",
+        "fps": 30,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
   "operating_temp_c": "-30 to 60",

--- a/cameras/tapo/c720.json
+++ b/cameras/tapo/c720.json
@@ -86,7 +86,14 @@
       "H.264"
     ],
     "max_fps": 15,
-    "streams": []
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" progressive scan CMOS Starlight sensor",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/d230s1.json
+++ b/cameras/tapo/d230s1.json
@@ -71,7 +71,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\"",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/d235-doorbell.json
+++ b/cameras/tapo/d235-doorbell.json
@@ -89,7 +89,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1920",
+        "fps": 20,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/2.7\" Progressive Scan CMOS",
   "operating_temp_c": "-20 to 45",

--- a/cameras/tapo/tc55.json
+++ b/cameras/tapo/tc55.json
@@ -19,7 +19,15 @@
     "codecs": [
       "H.264"
     ],
-    "max_fps": 15
+    "max_fps": 15,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 15,
+        "codec": "H.264"
+      }
+    ]
   },
   "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
   "lens": {

--- a/cameras/uniarch/uniarch-ipc-b122-apf28.json
+++ b/cameras/uniarch/uniarch-ipc-b122-apf28.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "CMOS",
   "lens": {

--- a/cameras/uniarch/uniarch-ipc-t122-apf28.json
+++ b/cameras/uniarch/uniarch-ipc-t122-apf28.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 25
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {
@@ -58,7 +66,7 @@
     "2D/3D DNR (digital noise reduction)",
     "ROI (Region of Interest) encoding",
     "wide temperature range -22F to 140F (-30C to 60C)",
-    "wide voltage tolerance \u00b125%"
+    "wide voltage tolerance ±25%"
   ],
   "environment": [
     "outdoor"

--- a/cameras/uniarch/uniarch-ipc-t124-apf28.json
+++ b/cameras/uniarch/uniarch-ipc-t124-apf28.json
@@ -22,7 +22,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "CMOS",
   "lens": {
@@ -72,7 +80,7 @@
   "configs": {
     "frigate": {
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/",
-      "notes": "Crowd-sourced connection data (iSpyConnect) is inconsistent across the Uniarch turret line \u2014 reported working paths for closely related models include '/', '/cam1/mpeg4', '/videoMain', and '/media/video2'. Try the bare root path first; if it fails, try the others. Not independently verified against a physical unit.",
+      "notes": "Crowd-sourced connection data (iSpyConnect) is inconsistent across the Uniarch turret line — reported working paths for closely related models include '/', '/cam1/mpeg4', '/videoMain', and '/media/video2'. Try the bare root path first; if it fails, try the others. Not independently verified against a physical unit.",
       "verified": false
     },
     "home_assistant": {

--- a/cameras/uniarch/uniarch-uho-p1a-m3f4d.json
+++ b/cameras/uniarch/uniarch-uho-p1a-m3f4d.json
@@ -21,7 +21,15 @@
       "H.265",
       "H.264"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2304x1296",
+        "fps": 20,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -77581,7 +77581,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -77663,7 +77671,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -77746,7 +77762,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 5MP progressive CMOS",
     "power": {
@@ -77829,7 +77853,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -77920,7 +77952,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",
     "lens": {
@@ -78197,7 +78237,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78289,7 +78337,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78381,7 +78437,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78474,7 +78538,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x2560",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" 6MP progressive CMOS",
     "lens": {
@@ -78662,7 +78734,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",
     "lens": {
@@ -78754,7 +78834,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -78938,7 +79026,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79027,7 +79123,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79119,7 +79223,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79210,7 +79322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -79306,7 +79426,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 6MP progressive CMOS",
     "lens": {
@@ -79402,7 +79530,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79498,7 +79634,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79594,7 +79738,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79691,7 +79843,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 6MP progressive CMOS",
     "lens": {
@@ -79787,7 +79947,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79883,7 +80051,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -41198,7 +41198,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -41712,7 +41720,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -41880,7 +41896,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -46347,6 +46371,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.264"
+        }
       ]
     },
     "power": {
@@ -46742,6 +46773,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1600x1200",
+          "codec": "H.264"
+        }
       ]
     },
     "power": {
@@ -48223,7 +48261,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "field_of_view_deg": "130 diagonal",
     "night_vision": {
@@ -48294,7 +48340,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "field_of_view_deg": "130 diagonal",
     "night_vision": {
@@ -76195,7 +76249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -76299,7 +76361,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -115129,7 +115199,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -115215,7 +115293,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -123514,7 +123600,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); 8W monocrystalline solar panel; DC 5V/2A adapter (sold separately); Nano SIM card required for 4G",
@@ -124786,7 +124880,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "field_of_view_deg": "Horizontal 108, Vertical 59.8",
@@ -125345,7 +125447,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -125694,7 +125804,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -125794,7 +125912,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -126133,7 +126259,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -126228,7 +126362,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -190318,7 +190460,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A via included AC adapter",
@@ -190400,7 +190550,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -190473,7 +190631,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5VDC power adapter (100-240VAC input) via USB cable",
@@ -190553,7 +190719,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A power adapter (Micro USB)",
@@ -190618,7 +190792,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A via AC power adapter"
@@ -190697,7 +190879,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A power adapter",
@@ -190775,7 +190965,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "DC power adapter (5.0 VDC, 1.0A)",
@@ -190858,7 +191056,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -190993,7 +191199,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -195302,7 +195516,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -195507,7 +195729,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -195913,7 +196143,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -196011,7 +196249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -197298,7 +197544,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3864x2218",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" OmniVision CMOS",
     "lens": {
@@ -200900,7 +201154,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
     "lens": {
@@ -201161,7 +201423,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "2/3\" Progressive Scan CMOS",
     "lens": {
@@ -201259,7 +201529,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -201353,6 +201631,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.7\" CMOS",
@@ -216184,7 +216469,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -227470,6 +227763,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "features": [
@@ -227685,6 +227985,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.9\" CMOS",
@@ -227962,6 +228269,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -228243,6 +228557,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony IMX415 CMOS",
@@ -228632,7 +228953,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -230317,7 +230646,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-25 to 45",
@@ -230413,7 +230750,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "field_of_view_deg": "120 (diagonal), 103 (horizontal), 55 (vertical)",
@@ -232114,7 +232459,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -232444,7 +232797,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
@@ -232608,7 +232969,14 @@
         "H.264"
       ],
       "max_fps": 15,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -233583,7 +233951,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -234460,7 +234836,14 @@
         "H.264"
       ],
       "max_fps": 15,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS Starlight sensor",
     "operating_temp_c": "-20 to 45",
@@ -234847,7 +235230,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
@@ -234946,7 +235337,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
@@ -235064,7 +235463,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "lens": {
@@ -239149,7 +239556,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -239240,7 +239655,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -239328,7 +239751,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -239488,7 +239919,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -42262,7 +42262,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42367,6 +42375,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "codec": "H.265"
+        }
       ]
     },
     "power": {
@@ -42471,7 +42486,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42668,7 +42691,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -42766,6 +42797,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42869,6 +42907,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42980,6 +43025,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43086,6 +43138,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43198,7 +43257,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43303,7 +43370,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43408,7 +43483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43512,7 +43595,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43622,7 +43713,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43726,6 +43825,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43829,7 +43935,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43931,7 +44045,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44033,7 +44155,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44133,7 +44263,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44237,7 +44375,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44338,7 +44484,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44445,7 +44599,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44543,7 +44705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44641,7 +44811,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44831,7 +45009,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -44929,7 +45115,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45026,7 +45220,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45125,7 +45327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -45220,7 +45430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45418,7 +45636,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45521,7 +45747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45720,7 +45954,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45823,7 +46065,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45924,7 +46174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -46025,7 +46283,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -77581,7 +77581,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -77663,7 +77671,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {
@@ -77746,7 +77762,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 5MP progressive CMOS",
     "power": {
@@ -77829,7 +77853,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -77920,7 +77952,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",
     "lens": {
@@ -78197,7 +78237,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78289,7 +78337,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78381,7 +78437,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -78474,7 +78538,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x2560",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" 6MP progressive CMOS",
     "lens": {
@@ -78662,7 +78734,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" 2MP progressive CMOS",
     "lens": {
@@ -78754,7 +78834,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -78938,7 +79026,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79027,7 +79123,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79119,7 +79223,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" 4MP progressive CMOS",
     "lens": {
@@ -79210,7 +79322,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 2MP progressive CMOS",
     "lens": {
@@ -79306,7 +79426,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 6MP progressive CMOS",
     "lens": {
@@ -79402,7 +79530,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79498,7 +79634,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79594,7 +79738,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79691,7 +79843,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3288x1850",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 6MP progressive CMOS",
     "lens": {
@@ -79787,7 +79947,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" 8MP progressive CMOS",
     "lens": {
@@ -79883,7 +80051,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.9\" CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -41198,7 +41198,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.7\" CMOS",
     "lens": {
@@ -41712,7 +41720,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -41880,7 +41896,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -46347,6 +46371,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "codec": "H.264"
+        }
       ]
     },
     "power": {
@@ -46742,6 +46773,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1600x1200",
+          "codec": "H.264"
+        }
       ]
     },
     "power": {
@@ -48223,7 +48261,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "field_of_view_deg": "130 diagonal",
     "night_vision": {
@@ -48294,7 +48340,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "field_of_view_deg": "130 diagonal",
     "night_vision": {
@@ -76195,7 +76249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -76299,7 +76361,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1280x960",
+          "fps": 60,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -115129,7 +115199,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -115215,7 +115293,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -123514,7 +123600,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Rechargeable battery (10,400mAh); 8W monocrystalline solar panel; DC 5V/2A adapter (sold separately); Nano SIM card required for 4G",
@@ -124786,7 +124880,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "field_of_view_deg": "Horizontal 108, Vertical 59.8",
@@ -125345,7 +125447,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -125694,7 +125804,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -125794,7 +125912,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -126133,7 +126259,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 25,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -126228,7 +126362,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "High Definition Color CMOS",
     "lens": {
@@ -190318,7 +190460,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A via included AC adapter",
@@ -190400,7 +190550,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -190473,7 +190631,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5VDC power adapter (100-240VAC input) via USB cable",
@@ -190553,7 +190719,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A power adapter (Micro USB)",
@@ -190618,7 +190792,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A via AC power adapter"
@@ -190697,7 +190879,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "5V DC 1.0A power adapter",
@@ -190775,7 +190965,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "power": {
       "method": "DC power adapter (5.0 VDC, 1.0A)",
@@ -190858,7 +191056,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -190993,7 +191199,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "storage": {
       "onboard": true,
@@ -195302,7 +195516,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -195507,7 +195729,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -195913,7 +196143,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -196011,7 +196249,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" progressive scan CMOS",
     "lens": {
@@ -197298,7 +197544,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3864x2218",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/1.8\" OmniVision CMOS",
     "lens": {
@@ -200900,7 +201154,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.5\" Progressive Scan CMOS",
     "lens": {
@@ -201161,7 +201423,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "2/3\" Progressive Scan CMOS",
     "lens": {
@@ -201259,7 +201529,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -201353,6 +201631,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4000x3000",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/1.7\" CMOS",
@@ -216184,7 +216469,15 @@
       "codecs": [
         "H.265"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "environment": [
       "outdoor"
@@ -227470,6 +227763,13 @@
     "video": {
       "codecs": [
         "H.265"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "codec": "H.265"
+        }
       ]
     },
     "features": [
@@ -227685,6 +227985,13 @@
     "video": {
       "codecs": [
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "codec": "H.264"
+        }
       ]
     },
     "sensor": "1/2.9\" CMOS",
@@ -227962,6 +228269,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "lens": {
@@ -228243,6 +228557,13 @@
       "codecs": [
         "H.265",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "sensor": "1/2.8\" Sony IMX415 CMOS",
@@ -228632,7 +228953,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "lens": {
       "count": 1,
@@ -230317,7 +230646,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-25 to 45",
@@ -230413,7 +230750,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.9\" Progressive Scan CMOS Starlight Sensor",
     "field_of_view_deg": "120 (diagonal), 103 (horizontal), 55 (vertical)",
@@ -232114,7 +232459,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -232444,7 +232797,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "operating_temp_c": "-20 to 45",
     "dimensions_mm": "148.7 x 104 x 70.6",
@@ -232608,7 +232969,14 @@
         "H.264"
       ],
       "max_fps": 15,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.8\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-20 to 45",
@@ -233583,7 +233951,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2880x1620",
+          "fps": 30,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS Starlight Sensor",
     "operating_temp_c": "-30 to 60",
@@ -234460,7 +234836,14 @@
         "H.264"
       ],
       "max_fps": 15,
-      "streams": []
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" progressive scan CMOS Starlight sensor",
     "operating_temp_c": "-20 to 45",
@@ -234847,7 +235230,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\"",
     "operating_temp_c": "-20 to 45",
@@ -234946,7 +235337,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1920",
+          "fps": 20,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/2.7\" Progressive Scan CMOS",
     "operating_temp_c": "-20 to 45",
@@ -235064,7 +235463,15 @@
       "codecs": [
         "H.264"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 15,
+          "codec": "H.264"
+        }
+      ]
     },
     "sensor": "1/3\" Progressive Scan CMOS Starlight Sensor",
     "lens": {
@@ -239149,7 +239556,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -239240,7 +239655,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -239328,7 +239751,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "CMOS",
     "lens": {
@@ -239488,7 +239919,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2304x1296",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -42262,7 +42262,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42367,6 +42375,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "codec": "H.265"
+        }
       ]
     },
     "power": {
@@ -42471,7 +42486,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 10
+      "max_fps": 10,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x3072",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -42668,7 +42691,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2592x1944",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -42766,6 +42797,13 @@
         "H.265",
         "H.264",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42869,6 +42907,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -42980,6 +43025,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43086,6 +43138,13 @@
         "H.265+",
         "H.265",
         "MJPEG"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43198,7 +43257,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43303,7 +43370,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43408,7 +43483,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43512,7 +43595,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43622,7 +43713,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43726,6 +43825,13 @@
         "H.265",
         "H.264+",
         "H.264"
+      ],
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "codec": "H.265"
+        }
       ]
     },
     "night_vision": {
@@ -43829,7 +43935,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -43931,7 +44045,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44033,7 +44155,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44133,7 +44263,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44237,7 +44375,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44338,7 +44484,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44445,7 +44599,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "4096x1860",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44543,7 +44705,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3632x1632",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44641,7 +44811,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -44831,7 +45009,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -44929,7 +45115,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45026,7 +45220,15 @@
         "H.264+",
         "H.264"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "5120x1440",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45125,7 +45327,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 15
+      "max_fps": 15,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 15,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",
@@ -45220,7 +45430,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45418,7 +45636,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45521,7 +45747,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3072x1728",
+          "fps": 20,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "color",
@@ -45720,7 +45954,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45823,7 +46065,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 25
+      "max_fps": 25,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -45924,7 +46174,15 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "hybrid",
@@ -46025,7 +46283,15 @@
         "H.265",
         "H.264"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "night_vision": {
       "type": "ir",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Point release **1.54.1**, folding the post-1.54.0 streams work into one branch.

## Summary
`video.streams[]` main stream backfilled for **+112 cameras across 17 brands** — dataset-wide coverage **1,349 → 1,461**.

Annke +34, CP Plus +22, Tapo +10, Kasa +9, Foscam +6, SV3C +5, Kedacom +4, LTS +4, Uniarch +4, Amcrest +3, Aqara/Arlo/Canon/Eufy +2 each, EZVIZ/Longse/Reolink +1 each.

## Notes
- Main-stream-only (OEM/consumer brands with configurable multi-profile streaming, no fixed sub-stream) — derived from each record's already-verified `resolution`/`max_fps`/`codecs`.
- Includes the Tapo/Kedacom records held back from 1.54.0 (deferred to avoid conflicts with the codec-normalization branch; safe now).
- Assembled from #200 + #201 + #202 (rolled into this branch; those PRs closed). Ran both `build.js` and `gen-docs.js` — no stale docs. Builds clean.