### PR TITLE
release: 1.54.2 — remaining Dahua streams (+13) + WizSense-3 third-stream fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [1.54.2] — 2026-07-30
+
+**`video.streams[]` — remaining Dahua + third-stream correction (#177).**
+
+- **+13 Dahua** cameras backfilled with full main/sub(/sub2) tables — the `#182`-overlap set deferred from 1.54.0 (4 fixed WizSense-2/3 bullets/dome + 9 PTZ speed domes). This completes every Dahua camera that carries a `codecs` list.
+- **Correction — WizSense-3 third stream restored (6 cameras).** An earlier extraction rule wrongly dropped "1 fps" third-stream rows, and in doing so also missed the genuinely useful **`1920×1080@30` third stream** on the WizSense-3 models. Fixed: `HFW3467E`/`HFW3667E`/`HFW3867E-AS-IL` and discontinued `HFW3449T1`/`HFW3549T1-AS-PV` now carry their real 3-stream tables; `HFW2849TH-S-PROX` (WizColor) corrected to its 3 streams (`352×288@1fps` third). Verified against official Dahua datasheet PDFs.
+
+Known limitation (tracked in #205): the low-value **WizSense-2** optional `352×288@1fps` CIF third stream is per-model and not exhaustively captured — those records carry datasheet-verified `main`+`sub`.
+
 ## [1.54.1] — 2026-07-29
 
 **`video.streams[]` backfill, continued (#177).** +112 cameras across 17 (mostly small) brands — dataset-wide streams coverage **1,349 → 1,461**. Main stream derived from each record's already-verified `resolution` / `max_fps` / `codecs`; main-stream-only (these OEM/consumer brands document configurable multi-profile streaming with no fixed sub-stream).

--- a/cameras/dahua/ipc-hdbw2541r-zas.json
+++ b/cameras/dahua/ipc-hdbw2541r-zas.json
@@ -30,7 +30,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2960x1668",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2449m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2449m-s-b-pro.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2849th-s-prox.json
+++ b/cameras/dahua/ipc-hfw2849th-s-prox.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 20
+    "max_fps": 20,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 20,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2849th-s-prox.json
+++ b/cameras/dahua/ipc-hfw2849th-s-prox.json
@@ -47,6 +47,12 @@
         "resolution": "704x576",
         "fps": 25,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "352x288",
+        "fps": 1,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ipc-hfw3449t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3449t1-as-pv.json
@@ -17,7 +17,8 @@
     "max_fps": 30,
     "streams": [
       { "name": "main", "resolution": "2688x1520", "fps": 30, "codec": "H.265" },
-      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" },
+      { "name": "sub2", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }
     ]
   },
   "sensor": "1/2.7\" CMOS",

--- a/cameras/dahua/ipc-hfw3467e-as-il.json
+++ b/cameras/dahua/ipc-hfw3467e-as-il.json
@@ -47,6 +47,12 @@
         "resolution": "1920x1080",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ipc-hfw3467e-as-il.json
+++ b/cameras/dahua/ipc-hfw3467e-as-il.json
@@ -34,7 +34,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw3549t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3549t1-as-pv.json
@@ -17,7 +17,8 @@
     "max_fps": 20,
     "streams": [
       { "name": "main", "resolution": "2592x1944", "fps": 20, "codec": "H.265" },
-      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" }
+      { "name": "sub", "resolution": "704x576", "fps": 25, "codec": "H.265" },
+      { "name": "sub2", "resolution": "1920x1080", "fps": 30, "codec": "H.265" }
     ]
   },
   "sensor": "1/2.7\" CMOS",

--- a/cameras/dahua/ipc-hfw3667e-as-il.json
+++ b/cameras/dahua/ipc-hfw3667e-as-il.json
@@ -47,6 +47,12 @@
         "resolution": "1920x1080",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ipc-hfw3867e-as-il.json
+++ b/cameras/dahua/ipc-hfw3867e-as-il.json
@@ -47,6 +47,12 @@
         "resolution": "1920x1080",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },

--- a/cameras/dahua/ptz83440-hnf-pa.json
+++ b/cameras/dahua/ptz83440-hnf-pa.json
@@ -28,7 +28,27 @@
       "H.264+",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 60,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/sd3d416nb-gny.json
+++ b/cameras/dahua/sd3d416nb-gny.json
@@ -27,7 +27,21 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd49216db-hny.json
+++ b/cameras/dahua/sd49216db-hny.json
@@ -37,7 +37,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V",

--- a/cameras/dahua/sd4e825gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825gb-hnr-a-pv1.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/sd50432gb-hnr.json
+++ b/cameras/dahua/sd50432gb-hnr.json
@@ -22,7 +22,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2560x1440",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/dahua/sd5a825ma-hnr.json
+++ b/cameras/dahua/sd5a825ma-hnr.json
@@ -31,7 +31,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE+ (802.3at) / 24 VDC",

