### PR TITLE
fix: 4 megapixels/resolution mismatches (surfaced by #169)

### DIFF
--- a/cameras/acti/a429.json
+++ b/cameras/acti/a429.json
@@ -8,8 +8,8 @@
   ],
   "resolution": {
     "megapixels": 4,
-    "max_width": 1920,
-    "max_height": 1080,
+    "max_width": 2688,
+    "max_height": 1520,
     "label": "4MP"
   },
   "lens": {
@@ -43,8 +43,8 @@
     "streams": [
       {
         "name": "main",
-        "resolution": "1920x1080",
-        "fps": 120,
+        "resolution": "2688x1520",
+        "fps": 60,
         "codec": "H.265"
       }
     ]

--- a/cameras/bosch/mic-550ir55-p.json
+++ b/cameras/bosch/mic-550ir55-p.json
@@ -12,9 +12,9 @@
   ],
   "resolution": {
     "megapixels": 0.38,
-    "max_width": 1920,
-    "max_height": 1080,
-    "label": "1080p"
+    "max_width": 768,
+    "max_height": 494,
+    "label": "D1 (analog SD)"
   },
   "sensor": "1/2.8\" CMOS",
   "lens": {

--- a/cameras/bosch/ndc-8502-r-ooh.json
+++ b/cameras/bosch/ndc-8502-r-ooh.json
@@ -13,9 +13,9 @@
   "release_year": 2023,
   "resolution": {
     "megapixels": 2,
-    "max_width": 3840,
-    "max_height": 2160,
-    "label": "4K UHD"
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
   },
   "sensor": "1/1.8\" CMOS (starlight)",
   "lens": {

--- a/cameras/kedacom/ipc442-i405-np.json
+++ b/cameras/kedacom/ipc442-i405-np.json
@@ -3,31 +3,98 @@
   "brand": "Kedacom",
   "model": "IPC442-i405-NP",
   "type": "ptz",
-  "connectivity": ["ethernet"],
-  "power_source": ["poe", "dc"],
-  "resolution": { "megapixels": 4.0, "max_width": 1920, "max_height": 1080, "label": "1080p" },
-  "video": { "codecs": ["H.265", "H.264"], "max_fps": 25, "streams": [{ "name": "main", "resolution": "1920x1080", "fps": 25, "codec": "H.265" }] },
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 25,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "1920x1080",
+        "fps": 25,
+        "codec": "H.265"
+      }
+    ]
+  },
   "sensor": "1/1.8\" progressive scan CMOS",
-  "lens": { "count": 1, "focal_length_mm": "2.7-13.5", "varifocal": true },
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.7-13.5",
+    "varifocal": true
+  },
   "field_of_view_deg": "108.1-46.6 (wide-tele)",
-  "night_vision": { "type": "ir", "range_m": 30 },
-  "power": { "method": "DC 12V / PoE (802.3at)", "consumption_w": 30, "voltage": "DC 12V" },
-  "storage": { "onboard": true, "max_microsd_gb": 256 },
-  "protocols": ["onvif", "rtsp", "http"],
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "DC 12V / PoE (802.3at)",
+    "consumption_w": 30,
+    "voltage": "DC 12V"
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 256
+  },
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
   "ip_rating": "IP66",
-  "audio": { "two_way": true },
-  "features": ["5x optical / 16x digital zoom", "360 endless pan", "512 presets", "face recognition", "bi-directional people counting", "3D noise reduction", "HLC", "BLC"],
+  "audio": {
+    "two_way": true
+  },
+  "features": [
+    "5x optical / 16x digital zoom",
+    "360 endless pan",
+    "512 presets",
+    "face recognition",
+    "bi-directional people counting",
+    "3D noise reduction",
+    "HLC",
+    "BLC"
+  ],
   "operating_temp_c": "-40 to 70",
   "dimensions_mm": "Ø197 x 142",
-  "environment": ["outdoor"],
-  "markets": ["global"],
+  "environment": [
+    "outdoor"
+  ],
+  "markets": [
+    "global"
+  ],
   "release_notes": "Recognitive PTZ speed dome with face recognition, visible 4.0MP sensor (1080p main stream). Not thermal.",
