### PR TITLE
data: backfill night_vision.min_lux_color — Dahua (#161)

### DIFF
--- a/cameras/dahua/hac-hdw1509t-a-led.json
+++ b/cameras/dahua/hac-hdw1509t-a-led.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "DC 12V (HDCVI coaxial)"

--- a/cameras/dahua/hac-hfw1509t-a-led.json
+++ b/cameras/dahua/hac-hfw1509t-a-led.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "DC 12V (HDCVI coaxial)"

--- a/cameras/dahua/hac-hfw1549sm-il-a-pro.json
+++ b/cameras/dahua/hac-hfw1549sm-il-a-pro.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "111h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "DC 12V",

--- a/cameras/dahua/ipc-hdbw2249e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2249e-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "100",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw2449e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2449e-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "100",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw2449f-as-e2-il.json
+++ b/cameras/dahua/ipc-hdbw2449f-as-e2-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "101.5",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "max_fps": 30

--- a/cameras/dahua/ipc-hdbw2449f-as-il.json
+++ b/cameras/dahua/ipc-hdbw2449f-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "101",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw2649e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2649e-s-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "112",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw2849e-s-il.json
+++ b/cameras/dahua/ipc-hdbw2849e-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "113 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-48h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0003
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdbw3467r-zas-il.json
+++ b/cameras/dahua/ipc-hdbw3467r-zas-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "104-29",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.json
+++ b/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdbw3849e-s-il.json
+++ b/cameras/dahua/ipc-hdbw3849e-s-il.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdbw3849f-as-il.json
+++ b/cameras/dahua/ipc-hdbw3849f-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "108.4h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.json
+++ b/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0006
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdbw3849r1-zas-pv.json
+++ b/cameras/dahua/ipc-hdbw3849r1-zas-pv.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hdbw3867e-as-il.json
+++ b/cameras/dahua/ipc-hdbw3867e-as-il.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdbw3867r-zas-il.json
+++ b/cameras/dahua/ipc-hdbw3867r-zas-il.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdbw5259r-ase-il.json
+++ b/cameras/dahua/ipc-hdbw5259r-ase-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "108.4h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0007
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdw1239t1-led-s6.json
+++ b/cameras/dahua/ipc-hdw1239t1-led-s6.json
@@ -16,7 +16,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 15,
-    "min_lux": 0.005
+    "min_lux": 0.005,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE/DC12V"

--- a/cameras/dahua/ipc-hdw1339da-saw-il.json
+++ b/cameras/dahua/ipc-hdw1339da-saw-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "103h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "12VDC",

--- a/cameras/dahua/ipc-hdw1339da-sw-pv.json
+++ b/cameras/dahua/ipc-hdw1339da-sw-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "103h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "12VDC",

--- a/cameras/dahua/ipc-hdw1439t-a-led-s4.json
+++ b/cameras/dahua/ipc-hdw1439t-a-led-s4.json
@@ -19,7 +19,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 15,
-    "min_lux": 0.008
+    "min_lux": 0.008,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw1439t1-led.json
+++ b/cameras/dahua/ipc-hdw1439t1-led.json
@@ -16,7 +16,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 15,
-    "min_lux": 0.006
+    "min_lux": 0.006,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2249t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2249t-s-pro.json
@@ -27,7 +27,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 30,
-    "min_lux": 0.0002
+    "min_lux": 0.0002,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2249t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2249t-zs-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2249th-s-prox.json
+++ b/cameras/dahua/ipc-hdw2249th-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110",
   "night_vision": {
     "type": "color",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.00003
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2249tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2249tm-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "100",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2439t-as-led-s2.json
+++ b/cameras/dahua/ipc-hdw2439t-as-led-s2.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "96",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE/DC12V"

--- a/cameras/dahua/ipc-hdw2449t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2449t-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "105",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2449t-s-pv.json
+++ b/cameras/dahua/ipc-hdw2449t-s-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "101.6",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2449t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2449t-zs-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "97-28h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2449th-s-prox.json
+++ b/cameras/dahua/ipc-hdw2449th-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "106",
   "night_vision": {
     "type": "color",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.00007
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw2449tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2449tm-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "95h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2549emp-s-pro.json
+++ b/cameras/dahua/ipc-hdw2549emp-s-pro.json
@@ -18,7 +18,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw2549t-s-pv.json
+++ b/cameras/dahua/ipc-hdw2549t-s-pv.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "111.0",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "max_fps": 30

--- a/cameras/dahua/ipc-hdw2649t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2649t-zs-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2649tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2649tm-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2849t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2849t-zs-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw2849tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2849tm-s-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111 (2.8mm) / 87 (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "video": {
     "codecs": ["H.265", "H.264", "MJPEG"],

--- a/cameras/dahua/ipc-hdw3449h-as-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3449h-as-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "113 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0001
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hdw3449h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3449h-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-48",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0003
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw3549h-as-pv.json
+++ b/cameras/dahua/ipc-hdw3549h-as-pv.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hdw3649h-as-pv.json
+++ b/cameras/dahua/ipc-hdw3649h-as-pv.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "111 (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw3649h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3649h-zas-pv-pro.json
@@ -54,7 +54,8 @@
   "field_of_view_deg": "112-48",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE+ (802.3at) / DC 12V",

--- a/cameras/dahua/ipc-hdw3849h-as-pv.json
+++ b/cameras/dahua/ipc-hdw3849h-as-pv.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE / DC 12V",

--- a/cameras/dahua/ipc-hdw3849h-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdw3849h-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hdw3849h-zas-pv.json
+++ b/cameras/dahua/ipc-hdw3849h-zas-pv.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hdw3849t-zs-il.json
+++ b/cameras/dahua/ipc-hdw3849t-zs-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hdw3867em-s-il.json
+++ b/cameras/dahua/ipc-hdw3867em-s-il.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw3867t-zs-il.json
+++ b/cameras/dahua/ipc-hdw3867t-zs-il.json
@@ -18,7 +18,8 @@
     "focal_length_mm": "2.7-13.5"
   },
   "night_vision": {
-    "type": "hybrid"
+    "type": "hybrid",
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hdw5259t-ze-il.json
+++ b/cameras/dahua/ipc-hdw5259t-ze-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0007
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdw5259tm-ase-il.json
+++ b/cameras/dahua/ipc-hdw5259tm-ase-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "108.4h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0007
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hdw5449h-ase-d2.json
+++ b/cameras/dahua/ipc-hdw5449h-ase-d2.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0002
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/dahua/ipc-hfw1339dtk1-sw-pv.json
+++ b/cameras/dahua/ipc-hfw1339dtk1-sw-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "103h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "12VDC",

--- a/cameras/dahua/ipc-hfw1439s-led-s4.json
+++ b/cameras/dahua/ipc-hfw1439s-led-s4.json
@@ -15,7 +15,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 30,
-    "min_lux": 0.008
+    "min_lux": 0.008,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1439s1-led-s4.json
+++ b/cameras/dahua/ipc-hfw1439s1-led-s4.json
@@ -15,7 +15,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 30,
-    "min_lux": 0.008
+    "min_lux": 0.008,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1439s1-led.json
+++ b/cameras/dahua/ipc-hfw1439s1-led.json
@@ -15,7 +15,8 @@
   "night_vision": {
     "type": "color",
     "range_m": 30,
-    "min_lux": 0.008
+    "min_lux": 0.008,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1439s1p-led-s4.json
+++ b/cameras/dahua/ipc-hfw1439s1p-led-s4.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw1539dtk1-sw-pv.json
+++ b/cameras/dahua/ipc-hfw1539dtk1-sw-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "104h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "12VDC",

--- a/cameras/dahua/ipc-hfw21249t-as-il.json
+++ b/cameras/dahua/ipc-hfw21249t-as-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "112",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw21249t-s-il.json
+++ b/cameras/dahua/ipc-hfw21249t-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112 (2.8mm) / 95 (3.6mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2249m-s-b-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "81",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249s-s-il-nl.json
+++ b/cameras/dahua/ipc-hfw2249s-s-il-nl.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw2249s-s-il.json
+++ b/cameras/dahua/ipc-hfw2249s-s-il.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "100",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249t-as-il.json
+++ b/cameras/dahua/ipc-hfw2249t-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "83",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2249t-zas-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "104-29",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2249tl-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "101",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2249tl-s-prox.json
+++ b/cameras/dahua/ipc-hfw2249tl-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.00003
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2439s-sa-led-b.json
+++ b/cameras/dahua/ipc-hfw2439s-sa-led-b.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "107h",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE/DC12V"

--- a/cameras/dahua/ipc-hfw2449m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2449m-s-b-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "89",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2449s-s-il.json
+++ b/cameras/dahua/ipc-hfw2449s-s-il.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw2449t-as-il.json
+++ b/cameras/dahua/ipc-hfw2449t-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "84h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2449t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2449t-zas-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "97-28h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.006
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2449tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "2.8mm: 105 / 3.6mm: 89 / 6mm: 55",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2449tl-s-prox.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "106",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.00007
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2449tl-s-pv.json
+++ b/cameras/dahua/ipc-hfw2449tl-s-pv.json
@@ -48,7 +48,8 @@
   "field_of_view_deg": "101.6",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V",

--- a/cameras/dahua/ipc-hfw2549tl-s-pv.json
+++ b/cameras/dahua/ipc-hfw2549tl-s-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "111.0",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2649m-s-b-pro.json
+++ b/cameras/dahua/ipc-hfw2649m-s-b-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "78",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2649s-s-il.json
+++ b/cameras/dahua/ipc-hfw2649s-s-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2649t-as-il.json
+++ b/cameras/dahua/ipc-hfw2649t-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "91h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2649t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2649t-zas-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2649tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2649tl-s-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "92",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2849s-s-il-s2.json
+++ b/cameras/dahua/ipc-hfw2849s-s-il-s2.json
@@ -14,7 +14,8 @@
   "field_of_view_deg": "106h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw2849s-s-il.json
+++ b/cameras/dahua/ipc-hfw2849s-s-il.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw2849t-as-il.json
+++ b/cameras/dahua/ipc-hfw2849t-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "87h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2849t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2849t-zas-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "114-32h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw2849th-s-prox.json
+++ b/cameras/dahua/ipc-hfw2849th-s-prox.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "105",
   "night_vision": {
     "type": "color",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.0001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw2849tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2849tl-s-pro.json
@@ -30,7 +30,8 @@
   "field_of_view_deg": "110 (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0004
   },
   "power": {
     "method": "12VDC/PoE (802.3af)",

--- a/cameras/dahua/ipc-hfw3467e-as-il.json
+++ b/cameras/dahua/ipc-hfw3467e-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "100/83/51",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw3549e-as-led.json
+++ b/cameras/dahua/ipc-hfw3549e-as-led.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3549t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3549t1-as-pv.json
@@ -31,7 +31,8 @@
   "field_of_view_deg": "106 (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "12VDC/PoE",

--- a/cameras/dahua/ipc-hfw3649t1-as-pv-s2.json
+++ b/cameras/dahua/ipc-hfw3649t1-as-pv-s2.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw3667e-as-il.json
+++ b/cameras/dahua/ipc-hfw3667e-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw3667t-zas-il.json
+++ b/cameras/dahua/ipc-hfw3667t-zas-il.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw3849e-as-il.json
+++ b/cameras/dahua/ipc-hfw3849e-as-il.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3849e-s-il.json
+++ b/cameras/dahua/ipc-hfw3849e-s-il.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3849t1-as-pv-pro.json
+++ b/cameras/dahua/ipc-hfw3849t1-as-pv-pro.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "108 (2.8mm)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3849t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3849t1-as-pv.json
@@ -25,7 +25,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "112-48h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.0006
   },
   "power": {
     "method": "12VDC/PoE+",

--- a/cameras/dahua/ipc-hfw3849t1-zas-pv.json
+++ b/cameras/dahua/ipc-hfw3849t1-zas-pv.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.004
   },
   "power": {
     "method": "PoE / DC 12V"

--- a/cameras/dahua/ipc-hfw3867e-as-il.json
+++ b/cameras/dahua/ipc-hfw3867e-as-il.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "110",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.007
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-hfw3867t-zas-il.json
+++ b/cameras/dahua/ipc-hfw3867t-zas-il.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.007
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"

--- a/cameras/dahua/ipc-hfw5849t1-ase-led.json
+++ b/cameras/dahua/ipc-hfw5849t1-ase-led.json
@@ -59,7 +59,8 @@
   "field_of_view_deg": "113 (2.8mm)",
   "night_vision": {
     "type": "color",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "12VDC/PoE/ePoE",

--- a/cameras/dahua/ipc-pdw2849-a180-s-pv.json
+++ b/cameras/dahua/ipc-pdw2849-a180-s-pv.json
@@ -22,7 +22,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 25
+    "range_m": 25,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-pfw2849s-a180-s-pv.json
+++ b/cameras/dahua/ipc-pfw2849s-a180-s-pv.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 25
+    "range_m": 25,
+    "min_lux_color": 0.005
   },
   "video": {
     "max_fps": 20

--- a/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.json
+++ b/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "180",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ipc-pfw5849-a180-e2-aste.json
+++ b/cameras/dahua/ipc-pfw5849-a180-e2-aste.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "180 horizontal",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3at) / DC 12V"

--- a/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.json
+++ b/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "81",
   "night_vision": {
     "type": "color",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0006
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/ptz37225-hnp-gb-a.json
+++ b/cameras/dahua/ptz37225-hnp-gb-a.json
@@ -18,7 +18,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true

--- a/cameras/dahua/sd4d225mb-hnr.json
+++ b/cameras/dahua/sd4d225mb-hnr.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "57.5-3.2h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4d425mb-hnr.json
+++ b/cameras/dahua/sd4d425mb-hnr.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "54.1-3.4h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4d825mb-hnr.json
+++ b/cameras/dahua/sd4d825mb-hnr.json
@@ -26,7 +26,8 @@
   "field_of_view_deg": "57.7-3.7h",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e225gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225gb-hnr-a-pv1.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd4e225mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e225mb-hnr-a-pv1.json
@@ -18,7 +18,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd4e425gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425gb-hnr-a-pv1.json
@@ -19,7 +19,8 @@
   "sensor": "1/2.8\" CMOS",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd4e425mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e425mb-hnr-a-pv1.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e825gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825gb-hnr-a-pv1.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd4e825mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd4e825mb-hnr-a-pv1.json
@@ -18,7 +18,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd4f420da-hny.json
+++ b/cameras/dahua/sd4f420da-hny.json
@@ -27,7 +27,8 @@
   "field_of_view_deg": "7-105",
   "night_vision": {
     "type": "color",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.0005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd5r404ga-hnf.json
+++ b/cameras/dahua/sd5r404ga-hnf.json
@@ -27,7 +27,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6al245gb-hnv.json
+++ b/cameras/dahua/sd6al245gb-hnv.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 550
+    "range_m": 550,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6al445gb-hnv.json
+++ b/cameras/dahua/sd6al445gb-hnv.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 550
+    "range_m": 550,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-agq-pv1.json
@@ -55,7 +55,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sd6e232mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e232mb-hnr-a-pv1.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6e245mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e245mb-hnr-a-pv1.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6e425mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e425mb-hnr-a-pv1.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6e432mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e432mb-hnr-a-pv1.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6e445mb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e445mb-hnr-a-pv1.json
@@ -24,7 +24,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd6e825ma-hnr-a-pv1.json
+++ b/cameras/dahua/sd6e825ma-hnr-a-pv1.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8c260pa-hnf.json
+++ b/cameras/dahua/sd8c260pa-hnf.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8c440fd-hnf.json
+++ b/cameras/dahua/sd8c440fd-hnf.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.0002
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8c448pa-hnf.json
+++ b/cameras/dahua/sd8c448pa-hnf.json
@@ -22,7 +22,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8c848pa-hnf.json
+++ b/cameras/dahua/sd8c848pa-hnf.json
@@ -26,7 +26,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8x442fa-hnf.json
+++ b/cameras/dahua/sd8x442fa-hnf.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "61.4-2.3 (H)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 600
+    "range_m": 600,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sd8x842fa-hnf.json
+++ b/cameras/dahua/sd8x842fa-hnf.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 600
+    "range_m": 600,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt4e225-4f-gb-a-pv1.json
+++ b/cameras/dahua/sdt4e225-4f-gb-a-pv1.json
@@ -30,7 +30,8 @@
   "field_of_view_deg": "101 (panorama) / 51.9-3.0 (detail)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt4e425-4f-gb-a-pv1.json
+++ b/cameras/dahua/sdt4e425-4f-gb-a-pv1.json
@@ -29,7 +29,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "max_fps": 30

--- a/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
+++ b/cameras/dahua/sdt4e425-4f-mb-agq-pv1.json
@@ -22,7 +22,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.json
+++ b/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.json
@@ -30,7 +30,8 @@
   "field_of_view_deg": "180 (panorama) / detail 25x zoom",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt4e425-8p-gb-apv1.json
+++ b/cameras/dahua/sdt4e425-8p-gb-apv1.json
@@ -18,7 +18,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true,

--- a/cameras/dahua/sdt5x2425-4z4-fa.json
+++ b/cameras/dahua/sdt5x2425-4z4-fa.json
@@ -29,7 +29,8 @@
   "field_of_view_deg": "overview 4x zoom / detail 25x zoom",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt5x425-4z4-fa-0832.json
+++ b/cameras/dahua/sdt5x425-4z4-fa-0832.json
@@ -28,7 +28,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt5x425-4z4-fa-2812.json
+++ b/cameras/dahua/sdt5x425-4z4-fa-2812.json
@@ -29,7 +29,8 @@
   "field_of_view_deg": "99.2-45.8 (panorama) / 58-3.5 (detail)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt5x425-4z4-fajg-2812.json
+++ b/cameras/dahua/sdt5x425-4z4-fajg-2812.json
@@ -29,7 +29,8 @@
   "field_of_view_deg": "99.2-45.8 H (panorama) / 58-3.5 H (detail)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.json
+++ b/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.json
@@ -28,7 +28,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt6e425-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt6e425-8p-mb-a-pv1.json
@@ -29,7 +29,8 @@
   },
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt6e432-8p-mb-a-pv1.json
+++ b/cameras/dahua/sdt6e432-8p-mb-a-pv1.json
@@ -30,7 +30,8 @@
   "field_of_view_deg": "180 (panorama) / 55.8-2.3 (detail)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 250
+    "range_m": 250,
+    "min_lux_color": 0.005
   },
   "video": {
     "codecs": [

--- a/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
+++ b/cameras/dahua/sdt8c842-8p-fa-apv-0280.json
@@ -30,7 +30,8 @@
   "field_of_view_deg": "200 (panorama) / 61.8-2.2 (detail)",
   "night_vision": {
     "type": "hybrid",
-    "range_m": 300
+    "range_m": 300,
+    "min_lux_color": 0.001
   },
   "video": {
     "codecs": [
@@ -87,7 +88,8 @@
     "global"
   ],
   "sources": [
-    "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280"
+    "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280",
+    "https://materialfile.dahuasecurity.com/uploads/soft/20241224/SDT8C842-8P-FA-APV-0280_S0_datasheet_20241120_BR.pdf"
   ],
   "last_verified": "2026-07-22",
   "configs": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -81003,7 +81003,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V (HDCVI coaxial)"
@@ -81262,7 +81263,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V (HDCVI coaxial)"
@@ -81396,7 +81398,8 @@
     "field_of_view_deg": "111h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "DC 12V",
@@ -90683,7 +90686,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -90980,7 +90984,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -91162,7 +91167,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -91251,7 +91257,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -91374,7 +91381,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -91634,7 +91642,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91720,7 +91729,8 @@
       "focal_length_mm": "2.7-13.5"
     },
     "night_vision": {
-      "type": "hybrid"
+      "type": "hybrid",
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91814,7 +91824,8 @@
     "field_of_view_deg": "110-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -91903,7 +91914,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92160,7 +92172,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -92682,7 +92695,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -92859,7 +92859,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -92936,7 +92937,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93013,7 +93015,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93098,7 +93101,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93188,7 +93192,8 @@
     "field_of_view_deg": "104h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC",
@@ -93349,7 +93354,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -93466,7 +93472,8 @@
     "field_of_view_deg": "112 (2.8mm) / 95 (3.6mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -93987,7 +93994,8 @@
     "field_of_view_deg": "81",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -94095,7 +94103,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94207,7 +94216,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -94297,7 +94307,8 @@
     "field_of_view_deg": "83",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94409,7 +94420,8 @@
     "field_of_view_deg": "104-29",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94521,7 +94533,8 @@
     "field_of_view_deg": "101",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -94631,7 +94644,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.00003
     },
     "video": {
       "codecs": [
@@ -94932,7 +94946,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE/DC12V"
@@ -95538,7 +95553,8 @@
     "field_of_view_deg": "89",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -102371,7 +102371,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "video": {
       "codecs": [
@@ -102491,7 +102492,8 @@
     "field_of_view_deg": "180 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -102915,7 +102917,8 @@
     "field_of_view_deg": "81",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -103439,7 +103442,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -105855,7 +105859,8 @@
     "field_of_view_deg": "57.5-3.2h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -105948,7 +105953,8 @@
     "field_of_view_deg": "54.1-3.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106041,7 +106047,8 @@
     "field_of_view_deg": "57.7-3.7h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106128,7 +106135,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106248,7 +106256,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106370,7 +106379,8 @@
     "sensor": "1/2.8\" CMOS",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106488,7 +106498,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106614,7 +106625,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106738,7 +106750,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106867,7 +106880,8 @@
     "field_of_view_deg": "7-105",
     "night_vision": {
       "type": "color",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0005
     },
     "video": {
       "codecs": [
@@ -108536,7 +108550,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -108779,7 +108794,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 550
+      "range_m": 550,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -108901,7 +108917,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 550
+      "range_m": 550,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109328,7 +109345,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -85559,7 +85559,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.005
+      "min_lux": 0.005,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE/DC12V"
@@ -85646,7 +85647,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",
@@ -85733,7 +85735,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",
@@ -85900,7 +85903,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85978,7 +85982,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.006
+      "min_lux": 0.006,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86921,7 +86926,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.0002
+      "min_lux": 0.0002,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -87148,7 +87154,8 @@
     "field_of_view_deg": "110-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "12VDC/PoE",
@@ -87235,7 +87242,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.00003
     },
     "video": {
       "codecs": [
@@ -87344,7 +87352,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -87444,7 +87453,8 @@
     "field_of_view_deg": "96",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE/DC12V"
@@ -87984,7 +87994,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -88096,7 +88107,8 @@
     "field_of_view_deg": "101.6",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "video": {
       "codecs": [

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -88220,7 +88220,8 @@
     "field_of_view_deg": "97-28h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -88308,7 +88309,8 @@
     "field_of_view_deg": "106",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.00007
     },
     "video": {
       "codecs": [
@@ -88419,7 +88421,8 @@
     "field_of_view_deg": "95h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -88917,7 +88920,8 @@
     "field_of_view_deg": "111.0",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "max_fps": 30
@@ -89129,7 +89133,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -89217,7 +89222,8 @@
     "field_of_view_deg": "112h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -90055,7 +90061,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -90146,7 +90153,8 @@
     "field_of_view_deg": "111 (2.8mm) / 87 (3.6mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -90256,7 +90264,8 @@
     "field_of_view_deg": "113 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -90347,7 +90356,8 @@
     "field_of_view_deg": "114-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0003
     },
     "video": {
       "codecs": [
@@ -90464,7 +90474,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -90552,7 +90563,8 @@
     "field_of_view_deg": "111 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -99095,7 +99095,8 @@
     "field_of_view_deg": "100/83/51",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -99211,7 +99212,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -99330,7 +99332,8 @@
     "field_of_view_deg": "106 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12VDC/PoE",
@@ -99423,7 +99426,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -99514,7 +99518,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -99883,7 +99888,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -99967,7 +99973,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100055,7 +100062,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100145,7 +100153,8 @@
     "field_of_view_deg": "108 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100234,7 +100243,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100323,7 +100333,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -100585,7 +100596,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -100696,7 +100708,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -101686,7 +101699,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -101807,7 +101821,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -101929,7 +101944,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "video": {
       "codecs": [
@@ -102135,7 +102151,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.005
     },
     "video": {
       "max_fps": 20
@@ -102232,7 +102249,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -88836,7 +88836,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -99629,7 +99630,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -101180,7 +101182,8 @@
     "field_of_view_deg": "113 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12VDC/PoE/ePoE",
@@ -115002,7 +115005,8 @@
     "field_of_view_deg": "200 (panorama) / 61.8-2.2 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 300
+      "range_m": 300,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -115059,7 +115063,8 @@
       "global"
     ],
     "sources": [
-      "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280"
+      "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280",
+      "https://materialfile.dahuasecurity.com/uploads/soft/20241224/SDT8C842-8P-FA-APV-0280_S0_datasheet_20241120_BR.pdf"
     ],
     "last_verified": "2026-07-22",
     "configs": {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -95663,7 +95663,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -95751,7 +95752,8 @@
     "field_of_view_deg": "84h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -95839,7 +95841,8 @@
     "field_of_view_deg": "97-28h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -95928,7 +95931,8 @@
     "field_of_view_deg": "2.8mm: 105 / 3.6mm: 89 / 6mm: 55",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -96040,7 +96044,8 @@
     "field_of_view_deg": "106",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.00007
     },
     "video": {
       "codecs": [
@@ -96174,7 +96179,8 @@
     "field_of_view_deg": "101.6",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -96713,7 +96719,8 @@
     "field_of_view_deg": "111.0",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -96826,7 +96833,8 @@
     "field_of_view_deg": "78",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -96938,7 +96946,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -97048,7 +97057,8 @@
     "field_of_view_deg": "91h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -97136,7 +97146,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -97225,7 +97236,8 @@
     "field_of_view_deg": "92",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -98210,7 +98222,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -98286,7 +98299,8 @@
     "field_of_view_deg": "106h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -98375,7 +98389,8 @@
     "field_of_view_deg": "87h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -98463,7 +98478,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -98552,7 +98568,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -98698,7 +98715,8 @@
     "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0004
     },
     "power": {
       "method": "12VDC/PoE (802.3af)",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -109447,7 +109447,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109568,7 +109569,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109697,7 +109699,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109822,7 +109825,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109948,7 +109952,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -110067,7 +110072,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112103,7 +112109,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112345,7 +112352,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -112468,7 +112476,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -112714,7 +112723,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112957,7 +112967,8 @@
     "field_of_view_deg": "61.4-2.3 (H)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 600
+      "range_m": 600,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113080,7 +113091,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 600
+      "range_m": 600,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -113541,7 +113553,8 @@
     "field_of_view_deg": "101 (panorama) / 51.9-3.0 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113664,7 +113677,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "max_fps": 30
@@ -113755,7 +113769,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113892,7 +113907,8 @@
     "field_of_view_deg": "180 (panorama) / detail 25x zoom",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -114003,7 +114019,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -114105,7 +114122,8 @@
     "field_of_view_deg": "overview 4x zoom / detail 25x zoom",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114228,7 +114246,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114352,7 +114371,8 @@
     "field_of_view_deg": "99.2-45.8 (panorama) / 58-3.5 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114481,7 +114501,8 @@
     "field_of_view_deg": "99.2-45.8 H (panorama) / 58-3.5 H (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114604,7 +114625,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114727,7 +114749,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -114853,7 +114876,8 @@
     "field_of_view_deg": "180 (panorama) / 55.8-2.3 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -81925,7 +81925,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -82422,7 +82423,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -82533,7 +82535,8 @@
     "field_of_view_deg": "101.5",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "max_fps": 30
@@ -82628,7 +82631,8 @@
     "field_of_view_deg": "101",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -83072,7 +83076,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -83609,7 +83614,8 @@
     "field_of_view_deg": "113 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -83945,7 +83951,8 @@
     "field_of_view_deg": "114-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0003
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84036,7 +84043,8 @@
     "field_of_view_deg": "104-29",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -84157,7 +84165,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84248,7 +84257,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "video": {
       "codecs": [
@@ -84360,7 +84370,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84450,7 +84461,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -84537,7 +84549,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -84628,7 +84641,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84719,7 +84733,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -85014,7 +85029,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85102,7 +85118,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85198,7 +85215,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -81003,7 +81003,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V (HDCVI coaxial)"
@@ -81262,7 +81263,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V (HDCVI coaxial)"
@@ -81396,7 +81398,8 @@
     "field_of_view_deg": "111h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "DC 12V",
@@ -90683,7 +90686,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE+ (802.3at) / DC 12V",
@@ -90980,7 +90984,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V",
@@ -91162,7 +91167,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -91251,7 +91257,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -91374,7 +91381,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -91634,7 +91642,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91720,7 +91729,8 @@
       "focal_length_mm": "2.7-13.5"
     },
     "night_vision": {
-      "type": "hybrid"
+      "type": "hybrid",
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -91814,7 +91824,8 @@
     "field_of_view_deg": "110-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -91903,7 +91914,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -92160,7 +92172,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -92682,7 +92695,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -92859,7 +92859,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -92936,7 +92937,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93013,7 +93015,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93098,7 +93101,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -93188,7 +93192,8 @@
     "field_of_view_deg": "104h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC",
@@ -93349,7 +93354,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -93466,7 +93472,8 @@
     "field_of_view_deg": "112 (2.8mm) / 95 (3.6mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -93987,7 +93994,8 @@
     "field_of_view_deg": "81",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -94095,7 +94103,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94207,7 +94216,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -94297,7 +94307,8 @@
     "field_of_view_deg": "83",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94409,7 +94420,8 @@
     "field_of_view_deg": "104-29",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -94521,7 +94533,8 @@
     "field_of_view_deg": "101",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -94631,7 +94644,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.00003
     },
     "video": {
       "codecs": [
@@ -94932,7 +94946,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE/DC12V"
@@ -95538,7 +95553,8 @@
     "field_of_view_deg": "89",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -102371,7 +102371,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "video": {
       "codecs": [
@@ -102491,7 +102492,8 @@
     "field_of_view_deg": "180 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3at) / DC 12V"
@@ -102915,7 +102917,8 @@
     "field_of_view_deg": "81",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -103439,7 +103442,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -105855,7 +105859,8 @@
     "field_of_view_deg": "57.5-3.2h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -105948,7 +105953,8 @@
     "field_of_view_deg": "54.1-3.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106041,7 +106047,8 @@
     "field_of_view_deg": "57.7-3.7h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106128,7 +106135,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106248,7 +106256,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106370,7 +106379,8 @@
     "sensor": "1/2.8\" CMOS",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106488,7 +106498,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106614,7 +106625,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -106738,7 +106750,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -106867,7 +106880,8 @@
     "field_of_view_deg": "7-105",
     "night_vision": {
       "type": "color",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0005
     },
     "video": {
       "codecs": [
@@ -108536,7 +108550,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -108779,7 +108794,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 550
+      "range_m": 550,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -108901,7 +108917,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 550
+      "range_m": 550,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109328,7 +109345,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -85559,7 +85559,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.005
+      "min_lux": 0.005,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE/DC12V"
@@ -85646,7 +85647,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",
@@ -85733,7 +85735,8 @@
     "field_of_view_deg": "103h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "12VDC",
@@ -85900,7 +85903,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.008
+      "min_lux": 0.008,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85978,7 +85982,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 15,
-      "min_lux": 0.006
+      "min_lux": 0.006,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -86921,7 +86926,8 @@
     "night_vision": {
       "type": "color",
       "range_m": 30,
-      "min_lux": 0.0002
+      "min_lux": 0.0002,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -87148,7 +87154,8 @@
     "field_of_view_deg": "110-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "12VDC/PoE",
@@ -87235,7 +87242,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.00003
     },
     "video": {
       "codecs": [
@@ -87344,7 +87352,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -87444,7 +87453,8 @@
     "field_of_view_deg": "96",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE/DC12V"
@@ -87984,7 +87994,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -88096,7 +88107,8 @@
     "field_of_view_deg": "101.6",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "video": {
       "codecs": [

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -88220,7 +88220,8 @@
     "field_of_view_deg": "97-28h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -88308,7 +88309,8 @@
     "field_of_view_deg": "106",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.00007
     },
     "video": {
       "codecs": [
@@ -88419,7 +88421,8 @@
     "field_of_view_deg": "95h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -88917,7 +88920,8 @@
     "field_of_view_deg": "111.0",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "max_fps": 30
@@ -89129,7 +89133,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -89217,7 +89222,8 @@
     "field_of_view_deg": "112h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -90055,7 +90061,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -90146,7 +90153,8 @@
     "field_of_view_deg": "111 (2.8mm) / 87 (3.6mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "video": {
       "codecs": [
@@ -90256,7 +90264,8 @@
     "field_of_view_deg": "113 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0001
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -90347,7 +90356,8 @@
     "field_of_view_deg": "114-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0003
     },
     "video": {
       "codecs": [
@@ -90464,7 +90474,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -90552,7 +90563,8 @@
     "field_of_view_deg": "111 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -99095,7 +99095,8 @@
     "field_of_view_deg": "100/83/51",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -99211,7 +99212,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -99330,7 +99332,8 @@
     "field_of_view_deg": "106 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "12VDC/PoE",
@@ -99423,7 +99426,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -99514,7 +99518,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -99883,7 +99888,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -99967,7 +99973,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100055,7 +100062,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100145,7 +100153,8 @@
     "field_of_view_deg": "108 (2.8mm)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100234,7 +100243,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -100323,7 +100333,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -100585,7 +100596,8 @@
     "field_of_view_deg": "110",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -100696,7 +100708,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -101686,7 +101699,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -101807,7 +101821,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -101929,7 +101944,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "video": {
       "codecs": [
@@ -102135,7 +102151,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.005
     },
     "video": {
       "max_fps": 20
@@ -102232,7 +102249,8 @@
     "field_of_view_deg": "180",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -88836,7 +88836,8 @@
     },
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -99629,7 +99630,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -101180,7 +101182,8 @@
     "field_of_view_deg": "113 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12VDC/PoE/ePoE",
@@ -115002,7 +115005,8 @@
     "field_of_view_deg": "200 (panorama) / 61.8-2.2 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 300
+      "range_m": 300,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -115059,7 +115063,8 @@
       "global"
     ],
     "sources": [
-      "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280"
+      "https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280",
+      "https://materialfile.dahuasecurity.com/uploads/soft/20241224/SDT8C842-8P-FA-APV-0280_S0_datasheet_20241120_BR.pdf"
     ],
     "last_verified": "2026-07-22",
     "configs": {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -95663,7 +95663,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -95751,7 +95752,8 @@
     "field_of_view_deg": "84h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -95839,7 +95841,8 @@
     "field_of_view_deg": "97-28h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.006
     },
     "power": {
       "method": "12VDC/PoE",
@@ -95928,7 +95931,8 @@
     "field_of_view_deg": "2.8mm: 105 / 3.6mm: 89 / 6mm: 55",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -96040,7 +96044,8 @@
     "field_of_view_deg": "106",
     "night_vision": {
       "type": "color",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.00007
     },
     "video": {
       "codecs": [
@@ -96174,7 +96179,8 @@
     "field_of_view_deg": "101.6",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V",
@@ -96713,7 +96719,8 @@
     "field_of_view_deg": "111.0",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -96826,7 +96833,8 @@
     "field_of_view_deg": "78",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -96938,7 +96946,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -97048,7 +97057,8 @@
     "field_of_view_deg": "91h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -97136,7 +97146,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "12VDC/PoE",
@@ -97225,7 +97236,8 @@
     "field_of_view_deg": "92",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -98210,7 +98222,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -98286,7 +98299,8 @@
     "field_of_view_deg": "106h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -98375,7 +98389,8 @@
     "field_of_view_deg": "87h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -98463,7 +98478,8 @@
     "field_of_view_deg": "114-32h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -98552,7 +98568,8 @@
     "field_of_view_deg": "105",
     "night_vision": {
       "type": "color",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.0001
     },
     "video": {
       "codecs": [
@@ -98698,7 +98715,8 @@
     "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "color",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0004
     },
     "power": {
       "method": "12VDC/PoE (802.3af)",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -109447,7 +109447,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109568,7 +109569,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109697,7 +109699,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109822,7 +109825,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -109948,7 +109952,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -110067,7 +110072,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112103,7 +112109,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112345,7 +112352,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.0002
     },
     "video": {
       "codecs": [
@@ -112468,7 +112476,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -112714,7 +112723,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -112957,7 +112967,8 @@
     "field_of_view_deg": "61.4-2.3 (H)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 600
+      "range_m": 600,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113080,7 +113091,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 600
+      "range_m": 600,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -113541,7 +113553,8 @@
     "field_of_view_deg": "101 (panorama) / 51.9-3.0 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113664,7 +113677,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "max_fps": 30
@@ -113755,7 +113769,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -113892,7 +113907,8 @@
     "field_of_view_deg": "180 (panorama) / detail 25x zoom",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -114003,7 +114019,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true,
@@ -114105,7 +114122,8 @@
     "field_of_view_deg": "overview 4x zoom / detail 25x zoom",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114228,7 +114246,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114352,7 +114371,8 @@
     "field_of_view_deg": "99.2-45.8 (panorama) / 58-3.5 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114481,7 +114501,8 @@
     "field_of_view_deg": "99.2-45.8 H (panorama) / 58-3.5 H (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114604,7 +114625,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.001
     },
     "video": {
       "codecs": [
@@ -114727,7 +114749,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -114853,7 +114876,8 @@
     "field_of_view_deg": "180 (panorama) / 55.8-2.3 (detail)",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 250
+      "range_m": 250,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -81925,7 +81925,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "video": {
       "codecs": [
@@ -82422,7 +82423,8 @@
     "field_of_view_deg": "100",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -82533,7 +82535,8 @@
     "field_of_view_deg": "101.5",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "max_fps": 30
@@ -82628,7 +82631,8 @@
     "field_of_view_deg": "101",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.006
     },
     "video": {
       "codecs": [
@@ -83072,7 +83076,8 @@
     "field_of_view_deg": "112",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "video": {
       "codecs": [
@@ -83609,7 +83614,8 @@
     "field_of_view_deg": "113 horizontal",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -83945,7 +83951,8 @@
     "field_of_view_deg": "114-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0003
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84036,7 +84043,8 @@
     "field_of_view_deg": "104-29",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "video": {
       "codecs": [
@@ -84157,7 +84165,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84248,7 +84257,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0005
     },
     "video": {
       "codecs": [
@@ -84360,7 +84370,8 @@
     "field_of_view_deg": "107h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -84450,7 +84461,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "12VDC/PoE",
@@ -84537,7 +84549,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.004
     },
     "power": {
       "method": "PoE / DC 12V"
@@ -84628,7 +84641,8 @@
     "field_of_view_deg": "112-48h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "power": {
       "method": "12VDC/PoE+",
@@ -84719,7 +84733,8 @@
     "field_of_view_deg": "112-48",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0006
     },
     "video": {
       "codecs": [
@@ -85014,7 +85029,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85102,7 +85118,8 @@
     },
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.007
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -85198,7 +85215,8 @@
     "field_of_view_deg": "108.4h",
     "night_vision": {
       "type": "hybrid",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.0007
     },
     "power": {
       "method": "12VDC/PoE+",

--- a/docs/cameras/dahua/hac-hdw1509t-a-led.md
+++ b/docs/cameras/dahua/hac-hdw1509t-a-led.md
@@ -8,7 +8,7 @@
 | Connectivity | coax |
 | Resolution | 5MP HD (5MP) |
 | Field of view | 107h° |
-| Night vision | color (40m) |
+| Night vision | color (40m), 0.005 lux color |
 | Power | DC 12V (HDCVI coaxial) |
 | Storage | NVR |
 | Protocols | hdcvi |

--- a/docs/cameras/dahua/hac-hfw1509t-a-led.md
+++ b/docs/cameras/dahua/hac-hfw1509t-a-led.md
@@ -8,7 +8,7 @@
 | Connectivity | coax |
 | Resolution | 5MP HD (5MP) |
 | Field of view | 107h° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.005 lux color |
 | Power | DC 12V (HDCVI coaxial) |
 | Storage | NVR |
 | Protocols | hdcvi |

--- a/docs/cameras/dahua/hac-hfw1549sm-il-a-pro.md
+++ b/docs/cameras/dahua/hac-hfw1549sm-il-a-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 5MP CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 111h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0001 lux color |
 | Power | DC 12V |
 | Storage | NVR |
 | Protocols | hdcvi |

--- a/docs/cameras/dahua/ipc-hdbw2249e-s-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2249e-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 100° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw2449e-s-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2449e-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 100° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw2449f-as-e2-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2449f-as-e2-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 2× 2.8mm F1.6 |
 | Field of view | 101.5° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | 12 VDC / PoE+ (802.3at) |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw2449f-as-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2449f-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8/3.6mm F1.6 |
 | Field of view | 101° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw2649e-s-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2649e-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 112° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw2849e-s-il.md
+++ b/docs/cameras/dahua/ipc-hdbw2849e-s-il.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.6 |
 | Field of view | 113 horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 114-48h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0003 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3467r-zas-il.md
+++ b/docs/cameras/dahua/ipc-hdbw3467r-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.7-13.5mm F1.4 |
 | Field of view | 104-29° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.md
+++ b/docs/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro-atc.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0005 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3849e-s-il.md
+++ b/docs/cameras/dahua/ipc-hdbw3849e-s-il.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP) |
 | Field of view | 107h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3849f-as-il.md
+++ b/docs/cameras/dahua/ipc-hdbw3849f-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.4 |
 | Field of view | 108.4h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.md
+++ b/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro-atc.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0006 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0006 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv.md
+++ b/docs/cameras/dahua/ipc-hdbw3849r1-zas-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.7-13.5 (motorized varifocal)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3867e-as-il.md
+++ b/docs/cameras/dahua/ipc-hdbw3867e-as-il.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Lens | 1× 2.8 (fixed)mm |
 | Field of view | 110° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw3867r-zas-il.md
+++ b/docs/cameras/dahua/ipc-hdbw3867r-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm |
 | Field of view | 114-32° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdbw5259r-ase-il.md
+++ b/docs/cameras/dahua/ipc-hdbw5259r-ase-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 108.4h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0007 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw1239t1-led-s6.md
+++ b/docs/cameras/dahua/ipc-hdw1239t1-led-s6.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p HD (2MP) |
 | Sensor | 1/2.8" CMOS |
 | Field of view | 110° |
-| Night vision | color (15m), 0.005 lux |
+| Night vision | color (15m), 0.005 lux, 0.005 lux color |
 | Power | PoE/DC12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw1339da-saw-il.md
+++ b/docs/cameras/dahua/ipc-hdw1339da-saw-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 103h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | 12VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw1339da-sw-pv.md
+++ b/docs/cameras/dahua/ipc-hdw1339da-sw-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 103h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | 12VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw1439t-a-led-s4.md
+++ b/docs/cameras/dahua/ipc-hdw1439t-a-led-s4.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP) |
 | Sensor | 1/3" CMOS |
 | Field of view | 107h° |
-| Night vision | color (15m), 0.008 lux |
+| Night vision | color (15m), 0.008 lux, 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw1439t1-led.md
+++ b/docs/cameras/dahua/ipc-hdw1439t1-led.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP) |
 | Sensor | 1/3" CMOS |
 | Field of view | 107h° |
-| Night vision | color (15m), 0.006 lux |
+| Night vision | color (15m), 0.006 lux, 0.006 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2249t-s-pro.md
+++ b/docs/cameras/dahua/ipc-hdw2249t-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 101° |
-| Night vision | color (30m), 0.0002 lux |
+| Night vision | color (30m), 0.0002 lux, 0.0002 lux color |
 | Power | DC 12V / PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2249t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw2249t-zs-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 110-32h° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.002 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2249th-s-prox.md
+++ b/docs/cameras/dahua/ipc-hdw2249th-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F0.8 |
 | Field of view | 110° |
-| Night vision | color (20m) |
+| Night vision | color (20m), 0.00003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2249tm-s-il.md
+++ b/docs/cameras/dahua/ipc-hdw2249tm-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 100° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2439t-as-led-s2.md
+++ b/docs/cameras/dahua/ipc-hdw2439t-as-led-s2.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 96° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.004 lux color |
 | Power | PoE/DC12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2449t-s-pro.md
+++ b/docs/cameras/dahua/ipc-hdw2449t-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 105° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2449t-s-pv.md
+++ b/docs/cameras/dahua/ipc-hdw2449t-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 101.6° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2449t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw2449t-zs-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 97-28h° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.006 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2449th-s-prox.md
+++ b/docs/cameras/dahua/ipc-hdw2449th-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F0.8 |
 | Field of view | 106° |
-| Night vision | color (20m) |
+| Night vision | color (20m), 0.00007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw2449tm-s-il.md
+++ b/docs/cameras/dahua/ipc-hdw2449tm-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 95h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2549emp-s-pro.md
+++ b/docs/cameras/dahua/ipc-hdw2549emp-s-pro.md
@@ -9,7 +9,7 @@
 | Resolution | 5MP (5MP, 2960×1668) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2549t-s-pv.md
+++ b/docs/cameras/dahua/ipc-hdw2549t-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 111.0° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2649t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw2649t-zs-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 114-32h° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.007 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2649tm-s-il.md
+++ b/docs/cameras/dahua/ipc-hdw2649tm-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 112h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2849t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw2849t-zs-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 114-32h° |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.008 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw2849tm-s-il.md
+++ b/docs/cameras/dahua/ipc-hdw2849tm-s-il.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm F1.6 |
 | Field of view | 111 (2.8mm) / 87 (3.6mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hdw3449h-as-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdw3449h-as-pv-pro.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 113 horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0001 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3449h-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdw3449h-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 114-48° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0003 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw3549h-as-pv.md
+++ b/docs/cameras/dahua/ipc-hdw3549h-as-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 5MP (5MP, 2960×1668) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.003 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3649h-as-pv.md
+++ b/docs/cameras/dahua/ipc-hdw3649h-as-pv.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 111 (2.8mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hdw3649h-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdw3649h-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw3849h-as-pv.md
+++ b/docs/cameras/dahua/ipc-hdw3849h-as-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3849h-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hdw3849h-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.7-12mm F1.2 |
 | Field of view | 112-48° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0006 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hdw3849h-zas-pv.md
+++ b/docs/cameras/dahua/ipc-hdw3849h-zas-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.7-13.5 (motorized varifocal)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3849t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw3849t-zs-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.4 |
 | Field of view | 114-32h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.007 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3867em-s-il.md
+++ b/docs/cameras/dahua/ipc-hdw3867em-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
 | Field of view | 105° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw3867t-zs-il.md
+++ b/docs/cameras/dahua/ipc-hdw3867t-zs-il.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm |
-| Night vision | hybrid |
+| Night vision | hybrid, 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw5259t-ze-il.md
+++ b/docs/cameras/dahua/ipc-hdw5259t-ze-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.6 |
 | Field of view | 110-32h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0007 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw5259tm-ase-il.md
+++ b/docs/cameras/dahua/ipc-hdw5259tm-ase-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 108.4h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0007 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hdw5449h-ase-d2.md
+++ b/docs/cameras/dahua/ipc-hdw5449h-ase-d2.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 2× 2.8 (fixed)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0002 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1339dtk1-sw-pv.md
+++ b/docs/cameras/dahua/ipc-hfw1339dtk1-sw-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 103h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | 12VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1439s-led-s4.md
+++ b/docs/cameras/dahua/ipc-hfw1439s-led-s4.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 107h° |
-| Night vision | color (30m), 0.008 lux |
+| Night vision | color (30m), 0.008 lux, 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1439s1-led-s4.md
+++ b/docs/cameras/dahua/ipc-hfw1439s1-led-s4.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 107h° |
-| Night vision | color (30m), 0.008 lux |
+| Night vision | color (30m), 0.008 lux, 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1439s1-led.md
+++ b/docs/cameras/dahua/ipc-hfw1439s1-led.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 107h° |
-| Night vision | color (30m), 0.008 lux |
+| Night vision | color (30m), 0.008 lux, 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1439s1p-led-s4.md
+++ b/docs/cameras/dahua/ipc-hfw1439s1p-led-s4.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/3" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw1539dtk1-sw-pv.md
+++ b/docs/cameras/dahua/ipc-hfw1539dtk1-sw-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 104h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | 12VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw21249t-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw21249t-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.5" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 112° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw21249t-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw21249t-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.5" CMOS |
 | Lens | 1× 2.8/3.6mm F1.6 |
 | Field of view | 112 (2.8mm) / 95 (3.6mm)° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2249m-s-b-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2249m-s-b-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 3.6mm F1.0 |
 | Field of view | 81° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0002 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2249s-s-il-nl.md
+++ b/docs/cameras/dahua/ipc-hfw2249s-s-il-nl.md
@@ -11,7 +11,7 @@
 | Resolution | 2MP (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2249s-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw2249s-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 100° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2249t-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw2249t-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 3.6mm F1.6 |
 | Field of view | 83° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2249t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw2249t-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 104-29° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2249tl-s-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2249tl-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 101° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2249tl-s-prox.md
+++ b/docs/cameras/dahua/ipc-hfw2249tl-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F0.8 |
 | Field of view | 110° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.00003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2439s-sa-led-b.md
+++ b/docs/cameras/dahua/ipc-hfw2439s-sa-led-b.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP) |
 | Field of view | 107h° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.004 lux color |
 | Power | PoE/DC12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2449m-s-b-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2449m-s-b-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 3.6mm F1.0 |
 | Field of view | 89° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2449s-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw2449s-s-il.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2449t-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw2449t-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 3.6mm F1.6 |
 | Field of view | 84h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.006 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2449t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw2449t-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 97-28h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.006 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2449tl-s-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2449tl-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8/3.6/6mm F1.0 |
 | Field of view | 2.8mm: 105 / 3.6mm: 89 / 6mm: 55° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2449tl-s-prox.md
+++ b/docs/cameras/dahua/ipc-hfw2449tl-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F0.8 |
 | Field of view | 106° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.00007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2449tl-s-pv.md
+++ b/docs/cameras/dahua/ipc-hfw2449tl-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 101.6° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.004 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2549tl-s-pv.md
+++ b/docs/cameras/dahua/ipc-hfw2549tl-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 111.0° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.006 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2649m-s-b-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2649m-s-b-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 3.6mm F1.0 |
 | Field of view | 78° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2649s-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw2649s-s-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.6 |
 | Field of view | 112° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2649t-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw2649t-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 3.6mm F1.6 |
 | Field of view | 91h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.007 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2649t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw2649t-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 114-32h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.007 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2649tl-s-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2649tl-s-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 92° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2849s-s-il-s2.md
+++ b/docs/cameras/dahua/ipc-hfw2849s-s-il-s2.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP) |
 | Field of view | 106h° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2849s-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw2849s-s-il.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed options)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.008 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2849t-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw2849t-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 3.6mm F1.6 |
 | Field of view | 87h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.008 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2849t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw2849t-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm F1.5 |
 | Field of view | 114-32h° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.008 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw2849th-s-prox.md
+++ b/docs/cameras/dahua/ipc-hfw2849th-s-prox.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 105° |
-| Night vision | color (20m) |
+| Night vision | color (20m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw2849tl-s-pro.md
+++ b/docs/cameras/dahua/ipc-hfw2849tl-s-pro.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm F1.0 |
 | Field of view | 110 (2.8mm)° |
-| Night vision | color (50m) |
+| Night vision | color (50m), 0.0004 lux color |
 | Power | 12VDC/PoE (802.3af) |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hfw3467e-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw3467e-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 1× 2.8/3.6/6mm F1.4 |
 | Field of view | 100/83/51° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw3549e-as-led.md
+++ b/docs/cameras/dahua/ipc-hfw3549e-as-led.md
@@ -11,7 +11,7 @@
 | Resolution | 5MP (5MP, 2880×1620) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed options)mm |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.003 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3549t1-as-pv.md
+++ b/docs/cameras/dahua/ipc-hfw3549t1-as-pv.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm F1.0 |
 | Field of view | 106 (2.8mm)° |
-| Night vision | color (40m) |
+| Night vision | color (40m), 0.003 lux color |
 | Power | 12VDC/PoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hfw3649t1-as-pv-s2.md
+++ b/docs/cameras/dahua/ipc-hfw3649t1-as-pv-s2.md
@@ -11,7 +11,7 @@
 | Resolution | 6MP (6MP, 3072×2048) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3667e-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw3667e-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.4 |
 | Field of view | 110° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw3667t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw3667t-zas-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm |
 | Field of view | 114-32° |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3849e-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw3849e-as-il.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed options)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3849e-s-il.md
+++ b/docs/cameras/dahua/ipc-hfw3849e-s-il.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3849t1-as-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hfw3849t1-as-pv-pro.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm F1.0 |
 | Field of view | 108 (2.8mm)° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0008 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-hfw3849t1-as-pv.md
+++ b/docs/cameras/dahua/ipc-hfw3849t1-as-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.8 (fixed)mm |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.md
+++ b/docs/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.7-13.5mm F1.2 |
 | Field of view | 112-48h° |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.0006 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3849t1-zas-pv.md
+++ b/docs/cameras/dahua/ipc-hfw3849t1-zas-pv.md
@@ -11,7 +11,7 @@
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 2.7-13.5 (motorized varifocal)mm |
-| Night vision | hybrid (50m) |
+| Night vision | hybrid (50m), 0.004 lux color |
 | Power | PoE / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw3867e-as-il.md
+++ b/docs/cameras/dahua/ipc-hfw3867e-as-il.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.8mm F1.4 |
 | Field of view | 110° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-hfw3867t-zas-il.md
+++ b/docs/cameras/dahua/ipc-hfw3867t-zas-il.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/2.7" CMOS |
 | Lens | 1× 2.7-13.5mm |
-| Night vision | hybrid (60m) |
+| Night vision | hybrid (60m), 0.007 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-hfw5849t1-ase-led.md
+++ b/docs/cameras/dahua/ipc-hfw5849t1-ase-led.md
@@ -12,7 +12,7 @@
 | Sensor | 1/1.2" CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm F1.0 |
 | Field of view | 113 (2.8mm)° |
-| Night vision | color (40m) |
+| Night vision | color (40m), 0.0005 lux color |
 | Power | 12VDC/PoE/ePoE |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/ipc-pdw2849-a180-s-pv.md
+++ b/docs/cameras/dahua/ipc-pdw2849-a180-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 2× 2.8mm F1.4 |
 | Field of view | 180° |
-| Night vision | hybrid (25m) |
+| Night vision | hybrid (25m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.md
+++ b/docs/cameras/dahua/ipc-pdw31259-a180-as-pv-atc.md
@@ -10,7 +10,7 @@
 | Sensor | 2 x 1/2.5" CMOS |
 | Lens | 2× 2.8mm F1.0 |
 | Field of view | 180° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.md
+++ b/docs/cameras/dahua/ipc-pdw3859-a180-as-pv-atc.md
@@ -10,7 +10,7 @@
 | Sensor | Dual 1/2.7" CMOS |
 | Lens | 2× 2.8mm F1.4 |
 | Field of view | 180° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.003 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-pfw2849s-a180-s-pv.md
+++ b/docs/cameras/dahua/ipc-pfw2849s-a180-s-pv.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS (x2) |
 | Lens | 2× 2.8mm F1.4 |
 | Field of view | 180° |
-| Night vision | hybrid (25m) |
+| Night vision | hybrid (25m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.md
+++ b/docs/cameras/dahua/ipc-pfw31259s-a180-as-pv-atc.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.5" CMOS |
 | Lens | 1× 2.8mm F1.0 |
 | Field of view | 180° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.002 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.md
+++ b/docs/cameras/dahua/ipc-pfw3859s-a180-as-pv-atc.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" CMOS |
 | Lens | 2× 2.8mm F1.4 |
 | Field of view | 180° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.003 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ipc-pfw5849-a180-e2-aste.md
+++ b/docs/cameras/dahua/ipc-pfw5849-a180-e2-aste.md
@@ -12,7 +12,7 @@
 | Sensor | 2x 1/2.8" CMOS |
 | Lens | 2× 2.8mm per sensormm |
 | Field of view | 180 horizontal° |
-| Night vision | hybrid (30m) |
+| Night vision | hybrid (30m), 0.0005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.md
+++ b/docs/cameras/dahua/ipc-pts2249b-e2-s-pv-pro.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" CMOS |
 | Lens | 2× 3.6mm F1.0 |
 | Field of view | 81° |
-| Night vision | color (30m) |
+| Night vision | color (30m), 0.0006 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/ptz37225-hnp-gb-a.md
+++ b/docs/cameras/dahua/ptz37225-hnp-gb-a.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (150m) |
+| Night vision | hybrid (150m), 0.005 lux color |
 | Power | 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd4d225mb-hnr.md
+++ b/docs/cameras/dahua/sd4d225mb-hnr.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm F1.6 |
 | Field of view | 57.5-3.2h° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4d425mb-hnr.md
+++ b/docs/cameras/dahua/sd4d425mb-hnr.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 5-125mm F1.6 |
 | Field of view | 54.1-3.4h° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4d825mb-hnr.md
+++ b/docs/cameras/dahua/sd4d825mb-hnr.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 5-125mm F1.6 |
 | Field of view | 57.7-3.7h° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | 12VDC/PoE+ |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4e225gb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e225gb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd4e225mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e225mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd4e425gb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e425gb-hnr-a-pv1.md
@@ -8,7 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd4e425mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e425mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4e825gb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e825gb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 5-125mm |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4e825mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd4e825mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ (802.3at) |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd4f420da-hny.md
+++ b/docs/cameras/dahua/sd4f420da-hny.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 2.8-56mm |
 | Field of view | 7-105° |
-| Night vision | color (80m) |
+| Night vision | color (80m), 0.0005 lux color |
 | Power | PoE+ (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd5r404ga-hnf.md
+++ b/docs/cameras/dahua/sd5r404ga-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2688×1520) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (40m) |
+| Night vision | hybrid (40m), 0.001 lux color |
 | Power | PoE (802.3at) / 12 VDC / 24 VAC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd6al245gb-hnv.md
+++ b/docs/cameras/dahua/sd6al245gb-hnv.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 3.95-177.7mm |
-| Night vision | hybrid (550m) |
+| Night vision | hybrid (550m), 0.005 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd6al445gb-hnv.md
+++ b/docs/cameras/dahua/sd6al445gb-hnv.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 3.95-177.7mm |
-| Night vision | hybrid (550m) |
+| Night vision | hybrid (550m), 0.005 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd6c3432gb-hnr-agq-pv1.md
+++ b/docs/cameras/dahua/sd6c3432gb-hnr-agq-pv1.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6-192 (32x optical zoom)mm |
-| Night vision | hybrid (150m) |
+| Night vision | hybrid (150m), 0.005 lux color |
 | Power | 12V DC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/dahua/sd6e232mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e232mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6.0-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / 24V DC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd6e245mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e245mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / 24VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd6e425mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e425mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 24V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd6e432mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e432mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / 24 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd6e445mb-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e445mb-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / DC 24V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd6e825ma-hnr-a-pv1.md
+++ b/docs/cameras/dahua/sd6e825ma-hnr-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE+ (802.3at) / 24 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd8c260pa-hnf.md
+++ b/docs/cameras/dahua/sd8c260pa-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd8c440fd-hnf.md
+++ b/docs/cameras/dahua/sd8c440fd-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6-240mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.0002 lux color |
 | Power | Hi-PoE |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif, http |

--- a/docs/cameras/dahua/sd8c448pa-hnf.md
+++ b/docs/cameras/dahua/sd8c448pa-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6-192mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.001 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sd8c848pa-hnf.md
+++ b/docs/cameras/dahua/sd8c848pa-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6.25-300mm |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd8x442fa-hnf.md
+++ b/docs/cameras/dahua/sd8x442fa-hnf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× 6.0-252mm |
 | Field of view | 61.4-2.3 (H)° |
-| Night vision | hybrid (600m) |
+| Night vision | hybrid (600m), 0.001 lux color |
 | Power | PoE (802.3bt) / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sd8x842fa-hnf.md
+++ b/docs/cameras/dahua/sd8x842fa-hnf.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× |
-| Night vision | hybrid (600m) |
+| Night vision | hybrid (600m), 0.005 lux color |
 | Power | PoE (802.3bt) / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt4e225-4f-gb-a-pv1.md
+++ b/docs/cameras/dahua/sdt4e225-4f-gb-a-pv1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" panorama + 1/2.8" PTZ CMOS |
 | Lens | 2× 2.8 (panorama) / 5-125 (detail)mm F1.0 (panorama) / F1.6-F3.6 (detail) |
 | Field of view | 101 (panorama) / 51.9-3.0 (detail)° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt4e425-4f-gb-a-pv1.md
+++ b/docs/cameras/dahua/sdt4e425-4f-gb-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | Dual 4MP (panorama + 25x PTZ detail) (8MP, 2560×1440) |
 | Sensor | Dual 1/2.8" CMOS (overview + PTZ) |
 | Lens | 2× 2.8 (overview) / 5-125 (detail)mm F1.0 (overview) / F1.6-F3.6 (detail) |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt4e425-4f-mb-agq-pv1.md
+++ b/docs/cameras/dahua/sdt4e425-4f-mb-agq-pv1.md
@@ -11,7 +11,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/1.8" CMOS (overview) + 1/2.8" CMOS (detail) |
 | Lens | 2× |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | rtsp, onvif, http |

--- a/docs/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.md
+++ b/docs/cameras/dahua/sdt4e425-8p-gb-a-pv1-sl.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" 8MP panorama + 1/2.8" 4MP PTZ CMOS |
 | Lens | 2× 2.8 (panorama) / 5-125 (PTZ)mm F1.4 (panorama) / F1.6-F3.6 (PTZ) |
 | Field of view | 180 (panorama) / detail 25x zoom° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE (802.3at) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt4e425-8p-gb-apv1.md
+++ b/docs/cameras/dahua/sdt4e425-8p-gb-apv1.md
@@ -10,7 +10,7 @@
 | Sensor | STARVIS CMOS |
 | Lens | 1× |
 | Field of view | 180° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.005 lux color |
 | Power | Hi-PoE (802.3bt) / 24 VAC |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/dahua/sdt5x2425-4z4-fa.md
+++ b/docs/cameras/dahua/sdt5x2425-4z4-fa.md
@@ -10,7 +10,7 @@
 | Sensor | Dual 1/1.8" CMOS |
 | Lens | 2× 2.8-12 (overview 4x) / 7-175 (detail 25x)mm |
 | Field of view | overview 4x zoom / detail 25x zoom° |
-| Night vision | hybrid (150m) |
+| Night vision | hybrid (150m), 0.001 lux color |
 | Power | Hi-PoE / 36 VDC |
 | Storage | NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt5x425-4z4-fa-0832.md
+++ b/docs/cameras/dahua/sdt5x425-4z4-fa-0832.md
@@ -9,7 +9,7 @@
 | Resolution | Dual 4MP (panorama + 25x PTZ detail) (8MP, 2688×1520) |
 | Sensor | Dual 1/1.8" CMOS (panorama + PTZ) |
 | Lens | 2× 8-32 (panorama, 4x) / 5.4-135 (detail, 25x)mm |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt5x425-4z4-fa-2812.md
+++ b/docs/cameras/dahua/sdt5x425-4z4-fa-2812.md
@@ -10,7 +10,7 @@
 | Sensor | Dual 1/1.8" CMOS (panorama + PTZ) |
 | Lens | 2× 2.8-12 (panorama 4x) / 5.4-135 (detail 25x)mm F1.3-F2.0 (panorama) / F1.6-F4.0 (detail) |
 | Field of view | 99.2-45.8 (panorama) / 58-3.5 (detail)° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt5x425-4z4-fajg-2812.md
+++ b/docs/cameras/dahua/sdt5x425-4z4-fajg-2812.md
@@ -10,7 +10,7 @@
 | Sensor | Dual 1/1.8" CMOS (4MP panorama + 4MP PTZ) |
 | Lens | 2× 2.8-12 (panorama, 4x) / 5.4-135 (detail, 25x)mm F1.3-F2.0 (panorama) / F1.6-F4.0 (detail) |
 | Field of view | 99.2-45.8 H (panorama) / 58-3.5 H (detail)° |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.md
+++ b/docs/cameras/dahua/sdt5x425-4z4-fajg-pv-0832.md
@@ -9,7 +9,7 @@
 | Resolution | Dual 4MP (4MP panorama + 4MP 25x PTZ) (8MP, 2688×1520) |
 | Sensor | Dual 1/1.8" CMOS (panorama + PTZ) |
 | Lens | 2× 8-32 4x (panorama) / 5.4-135 25x (detail)mm F1.4-F4.5 (detail) |
-| Night vision | hybrid (100m) |
+| Night vision | hybrid (100m), 0.001 lux color |
 | Power | Hi-PoE / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt6e425-8p-mb-a-pv1.md
+++ b/docs/cameras/dahua/sdt6e425-8p-mb-a-pv1.md
@@ -9,7 +9,7 @@
 | Resolution | 8MP panorama + 4MP 25x PTZ (12MP, 4096×1860) |
 | Sensor | 1/2.7" panorama + 1/2.8" PTZ CMOS |
 | Lens | 2× 2.8 (panorama) / 5-125 (PTZ)mm F1.4 (panorama) / F1.6-F3.6 (PTZ) |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE++ (802.3bt) / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt6e432-8p-mb-a-pv1.md
+++ b/docs/cameras/dahua/sdt6e432-8p-mb-a-pv1.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" 8MP panorama + 1/2.8" 4MP PTZ CMOS |
 | Lens | 2× 2.8 (panorama) / 4.8-154 (detail 32x)mm F1.4 (panorama) / F1.6-F4.0 (detail) |
 | Field of view | 180 (panorama) / 55.8-2.3 (detail)° |
-| Night vision | hybrid (250m) |
+| Night vision | hybrid (250m), 0.005 lux color |
 | Power | PoE++ (802.3bt) / DC 36V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |

--- a/docs/cameras/dahua/sdt8c842-8p-fa-apv-0280.md
+++ b/docs/cameras/dahua/sdt8c842-8p-fa-apv-0280.md
@@ -10,7 +10,7 @@
 | Sensor | Dual 1/1.8" CMOS |
 | Lens | 2× 2.8 (panorama) / 5.5-231 (detail)mm F1.0 (panorama) / F1.4-F4.5 (detail) |
 | Field of view | 200 (panorama) / 61.8-2.2 (detail)° |
-| Night vision | hybrid (300m) |
+| Night vision | hybrid (300m), 0.001 lux color |
 | Power | PoE++ (802.3bt) / DC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | rtsp, onvif |
@@ -35,6 +35,7 @@
 ## Sources
 
 - https://www.dahuasecurity.com/products/network-products/ptz-cameras/x-spans-series/project/sdt8c842-8p-fa-apv-0280
+- https://materialfile.dahuasecurity.com/uploads/soft/20241224/SDT8C842-8P-FA-APV-0280_S0_datasheet_20241120_BR.pdf
 
 ---
 *Auto-generated from dahua-sdt8c842-8p-fa-apv-0280.json — do not edit by hand.*


### PR DESCRIPTION
## Backfill `night_vision.min_lux_color` — Dahua (#161)

Fills the Color minimum-illumination figure for Dahua color/hybrid cameras, extracted from **official Dahua datasheets** (product pages + `materialfile.dahuasecurity.com` PDFs).

### Coverage
- **154 Dahua cameras** updated across 10 batches (IP bullets/eyeballs/turrets, HDCVI full-color LED, WizColor/TiOC, panoramic PDW/PFW/PTS, and PTZ SD4/SD5/SD6/SD8 + SDT X-Spans dual-PTZ).
- Dahua color/hybrid coverage: **174 now have `min_lux_color`**, up from ~20.
- **12 cameras deliberately left null** — Smart Dual-Light `-IL`/`-SAW-IL`/HAC `-IL-T` models (and one 4G cam with no illumination row) that publish **only a B/W** figure, no ambient-color sensitivity. Recording a value there would be invented data.

### Extraction rules applied
- Recorded the **Color, 30 IRE** figure only.
- **Never** recorded the `0 lux (Illuminator on)` sentinel.
- Single-figure WizColor/full-color models → that single figure is the Color value.
- Caught the **wrapped-Color-line trap**: on many Dahua PDFs the Color figure wraps onto the line *above* the "Min. Illumination" label; a naive read grabs only B/W. A re-verify pass overturned a full 6-camera false-null batch (WizSense-3 HFW3849T1 TiOC/WizColor) and several SD8/SDT PTZ.

Compact/inline-array JSON files were edited surgically to avoid reformatting. `build.js` + `gen-docs.js` regenerated; CI green.
