### PR TITLE
chore: regenerate data/docs artifacts for Camius IRIS8R FOV (#214)

### DIFF
--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -774,7 +774,7 @@ bosch-nuv-3703-f06,Bosch,FLEXIDOME micro 3100i (NUV-3703-F06),dome,5MP,5,CMOS,"5
 bosch-smart-home-outdoor-cam-2,Bosch Smart Home,Outdoor Camera II,dome,1080p HD,2,,130 diagonal,color,IP65,,true,2023
 camius-boltx-4k,Camius,Boltx 4K,bullet,4K UHD,8,"1/2.8"" CMOS",,ir,IP67,,false,2023
 camius-boltx-5mp,Camius,Boltx 5MP,bullet,5MP Super HD,5,"1/2.7"" CMOS",,ir,IP67,,false,2022
-camius-iris-4k,Camius,Iris 4K,dome,4K UHD,8,"1/2.8"" CMOS",,ir,IP67,,false,2023
+camius-iris-4k,Camius,Iris 4K,dome,4K UHD,8,"1/2.8"" CMOS",110 (2.8mm),ir,IP67,,false,2023
 camius-iris-5mp,Camius,IRIS528R,turret,2K (2880x1620),5,"1/2.7"" Progressive CMOS",110 (2.8mm),hybrid,IP67,,false,2022
 canon-vb-h47,Canon,VB-H47,ptz,1080p/2MP,2,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),none,,,true,2022
 canon-vb-m46,Canon,VB-M46,ptz,1.3MP,1.3,"1/2.8"" CMOS",62.4-3.3 horizontal (20x optical zoom),none,,,true,2022

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -76375,6 +76375,7 @@
       "label": "4K UHD"
     },
     "sensor": "1/2.8\" CMOS",
+    "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -76405,7 +76406,8 @@
     ],
     "release_year": 2023,
     "sources": [
-      "https://www.camius.com/4k-poe-dome-camera-iris8r/"
+      "https://www.camius.com/4k-poe-dome-camera-iris8r/",
+      "https://www.camius.com/8-4k-ethernet-powered-security-cameras/"
     ],
     "power_source": [
       "poe",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -76375,6 +76375,7 @@
       "label": "4K UHD"
     },
     "sensor": "1/2.8\" CMOS",
+    "field_of_view_deg": "110 (2.8mm)",
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -76405,7 +76406,8 @@
     ],
     "release_year": 2023,
     "sources": [
-      "https://www.camius.com/4k-poe-dome-camera-iris8r/"
+      "https://www.camius.com/4k-poe-dome-camera-iris8r/",
+      "https://www.camius.com/8-4k-ethernet-powered-security-cameras/"
     ],
     "power_source": [
       "poe",

--- a/docs/cameras/camius/iris-4k.md
+++ b/docs/cameras/camius/iris-4k.md
@@ -8,6 +8,7 @@
 | Connectivity | ethernet |
 | Resolution | 4K UHD (8MP, 3840×2160) |
 | Sensor | 1/2.8" CMOS |
+| Field of view | 110 (2.8mm)° |
 | Night vision | ir (30m) |
 | Power | PoE (IEEE 802.3af) / DC 12V |
 | Storage | NVR |
@@ -26,6 +27,7 @@
 ## Sources
 
 - https://www.camius.com/4k-poe-dome-camera-iris8r/
+- https://www.camius.com/8-4k-ethernet-powered-security-cameras/
 
 ---
 *Auto-generated from camius-iris-4k.json — do not edit by hand.*


### PR DESCRIPTION
PR #214 (external contribution) updated `cameras/camius/iris-4k.json` but not the generated `data/`+`docs/` artifacts, so the main `build` workflow's artifact-sync check failed (it regenerated 4 files and couldn't auto-push past branch protection). This regenerates them: `data/cameras.json`, `data/cameras.csv`, `docs/cameras.json`, `docs/cameras/camius/iris-4k.md` — only the field-of-view + source addition.