### PR TITLE
data: backfill night_vision.min_lux_color — ACTi (25 cameras) (#161)

### DIFF
--- a/cameras/acti/a317.json
+++ b/cameras/acti/a317.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "182.2 horizontal / 71.2 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 20 W (DC), 24 W (PoE)"

--- a/cameras/acti/a371-p1.json
+++ b/cameras/acti/a371-p1.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"

--- a/cameras/acti/a371-p2.json
+++ b/cameras/acti/a371-p2.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "39.4 horizontal / 22.1 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"

--- a/cameras/acti/a371.json
+++ b/cameras/acti/a371.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"

--- a/cameras/acti/a374-p1.json
+++ b/cameras/acti/a374-p1.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"

--- a/cameras/acti/a374.json
+++ b/cameras/acti/a374.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"

--- a/cameras/acti/a570-p1.json
+++ b/cameras/acti/a570-p1.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "117.8 horizontal / 70.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0176
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"

--- a/cameras/acti/a570-p2.json
+++ b/cameras/acti/a570-p2.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "53 horizontal / 18 vertical (visible); 24.9 horizontal / 18 vertical (thermal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0176
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"

--- a/cameras/acti/a570.json
+++ b/cameras/acti/a570.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux_color": 0.0176
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"

--- a/cameras/acti/a573-p1.json
+++ b/cameras/acti/a573-p1.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0176
   },
   "power": {
     "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"

--- a/cameras/acti/a573.json
+++ b/cameras/acti/a573.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "128.3 horizontal / 75.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0176
   },
   "power": {
     "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"

--- a/cameras/acti/a966.json
+++ b/cameras/acti/a966.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "60.2 - 2.3 horizontal / 35.2 - 1.3 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.002
   },
   "ptz": {
     "autotracking": true

--- a/cameras/acti/q550.json
+++ b/cameras/acti/q550.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "180 horizontal / 47.41 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"

--- a/cameras/acti/vmgb-359-p1.json
+++ b/cameras/acti/vmgb-359-p1.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "84 horizontal / 44.8 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0089
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"

--- a/cameras/acti/vmgb-359.json
+++ b/cameras/acti/vmgb-359.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "39.42 horizontal / 22.14 vertical (visible)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.017
   },
   "power": {
     "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"

--- a/cameras/acti/z325.json
+++ b/cameras/acti/z325.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"

--- a/cameras/acti/z332.json
+++ b/cameras/acti/z332.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 5.5 W (DC), 3.9 W (PoE)"

--- a/cameras/acti/z429.json
+++ b/cameras/acti/z429.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 8 W (PoE)"

--- a/cameras/acti/z510.json
+++ b/cameras/acti/z510.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100.0 horizontal / 51.1 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"

--- a/cameras/acti/z512.json
+++ b/cameras/acti/z512.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"

--- a/cameras/acti/z56.json
+++ b/cameras/acti/z56.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"

--- a/cameras/acti/z64.json
+++ b/cameras/acti/z64.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 (Visual camera) vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "12V / PoE (IEEE 802.3af); 8 W (PoE)"

--- a/cameras/acti/z722.json
+++ b/cameras/acti/z722.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "97 horizontal / 52.2 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 2.8 W (PoE)"

--- a/cameras/acti/z818.json
+++ b/cameras/acti/z818.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 8.6 W (PoE)"

--- a/cameras/acti/z914.json
+++ b/cameras/acti/z914.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "126 horizontal / 71 vertical",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -16001,7 +16001,8 @@
     "field_of_view_deg": "182.2 horizontal / 71.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 20 W (DC), 24 W (PoE)"
@@ -16099,7 +16100,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"
@@ -16198,7 +16200,8 @@
     "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"
@@ -16297,7 +16300,8 @@
     "field_of_view_deg": "39.4 horizontal / 22.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -16518,7 +16522,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -16598,7 +16603,8 @@
     "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -18103,7 +18109,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18202,7 +18209,8 @@
     "field_of_view_deg": "117.8 horizontal / 70.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18280,7 +18288,8 @@
     "field_of_view_deg": "53 horizontal / 18 vertical (visible); 24.9 horizontal / 18 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18358,7 +18367,8 @@
     "field_of_view_deg": "128.3 horizontal / 75.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"
@@ -18457,7 +18467,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"
@@ -20784,7 +20795,8 @@
     "field_of_view_deg": "60.2 - 2.3 horizontal / 35.2 - 1.3 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.002
     },
     "ptz": {
       "autotracking": true
@@ -29870,7 +29882,8 @@
     "field_of_view_deg": "180 horizontal / 47.41 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"
@@ -30948,7 +30961,8 @@
     "field_of_view_deg": "39.42 horizontal / 22.14 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.017
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -31046,7 +31060,8 @@
     "field_of_view_deg": "84 horizontal / 44.8 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -32890,7 +32905,8 @@
     "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"
@@ -33377,7 +33393,8 @@
     "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.5 W (DC), 3.9 W (PoE)"
@@ -34142,7 +34159,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 8 W (PoE)"
@@ -34439,7 +34457,8 @@
     "field_of_view_deg": "100.0 horizontal / 51.1 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"
@@ -34632,7 +34651,8 @@
     "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"
@@ -34922,7 +34942,8 @@
     "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"
@@ -35019,7 +35040,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 (Visual camera) vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "12V / PoE (IEEE 802.3af); 8 W (PoE)"
@@ -35389,7 +35411,8 @@
     "field_of_view_deg": "97 horizontal / 52.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 2.8 W (PoE)"
@@ -36354,7 +36377,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 8.6 W (PoE)"
@@ -37384,7 +37408,8 @@
     "field_of_view_deg": "126 horizontal / 71 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -16001,7 +16001,8 @@
     "field_of_view_deg": "182.2 horizontal / 71.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 20 W (DC), 24 W (PoE)"
@@ -16099,7 +16100,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"
@@ -16198,7 +16200,8 @@
     "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE)"
@@ -16297,7 +16300,8 @@
     "field_of_view_deg": "39.4 horizontal / 22.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -16518,7 +16522,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -16598,7 +16603,8 @@
     "field_of_view_deg": "53 horizontal / 28 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE)"
@@ -18103,7 +18109,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18202,7 +18209,8 @@
     "field_of_view_deg": "117.8 horizontal / 70.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18280,7 +18288,8 @@
     "field_of_view_deg": "53 horizontal / 18 vertical (visible); 24.9 horizontal / 18 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -18358,7 +18367,8 @@
     "field_of_view_deg": "128.3 horizontal / 75.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"
@@ -18457,7 +18467,8 @@
     "field_of_view_deg": "84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0176
     },
     "power": {
       "method": "DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE)"
@@ -20784,7 +20795,8 @@
     "field_of_view_deg": "60.2 - 2.3 horizontal / 35.2 - 1.3 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.002
     },
     "ptz": {
       "autotracking": true
@@ -29870,7 +29882,8 @@
     "field_of_view_deg": "180 horizontal / 47.41 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"
@@ -30948,7 +30961,8 @@
     "field_of_view_deg": "39.42 horizontal / 22.14 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.017
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -31046,7 +31060,8 @@
     "field_of_view_deg": "84 horizontal / 44.8 vertical (visible)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0089
     },
     "power": {
       "method": "DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE)"
@@ -32890,7 +32905,8 @@
     "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"
@@ -33377,7 +33393,8 @@
     "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.5 W (DC), 3.9 W (PoE)"
@@ -34142,7 +34159,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 8 W (PoE)"
@@ -34439,7 +34457,8 @@
     "field_of_view_deg": "100.0 horizontal / 51.1 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"
@@ -34632,7 +34651,8 @@
     "field_of_view_deg": "100.7 horizontal / 51.5 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE)"
@@ -34922,7 +34942,8 @@
     "field_of_view_deg": "100.8 horizontal / 55.8 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE)"
@@ -35019,7 +35040,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 (Visual camera) vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "12V / PoE (IEEE 802.3af); 8 W (PoE)"
@@ -35389,7 +35411,8 @@
     "field_of_view_deg": "97 horizontal / 52.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 2.8 W (PoE)"
@@ -36354,7 +36377,8 @@
     "field_of_view_deg": "111.5 - 34.4 horizontal / 58.7 - 19.2 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 8.6 W (PoE)"
@@ -37384,7 +37408,8 @@
     "field_of_view_deg": "126 horizontal / 71 vertical",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE)"

