### PR TITLE
Add Camius IRIS8R field of view

### DIFF
--- a/cameras/camius/iris-4k.json
+++ b/cameras/camius/iris-4k.json
@@ -13,6 +13,7 @@
     "label": "4K UHD"
   },
   "sensor": "1/2.8\" CMOS",
+  "field_of_view_deg": "110 (2.8mm)",
   "night_vision": {
     "type": "ir",
     "range_m": 30
@@ -43,7 +44,8 @@
   ],
   "release_year": 2023,
   "sources": [
-    "https://www.camius.com/4k-poe-dome-camera-iris8r/"
+    "https://www.camius.com/4k-poe-dome-camera-iris8r/",
+    "https://www.camius.com/8-4k-ethernet-powered-security-cameras/"
   ],
   "power_source": [
     "poe",


### PR DESCRIPTION
Adds the manufacturer-listed horizontal field of view for the Camius IRIS8R.

Source: https://www.camius.com/8-4k-ethernet-powered-security-cameras/

Tested with `npm run build`.

Refs #179