--- a/cameras/dahua/sd5r404ga-hnf.json
+++ b/cameras/dahua/sd5r404ga-hnf.json
@@ -37,7 +37,27 @@
       "H.264+",
       "MJPEG"
     ],
-    "max_fps": 60
+    "max_fps": 60,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "PoE (802.3at) / 12 VDC / 24 VAC",

--- a/cameras/dahua/sd8c260pa1-hnf.json
+++ b/cameras/dahua/sd8c260pa1-hnf.json
@@ -27,7 +27,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd8c848pa-hnf.json
+++ b/cameras/dahua/sd8c848pa-hnf.json
@@ -34,7 +34,27 @@
       "H.264",
       "MJPEG"
     ],
-    "max_fps": 30
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "704x576",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub2",
+        "resolution": "1920x1080",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
   },
   "power": {
     "method": "Hi-PoE / DC 36V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98501,6 +98501,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "352x288",
+          "fps": 1,
+          "codec": "H.265"
         }
       ]
     },

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -82857,7 +82857,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95476,7 +95490,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98460,7 +98488,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98959,7 +99001,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -103493,7 +103549,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -104506,7 +104582,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104612,7 +104702,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -106374,7 +106484,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -106703,7 +106833,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -108124,7 +108274,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -108232,7 +108402,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC / 24 VAC",
@@ -111876,7 +112066,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -112350,7 +112560,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -99020,6 +99020,12 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98840,6 +98840,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
@@ -99147,6 +99153,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
@@ -99362,6 +99374,12 @@
         },
         {
           "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
@@ -100427,6 +100445,12 @@
         },
         {
           "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98501,6 +98501,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "352x288",
+          "fps": 1,
+          "codec": "H.265"
         }
       ]
     },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -82857,7 +82857,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2960x1668",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -95476,7 +95490,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98460,7 +98488,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 20
+      "max_fps": 20,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 20,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 25,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -98959,7 +99001,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -103493,7 +103549,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 60,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true
@@ -104506,7 +104582,21 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -104612,7 +104702,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V",
@@ -106374,7 +106484,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -106703,7 +106833,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2560x1440",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -108124,7 +108274,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE+ (802.3at) / 24 VDC",
@@ -108232,7 +108402,27 @@
         "H.264+",
         "MJPEG"
       ],
-      "max_fps": 60
+      "max_fps": 60,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "PoE (802.3at) / 12 VDC / 24 VAC",
@@ -111876,7 +112066,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "ptz": {
       "autotracking": true,
@@ -112350,7 +112560,27 @@
         "H.264",
         "MJPEG"
       ],
-      "max_fps": 30
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "704x576",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
     },
     "power": {
       "method": "Hi-PoE / DC 36V",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -99020,6 +99020,12 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98840,6 +98840,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
@@ -99147,6 +99153,12 @@
           "resolution": "704x576",
           "fps": 25,
           "codec": "H.265"
+        },
+        {
+          "name": "sub2",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
@@ -99362,6 +99374,12 @@
         },
         {
           "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
@@ -100427,6 +100445,12 @@
         },
         {
           "name": "sub",
+          "resolution": "1920x1080",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub2",
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cctv-camera-database",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "description": "An open, structured database of CCTV / IP camera specifications.",
   "scripts": {
     "build": "node scripts/build.js && node scripts/gen-docs.js",


### PR DESCRIPTION
Point release **1.54.2**.

## Summary
- **+13 Dahua** cameras backfilled (the `#182`-overlap set deferred from 1.54.0: 4 fixed + 9 PTZ) — **completes every Dahua camera with a codecs list**.
- **Correction:** restored the real **`1920×1080@30` third stream** on 6 Dahua WizSense-3 cameras (HFW3467/3667/3867-E-AS-IL, HFW3449/3549T1-AS-PV) + HFW2849TH-S-PROX's 3 streams — an earlier rule wrongly dropped "1 fps" third-stream rows and, with them, these useful WizSense-3 1080p thirds.

Dataset streams → **1,474**.

## Context
A user report (HFW2849TH-S-PROX "3 not 2") surfaced that the "drop 1-fps thirds" extraction rule was wrong. Investigation (per-model datasheet sampling) found: WizSense-3 has a genuinely useful **1080p** third stream (fixed here); WizSense-2 has only a low-value **`352×288@1fps` CIF** third that is per-model and not exhaustively captured (documented in #205). Extraction memory updated so the rule-error doesn't recur.

Assembled from #204 + the WizSense-3 fixes (branches rolled in; #204 closed). Ran build.js + gen-docs.js; clean.