--- a/docs/cameras/acti/a317.md
+++ b/docs/cameras/acti/a317.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0-F1.6 (Visual camera) |
 | Field of view | 182.2 horizontal / 71.2 vertical° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0008 lux color |
 | Power | DC 12V / PoE Class 4 (IEEE 802.3at); 20 W (DC), 24 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/a371-p1.md
+++ b/docs/cameras/acti/a371-p1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 6.4 (fixed, visible); 6.9 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 53 horizontal / 28 vertical (visible)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0089 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/a371-p2.md
+++ b/docs/cameras/acti/a371-p2.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 8.0 (fixed, visible); 9.7 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 39.4 horizontal / 22.1 vertical (visible)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0089 lux color |
 | Power | DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | Yes |

--- a/docs/cameras/acti/a371.md
+++ b/docs/cameras/acti/a371.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 4.3 (fixed, visible); 3.6 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 84 horizontal / 43.1 vertical (visible)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0089 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/a374-p1.md
+++ b/docs/cameras/acti/a374-p1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 6.4 (fixed, visible); 6.9 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 53 horizontal / 28 vertical (visible)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0089 lux color |
 | Power | DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | Yes |

--- a/docs/cameras/acti/a374.md
+++ b/docs/cameras/acti/a374.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 4.3 (fixed, visible); 3.6 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 84 horizontal / 43.1 vertical (visible)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0089 lux color |
 | Power | DC 12V / AC 24V / PoE Class 3 (IEEE 802.3af); 8.5 W (DC), 8.5 W (AC), 8.5 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | Yes |

