### PR TITLE
data: backfill video.streams[] — remaining Dahua (13 cameras) (#177)

### DIFF
--- a/cameras/dahua/ipc-hdbw2541r-zas.json
+++ b/cameras/dahua/ipc-hdbw2541r-zas.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2449m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2449m-s-b-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2849th-s-prox.json
+++ b/cameras/dahua/ipc-hfw2849th-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2849th-s-prox.json
+++ b/cameras/dahua/ipc-hfw2849th-s-prox.json
@@ -47,6 +47,12 @@
         "resolution": "704x576",
         "fps": 25,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "352x288",
+        "fps": 1,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ipc-hfw3467e-as-il.json
+++ b/cameras/dahua/ipc-hfw3467e-as-il.json
@@ -47,6 +47,12 @@
         "resolution": "1920x1080",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ipc-hfw3467e-as-il.json
+++ b/cameras/dahua/ipc-hfw3467e-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ptz83440-hnf-pa.json
+++ b/cameras/dahua/ptz83440-hnf-pa.json
@@ -28,7 +28,27 @@
       "H.264+",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/sd3d416nb-gny.json
+++ b/cameras/dahua/sd3d416nb-gny.json
@@ -27,7 +27,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd49216db-hny.json
+++ b/cameras/dahua/sd49216db-hny.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/sd4e825gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825gb-hnr-a-pv1.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/sd50432gb-hnr.json
+++ b/cameras/dahua/sd50432gb-hnr.json
@@ -22,7 +22,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/dahua/sd5a825ma-hnr.json
+++ b/cameras/dahua/sd5a825ma-hnr.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",

--- a/cameras/dahua/sd5r404ga-hnf.json
+++ b/cameras/dahua/sd5r404ga-hnf.json
@@ -37,7 +37,27 @@
       "H.264+",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / 12 VDC / 24 VAC",

--- a/cameras/dahua/sd8c260pa1-hnf.json
+++ b/cameras/dahua/sd8c260pa1-hnf.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8c848pa-hnf.json
+++ b/cameras/dahua/sd8c848pa-hnf.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98501,6 +98501,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "352x288",
+          "fps": 1,
+          "codec": "H.265"
         }
       ]
     },

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -82857,7 +82857,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95476,7 +95490,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98460,7 +98488,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98959,7 +99001,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -103493,7 +103549,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -104506,7 +104582,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104612,7 +104702,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -106374,7 +106484,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -106703,7 +106833,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -108124,7 +108274,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -108232,7 +108402,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC / 24 VAC",
@@ -111876,7 +112066,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -112350,7 +112560,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -99020,6 +99020,12 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98501,6 +98501,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "352x288",
+          "fps": 1,
+          "codec": "H.265"
         }
       ]
     },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -82857,7 +82857,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95476,7 +95490,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98460,7 +98488,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98959,7 +99001,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -103493,7 +103549,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -104506,7 +104582,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104612,7 +104702,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -106374,7 +106484,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -106703,7 +106833,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -108124,7 +108274,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -108232,7 +108402,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC / 24 VAC",
@@ -111876,7 +112066,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -112350,7 +112560,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -99020,6 +99020,12 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },


### PR DESCRIPTION
Backfills the last 13 Dahua cameras that had codecs but no `streams[]` — the `#182`-overlap set deferred from the 1.54.0 release (4 fixed WizSense-2/3 bullets/dome + 9 PTZ speed domes).

Full **main/sub(/sub2)** tables from official Dahua Stream Capability datasheets — consistent with the earlier Dahua PRs (#183), not the main-only derivation used for OEM tails. Notable per-model: **PTZ83440-HNF-PA** main @60fps; **SD3D416NB-GNY** is 2-stream only (no sub2); fixed 5/8 MP capped @20 at full res. All 13 main resolutions cross-checked against stored `resolution.max_*`. Ran both build.js + gen-docs.js; no reformatting, no stale docs.

**This completes every Dahua camera that carries a codecs list.** The remaining ~154 Dahua lack a `video` block entirely — that's a separate full-video-block backfill (codecs + max_fps + streams), not streams-only.