-  "sources": ["https://www.kedacom.com/th/rykksxj/4602.jhtml"],
+  "sources": [
+    "https://www.kedacom.com/th/rykksxj/4602.jhtml"
+  ],
   "last_verified": "2026-07-04",
   "configs": {
-    "frigate": { "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/id=0", "best_substream": "rtsp://{user}:{pass}@{ip}:554/id=1", "verified": false },
-    "home_assistant": { "integration": "onvif" },
-    "blue_iris": { "profile": "ONVIF" }
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/id=0",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/id=1",
+      "verified": false
+    },
+    "home_assistant": {
+      "integration": "onvif"
+    },
+    "blue_iris": {
+      "profile": "ONVIF"
+    }
   },
   "status": "available"
 }

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -620,7 +620,7 @@ blink-wired-floodlight,Blink,Wired Floodlight Camera,bullet,1080p,2,,142 diagona
 blink-xt2,Blink,XT2,bullet,1080p HD,2,,110 diagonal,ir,IP65,,true,2019
 bosch-fcs-8000-vfd-i,Bosch,AVIOTEC 8000i IR (FCS-8000-VFD-I),bullet,4MP,4.1,1/1.8 inch CMOS,"48-103 (horizontal: 103° wide, 48° tele)",ir,IP66/IP67,IK10,true,2023
 bosch-flexidome-5100i-mena,Bosch,FLEXIDOME 5100i (MENA),dome,5MP,5,"1/2.7"" CMOS",110-32 horizontal,ir,IP66,IK10,true,2022
-bosch-mic-550ir55-p,Bosch,MIC Series 550 IR (MIC-550IR55-P),ptz,1080p,0.38,"1/2.8"" CMOS",,ir,IP68,,true,
+bosch-mic-550ir55-p,Bosch,MIC Series 550 IR (MIC-550IR55-P),ptz,D1 (analog SD),0.38,"1/2.8"" CMOS",,ir,IP68,,true,
 bosch-mic-7504-z12br,Bosch,MIC IP ultra 7100i (MIC-7504-Z12BR),ptz,4K UHD,8.3,1 in. Exmor R CMOS,6.1 to 64.6,none,IP68,IK10,true,
 bosch-mic-7504-z12gr,Bosch,MIC IP ultra 7100i (MIC-7504-Z12GR),ptz,4K UHD,8,1-inch CMOS,61-90,none,IP66/IP68,IK10,,
 bosch-mic-7504-z12wr,Bosch,MIC IP ultra 7100i (MIC-7504-Z12WR) PTZ 8MP 12x IP68 enhanced white,ptz,4K UHD,8.3,1-inch Exmor R CMOS,6.1-64.6,none,IP68,IK10,true,2019
@@ -685,7 +685,7 @@ bosch-nbt-8701-f14vf,Bosch,DINION thermal 8100i - VGA (NBT-8701-F14VF),bullet,VG
 bosch-nbt-8701-f25vf,Bosch,DINION thermal 8100i - VGA (NBT-8701-F25VF),bullet,VGA,0.3,"Uncooled VOx (vanadium oxide) microbolometer, 640x480, 12 um pixel pitch, 8-14 um spectral response",17,none,IP66/IP67,IK10,true,2025
 bosch-nbt-8701-f42vf,Bosch,DINION thermal 8100i VGA (NBT-8701-F42VF),bullet,VGA,0.3,"640 x 480 VOx uncooled microbolometer, 12 µm pixel pitch",10,none,IP66/IP67,IK10,,
 bosch-nce-7703-fk,Bosch,FLEXIDOME corner 7100i IR (NCE-7703-FK),dome,6MP,6,1/1.8 inch CMOS,"131.1° horizontal, 96.5° vertical",ir,IP66,IK11,,2023
-bosch-ndc-8502-r-ooh,Bosch,FLEXIDOME 8000i Outdoor Dome (NDC-8502-R),dome,4K UHD,2,"1/1.8"" CMOS (starlight)",100-33 horizontal,ir,IP66,IK10,true,2023
+bosch-ndc-8502-r-ooh,Bosch,FLEXIDOME 8000i Outdoor Dome (NDC-8502-R),dome,1080p,2,"1/1.8"" CMOS (starlight)",100-33 horizontal,ir,IP66,IK10,true,2023
 bosch-ndd-7802-al,Bosch,FLEXIDOME dual 7100i IR (NDD-7802-AL),dual-lens,2x 3MP (2048×1536 per imager),6,,"37°–104° horizontal (per lens, varifocal)",ir,IP66/IP67,IK10,true,2025
 bosch-ndd-7803-al,Bosch,FLEXIDOME Dual 7100i IR (NDD-7803-AL),dual-lens,2x 5MP (10MP total),10,"2x 1/2.8"" CMOS",104° to 37° (horizontal),ir,IP67,IK10,true,2025
 bosch-nde-3503-f02,Bosch,FLEXIDOME IP micro 3000i - outdoor (NDE-3503-F02),dome,5MP,5.3,1/2.9 inch CMOS,118° x 69° (H x V),none,IP66,IK10,,2021