--- a/docs/cameras/acti/a570-p1.md
+++ b/docs/cameras/acti/a570-p1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 2.2 (fixed, visible); 2.1 (fixed, thermal)mm F2.25 (visible); F1.0 (thermal) |
 | Field of view | 117.8 horizontal / 70.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0176 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | Yes |

--- a/docs/cameras/acti/a570-p2.md
+++ b/docs/cameras/acti/a570-p2.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 6.4 (fixed, visible); 6.9 (fixed, thermal)mm F1.6 (visible); F1.0 (thermal) |
 | Field of view | 53 horizontal / 18 vertical (visible); 24.9 horizontal / 18 vertical (thermal)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0176 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | Yes |

--- a/docs/cameras/acti/a570.md
+++ b/docs/cameras/acti/a570.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 4.3 (fixed, visible); 3.6 (fixed, thermal)mm F1.6 (visible); F1.0 (thermal) |
 | Field of view | 84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)° |
-| Night vision | hybrid (15m) |
+| Night vision | hybrid (15m), 0.0176 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/a573-p1.md
+++ b/docs/cameras/acti/a573-p1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 4.3 (fixed, visible); 3.6 (fixed, thermal)mm F1.6 (visible); F1.0 (thermal) |
 | Field of view | 84 horizontal / 43.1 vertical (visible); 50 horizontal / 37.3 vertical (thermal)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0176 lux color |
 | Power | DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |

--- a/docs/cameras/acti/a573.md
+++ b/docs/cameras/acti/a573.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 2.2 (fixed, visible); 2.1 (fixed, thermal)mm F2.25 (visible); F1.0 (thermal) |
 | Field of view | 128.3 horizontal / 75.4 vertical (visible); 90 horizontal / 65.4 vertical (thermal)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0176 lux color |
 | Power | DC 12V / PoE Class 4 (IEEE 802.3at); 12.8 W (DC), 12.8 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |

--- a/docs/cameras/acti/a966.md
+++ b/docs/cameras/acti/a966.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 5.9-194.7 (zoom, 33x optical/16x digital)mm F1.5-F3.4 |
 | Field of view | 60.2 - 2.3 horizontal / 35.2 - 1.3 vertical° |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.002 lux color |
 | Power | High PoE (IEEE 802.3bt) / DC 36V; 42 W (PoE, heater and IR on) |
 | Protocols | rtsp, onvif |
 | IP rating | IP66 |

--- a/docs/cameras/acti/q550.md
+++ b/docs/cameras/acti/q550.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 2× 4.0 (fixed)mm F1.0 |
 | Field of view | 180 horizontal / 47.41 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0005 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/vmgb-359-p1.md
+++ b/docs/cameras/acti/vmgb-359-p1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 4.0 (fixed, visible); 3.1 (fixed, thermal)mm F1.6 (visible) |
 | Field of view | 84 horizontal / 44.8 vertical (visible)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.0089 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/vmgb-359.md
+++ b/docs/cameras/acti/vmgb-359.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (visible) |
 | Lens | 2× 8.0 (fixed, visible); 6.2 (fixed, thermal)mm |
 | Field of view | 39.42 horizontal / 22.14 vertical (visible)° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.017 lux color |
 | Power | DC 12V / PoE Class 3 (IEEE 802.3af); 6 W (DC), 6.5 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z325.md
+++ b/docs/cameras/acti/z325.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 100.8 horizontal / 55.8 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z332.md
+++ b/docs/cameras/acti/z332.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 100.7 horizontal / 51.5 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 5.5 W (DC), 3.9 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z429.md
+++ b/docs/cameras/acti/z429.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5 (zoom, 5x optical)mm F1.4 |
 | Field of view | 111.5 - 34.4 horizontal / 58.7 - 19.2 vertical° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 8 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z510.md
+++ b/docs/cameras/acti/z510.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 100.0 horizontal / 51.1 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z512.md
+++ b/docs/cameras/acti/z512.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 100.7 horizontal / 51.5 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 3.9 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z56.md
+++ b/docs/cameras/acti/z56.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 100.8 horizontal / 55.8 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.005 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 5.3 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z64.md
+++ b/docs/cameras/acti/z64.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8-12 (zoom, 4.3x optical)mm F1.4-F3.3 |
 | Field of view | 111.5 - 34.4 horizontal / 58.7 - 19.2 (Visual camera) vertical° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.001 lux color |
 | Power | 12V / PoE (IEEE 802.3af); 8 W (PoE) |
 | IP rating | IP68 |
 | Two-way audio | No |

--- a/docs/cameras/acti/z722.md
+++ b/docs/cameras/acti/z722.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 97 horizontal / 52.2 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 2.8 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z818.md
+++ b/docs/cameras/acti/z818.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5 (zoom, 5x optical)mm F1.4 |
 | Field of view | 111.5 - 34.4 horizontal / 58.7 - 19.2 vertical° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 8.6 W (PoE) |
 | Protocols | rtsp, onvif |
 | IP rating | IP68 |

--- a/docs/cameras/acti/z914.md
+++ b/docs/cameras/acti/z914.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2 (fixed)mm |
 | Field of view | 126 horizontal / 71 vertical° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.001 lux color |
 | Power | DC 12V / PoE (IEEE 802.3af); 12.95 W (PoE) |
 | Two-way audio | Yes |
 | Operating temp | -10 to 50°C |


### PR DESCRIPTION
Backfills `night_vision.min_lux_color` for **25 ACTi** color/hybrid cameras — part of the #161 low-light lux lane.

## Method (deterministic)
Pulled from ACTi's hidden spec API (`newPopupSpecifications_value.ashx`, "Minimum Illumination" field) — the same endpoint used for the ACTi streams backfill — parsing the printed **Color** figure:
- e.g. `Color: 0.0008 lux at F1.0 (AGC on); B/W: 0 lux` → `min_lux_color = 0.0008`
- values range 0.0005–0.0176 lux (varying by aperture, as printed).
- **Skips the `B/W: 0 lux` / IR-on figure** — that's the #180 sentinel trap (0 lux = IR on, not ambient sensitivity), never recorded.

## Notes
- `A573-P2` skipped — a partial sensor-unit entry with no illumination field in the API.
- Every value is straight from the official ACTi spec API; nothing guessed.

Dataset-wide `min_lux_color` coverage **337 → 362**. Builds clean; no reformatting.