@@ -2046,7 +2046,7 @@ kedacom-ipc2855-gi4n,Kedacom,IPC2855-Gi4N,bullet,4K,8,"1/1.8"" progressive scan 
 kedacom-ipc425-f223-n,Kedacom,IPC425-F223-N,ptz,1080p,2,"1/1.9"" progressive scan CMOS",,ir,,,true,
 kedacom-ipc425-f233-n,Kedacom,IPC425-F233-N,ptz,1080p,2,"1/2.8"" progressive scan CMOS",2.34-67.8 (tele-wide),ir,,,true,
 kedacom-ipc425-g223-n,Kedacom,IPC425-G223-N,ptz,1080p,2,"1/1.9"" progressive scan CMOS",,ir,,,true,
-kedacom-ipc442-i405-np,Kedacom,IPC442-i405-NP,ptz,1080p,4,"1/1.8"" progressive scan CMOS",108.1-46.6 (wide-tele),ir,IP66,,true,
+kedacom-ipc442-i405-np,Kedacom,IPC442-i405-NP,ptz,1080p,2,"1/1.8"" progressive scan CMOS",108.1-46.6 (wide-tele),ir,IP66,,true,
 kedacom-lc2110-an,Kedacom,LC2110-AN,dome,960p,1.3,"1/3"" progressive scan CMOS",23-96.3,ir,IP66,,,
 kedacom-lc2110-bn-d,Kedacom,LC2110-BN-D,dome,960p,1.3,"1/3"" progressive scan CMOS",23-96.3,ir,IP66,,,
 kedacom-lc2150-an-d,Kedacom,LC2150-AN-D,bullet,960p,1.3,"1/3"" progressive scan CMOS",16.9-75.6,ir,IP66,,,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -17857,8 +17857,8 @@
     ],
     "resolution": {
       "megapixels": 4,
-      "max_width": 1920,
-      "max_height": 1080,
+      "max_width": 2688,
+      "max_height": 1520,
       "label": "4MP"
     },
     "lens": {
@@ -17892,8 +17892,8 @@
       "streams": [
         {
           "name": "main",
-          "resolution": "1920x1080",
-          "fps": 120,
+          "resolution": "2688x1520",
+          "fps": 60,
           "codec": "H.265"
         }
       ]
@@ -58631,9 +58631,9 @@
     ],
     "resolution": {
       "megapixels": 0.38,
-      "max_width": 1920,
-      "max_height": 1080,
-      "label": "1080p"
+      "max_width": 768,
+      "max_height": 494,
+      "label": "D1 (analog SD)"
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -66331,9 +66331,9 @@
     "release_year": 2023,
     "resolution": {
       "megapixels": 2,
-      "max_width": 3840,
-      "max_height": 2160,
-      "label": "4K UHD"
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
     },
     "sensor": "1/1.8\" CMOS (starlight)",
     "lens": {
@@ -197473,7 +197473,7 @@
       "dc"
     ],
     "resolution": {
-      "megapixels": 4,
+      "megapixels": 2,
       "max_width": 1920,
       "max_height": 1080,
       "label": "1080p"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -17857,8 +17857,8 @@
     ],
     "resolution": {
       "megapixels": 4,
-      "max_width": 1920,
-      "max_height": 1080,
+      "max_width": 2688,
+      "max_height": 1520,
       "label": "4MP"
     },
     "lens": {
@@ -17892,8 +17892,8 @@
       "streams": [
         {
           "name": "main",
-          "resolution": "1920x1080",
-          "fps": 120,
+          "resolution": "2688x1520",
+          "fps": 60,
           "codec": "H.265"
         }
       ]
@@ -58631,9 +58631,9 @@
     ],
     "resolution": {
       "megapixels": 0.38,
-      "max_width": 1920,
-      "max_height": 1080,
-      "label": "1080p"
+      "max_width": 768,
+      "max_height": 494,
+      "label": "D1 (analog SD)"
     },
     "sensor": "1/2.8\" CMOS",
     "lens": {
@@ -66331,9 +66331,9 @@
     "release_year": 2023,
     "resolution": {
       "megapixels": 2,
-      "max_width": 3840,
-      "max_height": 2160,
-      "label": "4K UHD"
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
     },
     "sensor": "1/1.8\" CMOS (starlight)",
     "lens": {
@@ -197473,7 +197473,7 @@
       "dc"
     ],
     "resolution": {
-      "megapixels": 4,
+      "megapixels": 2,
       "max_width": 1920,
       "max_height": 1080,
       "label": "1080p"

--- a/docs/cameras/acti/a429.md
+++ b/docs/cameras/acti/a429.md
@@ -6,7 +6,7 @@
 | Model | A429 |
 | Type | bullet |
 | Connectivity | ethernet |
-| Resolution | 4MP (4MP, 1920×1080) |
+| Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12 (zoom)mm F1.38-F2.53 |
 | Field of view | 106 - 41.8 horizontal / 55.4 - 23.6 vertical° |

--- a/docs/cameras/bosch/mic-550ir55-p.md
+++ b/docs/cameras/bosch/mic-550ir55-p.md
@@ -8,7 +8,7 @@
 | Model | MIC Series 550 IR (MIC-550IR55-P) |
 | Type | ptz |
 | Connectivity | coax |
-| Resolution | 1080p (0.38MP, 1920×1080) |
+| Resolution | D1 (analog SD) (0.38MP, 768×494) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.7-94 (20x optical zoom)mm |
 | Night vision | ir (120m), 0.0052 lux |

--- a/docs/cameras/bosch/ndc-8502-r-ooh.md
+++ b/docs/cameras/bosch/ndc-8502-r-ooh.md
@@ -8,7 +8,7 @@
 | Model | FLEXIDOME 8000i Outdoor Dome (NDC-8502-R) |
 | Type | dome |
 | Connectivity | ethernet |
-| Resolution | 4K UHD (2MP, 3840×2160) |
+| Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/1.8" CMOS (starlight) |
 | Lens | 1× 3-9 (motorized varifocal)mm F1.2 |
 | Field of view | 100-33 horizontal° |

--- a/docs/cameras/kedacom/ipc442-i405-np.md
+++ b/docs/cameras/kedacom/ipc442-i405-np.md
@@ -6,7 +6,7 @@
 | Model | IPC442-i405-NP |
 | Type | ptz |
 | Connectivity | ethernet |
-| Resolution | 1080p (4MP, 1920×1080) |
+| Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/1.8" progressive scan CMOS |
 | Lens | 1× 2.7-13.5mm |
 | Field of view | 108.1-46.6 (wide-tele)° |


### PR DESCRIPTION
Fixes the genuine single-sensor `megapixels` vs `max_width×max_height` mismatches that the new #169 check surfaced (from PR #208). Each verified against the official datasheet / spec API:

| Camera | Fix | Source |
|--------|-----|--------|
| `acti-a429` | resolution `1920x1080` → **`2688x1520`** (+ main stream → `2688x1520@60`) | 1080p was the **120fps High-Frame-Mode** row, not the max resolution — ACTi spec API confirms 4MP / 2688×1520@60 |
| `bosch-mic-550ir55-p` | resolution `1920x1080` → **`768x494`**, label → "D1 (analog SD)" | MIC Series 550 is an **analog SD PTZ** (550 TVL, ~0.38MP) — not HD; the 0.38MP was right, the resolution was wrong |
| `bosch-ndc-8502-r-ooh` | resolution `3840x2160` → **`1920x1080`**, label `4K UHD` → `1080p` | FLEXIDOME 8000i **`8502`** models are 2MP; the `8504` are the 4K variants |
| `kedacom-ipc442-i405-np` | megapixels `4` → **`2`** | Kedacom's official max output is 1080p (sensor is *marketed* 4MP but exposes no 4MP resolution mode) — kept MP consistent with the stated max output *(low confidence — flagged in commit)* |

The other records #169 flags are **legitimate multi-sensor cameras** (Dahua X-Spans SDT combos, Hanwha PNM panoramic PTZ) where the stated megapixels is the combined multi-imager total — those are correct and excluded from concern.

Builds clean; ran build.js + gen-docs.js.