### PR TITLE
data: Hikvision datasheet backfill — dims/weight/ik/fov/lux/streams (#178/#162/#179/#161/#177)

### DIFF
--- a/cameras/hikvision/ds-2ae4215itg.json
+++ b/cameras/hikvision/ds-2ae4215itg.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø164.5 x 290.6",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC (IR 7W)"
   },
@@ -55,6 +59,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae4215tg-3.json
+++ b/cameras/hikvision/ds-2ae4215tg-3.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø165 x 179.5",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC"
   },
@@ -54,5 +57,5 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/hikvision/ds-2ae4215tg.json
+++ b/cameras/hikvision/ds-2ae4215tg.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø180 x 239.5",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC"
   },
@@ -53,6 +56,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae4225itg.json
+++ b/cameras/hikvision/ds-2ae4225itg.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø164.5 x 290.6",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC (IR 7W)"
   },
@@ -55,6 +59,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae4225tg-3.json
+++ b/cameras/hikvision/ds-2ae4225tg-3.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø165 x 179.5",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC"
   },
@@ -54,5 +57,5 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/hikvision/ds-2ae4225tg.json
+++ b/cameras/hikvision/ds-2ae4225tg.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø180 x 239.5",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC"
   },
@@ -53,6 +56,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae4425itg.json
+++ b/cameras/hikvision/ds-2ae4425itg.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
+  "field_of_view_deg": "55h",
+  "dimensions_mm": "Ø164.5 x 290.6",
+  "weight_g": 2000,
   "power": {
     "method": "12 VDC (IR 7W)"
   },
@@ -55,6 +59,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae5225itg.json
+++ b/cameras/hikvision/ds-2ae5225itg.json
@@ -22,6 +22,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø208 x 343.9",
+  "weight_g": 3300,
   "power": {
     "method": "36 VDC"
   },
@@ -54,6 +57,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae5225tg.json
+++ b/cameras/hikvision/ds-2ae5225tg.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "57.6h",
+  "dimensions_mm": "Ø220 x 280",
+  "weight_g": 3000,
   "power": {
     "method": "36 VDC"
   },
@@ -53,7 +56,7 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10"
 }

--- a/cameras/hikvision/ds-2ae5232itg.json
+++ b/cameras/hikvision/ds-2ae5232itg.json
@@ -22,6 +22,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "field_of_view_deg": "55h",
+  "dimensions_mm": "Ø208 x 343.9",
+  "weight_g": 3300,
   "power": {
     "method": "36 VDC"
   },
@@ -54,6 +57,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae5232tg.json
+++ b/cameras/hikvision/ds-2ae5232tg.json
@@ -21,6 +21,9 @@
   "night_vision": {
     "type": "none"
   },
+  "field_of_view_deg": "55h",
+  "dimensions_mm": "Ø220 x 280",
+  "weight_g": 3000,
   "power": {
     "method": "36 VDC"
   },
@@ -53,7 +56,7 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10"
 }

--- a/cameras/hikvision/ds-2ae5425itg.json
+++ b/cameras/hikvision/ds-2ae5425itg.json
@@ -22,6 +22,9 @@
     "type": "ir",
     "range_m": 150
   },
+  "field_of_view_deg": "55h",
+  "dimensions_mm": "Ø208 x 343.9",
+  "weight_g": 3300,
   "power": {
     "method": "36 VDC"
   },
@@ -54,6 +57,6 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66"
 }

--- a/cameras/hikvision/ds-2ae7232itg.json
+++ b/cameras/hikvision/ds-2ae7232itg.json
@@ -18,9 +18,11 @@
     "focal_length_mm": "4.8-153.6",
     "varifocal": true
   },
+  "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
   "night_vision": {
     "type": "ir",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "36 VDC"
@@ -55,6 +57,8 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
-  "ip_rating": "IP66"
+  "last_verified": "2026-08-03",
+  "ip_rating": "IP66",
+  "dimensions_mm": "Ø 220 x 356.9",
+  "weight_g": 4500
 }

--- a/cameras/hikvision/ds-2ae7232itg.json
+++ b/cameras/hikvision/ds-2ae7232itg.json
@@ -59,6 +59,6 @@
   ],
   "last_verified": "2026-08-03",
   "ip_rating": "IP66",
-  "dimensions_mm": "Ø 220 x 356.9",
+  "dimensions_mm": "Ø220 x 356.9",
   "weight_g": 4500
 }

--- a/cameras/hikvision/ds-2cd1023g0e-i.json
+++ b/cameras/hikvision/ds-2cd1023g0e-i.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "112.1 horizontal (2.8mm) / 90.2 horizontal (4mm)",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -65,7 +66,7 @@
   "sources": [
     "https://assets.hikvision.com/prd/normal/all/doc/m000007714/DS-2CD1023G0E-I_Datasheet_20260409.pdf"
   ],
-  "last_verified": "2026-07-04",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd1023g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1023g2-iuf.json
@@ -94,7 +94,7 @@
   ],
   "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+  "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
   "dimensions_mm": "170.8 x 66 x 69.1",
   "weight_g": 285,
   "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD."

--- a/cameras/hikvision/ds-2cd1023g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1023g2-iuf.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 285,
   "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD."
 }

--- a/cameras/hikvision/ds-2cd1023g2-liu.json
+++ b/cameras/hikvision/ds-2cd1023g2-liu.json
@@ -81,7 +81,9 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 265,
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd1023g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1023g2-liuf.json
@@ -18,6 +18,7 @@
     "focal_length_mm": "2.8/4",
     "varifocal": false
   },
+  "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -91,7 +92,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 265,
   "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m."
 }

--- a/cameras/hikvision/ds-2cd1027g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1027g2h-liuf.json
@@ -18,6 +18,7 @@
     "focal_length_mm": "2.8/4",
     "varifocal": false
   },
+  "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "67.9 x 69.8 x 172.9",
+  "weight_g": 550,
   "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic."
 }

--- a/cameras/hikvision/ds-2cd1043g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1043g2-iuf.json
@@ -18,9 +18,11 @@
     "focal_length_mm": "2.8/4",
     "varifocal": false
   },
+  "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 270,
   "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD."
 }

--- a/cameras/hikvision/ds-2cd1043g2-liu.json
+++ b/cameras/hikvision/ds-2cd1043g2-liu.json
@@ -81,7 +81,9 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 270,
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd1043g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1043g2-liuf.json
@@ -18,6 +18,7 @@
     "focal_length_mm": "2.8/4",
     "varifocal": false
   },
+  "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -93,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "170.8 x 66 x 69.1",
+  "weight_g": 270,
   "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic."
 }

--- a/cameras/hikvision/ds-2cd1047g0-luf.json
+++ b/cameras/hikvision/ds-2cd1047g0-luf.json
@@ -95,7 +95,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 76.6 x 164.4",
+  "dimensions_mm": "Ø76.6 x 164.4",
   "weight_g": 430,
   "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense."
 }

--- a/cameras/hikvision/ds-2cd1047g0-luf.json
+++ b/cameras/hikvision/ds-2cd1047g0-luf.json
@@ -94,6 +94,8 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 76.6 x 164.4",
+  "weight_g": 430,
   "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense."
 }

--- a/cameras/hikvision/ds-2cd1047g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1047g2h-liuf.json
@@ -95,6 +95,8 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "67.9 x 69.8 x 172.9",
+  "weight_g": 550,
   "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense."
 }

--- a/cameras/hikvision/ds-2cd1067g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1067g2h-liuf.json
@@ -38,6 +38,8 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "dimensions_mm": "67.9 x 69.8 x 172.9",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -95,6 +97,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res."
 }

--- a/cameras/hikvision/ds-2cd1123g2-i.json
+++ b/cameras/hikvision/ds-2cd1123g2-i.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "110.8 x 84.7 (dia x H)",
+  "weight_g": 520,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -93,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot."
 }

--- a/cameras/hikvision/ds-2cd1123g2-liu.json
+++ b/cameras/hikvision/ds-2cd1123g2-liu.json
@@ -43,6 +43,9 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK08",
+  "dimensions_mm": "121.4 x 97.7 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -81,7 +84,7 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd1123g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1123g2-liuf.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.4 x 97.7 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08."
 }

--- a/cameras/hikvision/ds-2cd1127g0-luf-d.json
+++ b/cameras/hikvision/ds-2cd1127g0-luf-d.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.5 x 97.6 (dia x H)",
+  "weight_g": 500,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR."
 }

--- a/cameras/hikvision/ds-2cd1127g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1127g2h-liuf.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.5 x 97.6 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08."
 }

--- a/cameras/hikvision/ds-2cd1143g2-i.json
+++ b/cameras/hikvision/ds-2cd1143g2-i.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "110.8 x 84.7 (dia x H)",
+  "weight_g": 520,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -95,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD."
 }

--- a/cameras/hikvision/ds-2cd1143g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1143g2-iuf.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 25
+    "range_m": 25,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -38,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "121.4 x 92.2 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -97,6 +100,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I."
 }

--- a/cameras/hikvision/ds-2cd1143g2-liu.json
+++ b/cameras/hikvision/ds-2cd1143g2-liu.json
@@ -43,6 +43,9 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK08",
+  "dimensions_mm": "121.4 x 97.7 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -81,7 +84,7 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd1143g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1143g2-liuf.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.4 x 97.7 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08."
 }

--- a/cameras/hikvision/ds-2cd1147g0-luf-d.json
+++ b/cameras/hikvision/ds-2cd1147g0-luf-d.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.5 x 97.6 (dia x H)",
+  "weight_g": 500,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic."
 }

--- a/cameras/hikvision/ds-2cd1147g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1147g2h-liuf.json
@@ -39,6 +39,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "121.5 x 97.6 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08."
 }

--- a/cameras/hikvision/ds-2cd1167g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1167g2h-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+  "dimensions_mm": "Ø121.5 x 97.6",
+  "weight_g": 550,
   "night_vision": {
     "type": "hybrid",
     "range_m": 20,
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps."
 }

--- a/cameras/hikvision/ds-2cd1323g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1323g2-iuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 85.3",
+  "weight_g": 340,
   "night_vision": {
     "type": "ir",
     "range_m": 30
@@ -93,6 +95,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR."
 }

--- a/cameras/hikvision/ds-2cd1323g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1323g2-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 89.2",
+  "weight_g": 340,
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -94,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
 }

--- a/cameras/hikvision/ds-2cd1327g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1327g2h-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 93",
+  "weight_g": 380,
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -94,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic."
 }

--- a/cameras/hikvision/ds-2cd1343g2-iuf.json
+++ b/cameras/hikvision/ds-2cd1343g2-iuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 85.3",
+  "weight_g": 340,
   "night_vision": {
     "type": "ir",
     "range_m": 30
@@ -94,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP."
 }

--- a/cameras/hikvision/ds-2cd1343g2-liuf.json
+++ b/cameras/hikvision/ds-2cd1343g2-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 89.2",
+  "weight_g": 340,
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -94,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic."
 }

--- a/cameras/hikvision/ds-2cd1347g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1347g2h-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 93",
+  "weight_g": 420,
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
@@ -94,6 +96,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic."
 }

--- a/cameras/hikvision/ds-2cd1367g2h-liuf.json
+++ b/cameras/hikvision/ds-2cd1367g2h-liuf.json
@@ -19,6 +19,8 @@
     "varifocal": false
   },
   "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+  "dimensions_mm": "Ø110 x 93",
+  "weight_g": 415,
   "night_vision": {
     "type": "hybrid",
     "range_m": 20,
@@ -95,6 +97,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps."
 }

--- a/cameras/hikvision/ds-2cd1623g2-izs.json
+++ b/cameras/hikvision/ds-2cd1623g2-izs.json
@@ -19,6 +19,8 @@
     "varifocal": true
   },
   "field_of_view_deg": "102.4-31.2 horizontal",
+  "dimensions_mm": "Ø105 x 244.4",
+  "weight_g": 720,
   "night_vision": {
     "type": "ir",
     "range_m": 50
@@ -95,6 +97,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD."
 }

--- a/cameras/hikvision/ds-2cd1643g2-izs.json
+++ b/cameras/hikvision/ds-2cd1643g2-izs.json
@@ -19,6 +19,8 @@
     "varifocal": true
   },
   "field_of_view_deg": "95.9-29.2 horizontal",
+  "dimensions_mm": "Ø105 x 244.4",
+  "weight_g": 745,
   "night_vision": {
     "type": "ir",
     "range_m": 50
@@ -95,6 +97,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP."
 }

--- a/cameras/hikvision/ds-2cd1723g2-izs.json
+++ b/cameras/hikvision/ds-2cd1723g2-izs.json
@@ -19,6 +19,8 @@
     "varifocal": true
   },
   "field_of_view_deg": "102.4-31.2 horizontal",
+  "dimensions_mm": "Ø141 x 99.9",
+  "weight_g": 820,
   "night_vision": {
     "type": "ir",
     "range_m": 30
@@ -95,6 +97,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10."
 }

--- a/cameras/hikvision/ds-2cd1743g2-izs.json
+++ b/cameras/hikvision/ds-2cd1743g2-izs.json
@@ -19,6 +19,8 @@
     "varifocal": true
   },
   "field_of_view_deg": "95.9-29.2 horizontal",
+  "dimensions_mm": "Ø141 x 99.9",
+  "weight_g": 820,
   "night_vision": {
     "type": "ir",
     "range_m": 30
@@ -96,6 +98,6 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10."
 }

--- a/cameras/hikvision/ds-2cd1h43g2-izs.json
+++ b/cameras/hikvision/ds-2cd1h43g2-izs.json
@@ -21,7 +21,8 @@
   "field_of_view_deg": "95.9-29.2 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,6 +95,8 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "129.4 x 116.4 (dia x H)",
+  "weight_g": 595,
   "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD."
 }

--- a/cameras/hikvision/ds-2cd1t27g0-luf-c.json
+++ b/cameras/hikvision/ds-2cd1t27g0-luf-c.json
@@ -95,6 +95,8 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "205.6 x 83.7 x 80.7",
+  "weight_g": 420,
   "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic."
 }

--- a/cameras/hikvision/ds-2cd20126g3-iuy-srb.json
+++ b/cameras/hikvision/ds-2cd20126g3-iuy-srb.json
@@ -90,7 +90,9 @@
     "global"
   ],
   "release_year": 2025,
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "74.4 x 176.3 (dia x H)",
+  "weight_g": 530,
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd20126g3-iy.json
+++ b/cameras/hikvision/ds-2cd20126g3-iy.json
@@ -89,7 +89,9 @@
     "global"
   ],
   "release_year": 2025,
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "74.4 x 176.3 (dia x H)",
+  "weight_g": 530,
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
+++ b/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
@@ -101,8 +101,10 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "release_year": 2025,
+  "dimensions_mm": "74.4 x 176.3 (dia x H)",
+  "weight_g": 530,
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd20166g3-iuy.json
+++ b/cameras/hikvision/ds-2cd20166g3-iuy.json
@@ -42,6 +42,18 @@
         "resolution": "4608x3456",
         "fps": 15,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
@@ -88,7 +100,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2021g1-i.json
+++ b/cameras/hikvision/ds-2cd2021g1-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "171.4 x 69.7 x 67.9",
+  "weight_g": 350,
   "field_of_view_deg": "111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal",
   "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense."
 }

--- a/cameras/hikvision/ds-2cd2026g2-iu.json
+++ b/cameras/hikvision/ds-2cd2026g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "74.4 x 179.2 (dia x H)",
+  "weight_g": 500,
   "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
   "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U)."
 }

--- a/cameras/hikvision/ds-2cd2027g2-lu.json
+++ b/cameras/hikvision/ds-2cd2027g2-lu.json
@@ -83,7 +83,9 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "215.2 x 78.8 x 78.6",
+  "weight_g": 680,
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd2043g2-iu.json
+++ b/cameras/hikvision/ds-2cd2043g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "70 x 161.7 (dia x H)",
+  "weight_g": 490,
   "field_of_view_deg": "103 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
   "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U)."
 }

--- a/cameras/hikvision/ds-2cd2043g2-l.json
+++ b/cameras/hikvision/ds-2cd2043g2-l.json
@@ -94,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "215.2 x 78.8 x 78.6",
+  "weight_g": 695,
   "field_of_view_deg": "102 (2.8mm) horizontal",
   "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR)."
 }

--- a/cameras/hikvision/ds-2cd2043g2-li2u.json
+++ b/cameras/hikvision/ds-2cd2043g2-li2u.json
@@ -93,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "74.4 x 176.3 (dia x H)",
+  "weight_g": 515,
   "field_of_view_deg": "104 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
   "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone."
 }

--- a/cameras/hikvision/ds-2cd2046g2-iu.json
+++ b/cameras/hikvision/ds-2cd2046g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -87,13 +88,27 @@
         "resolution": "2688x1520",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "dimensions_mm": "Ø70 x 161.7",
+  "weight_g": 485,
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
   "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U)."
 }

--- a/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 176.3",
+  "weight_g": 515,
   "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
   "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.json
@@ -94,7 +94,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 176.3",
+  "dimensions_mm": "Ø74.4 x 176.3",
   "weight_g": 515,
   "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
   "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio."

--- a/cameras/hikvision/ds-2cd2046g2h-iu.json
+++ b/cameras/hikvision/ds-2cd2046g2h-iu.json
@@ -94,7 +94,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 179.2",
+  "dimensions_mm": "Ø74.4 x 179.2",
   "weight_g": 525,
   "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
   "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U)."

--- a/cameras/hikvision/ds-2cd2046g2h-iu.json
+++ b/cameras/hikvision/ds-2cd2046g2h-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 179.2",
+  "weight_g": 525,
   "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
   "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U)."
 }

--- a/cameras/hikvision/ds-2cd2047g2-l.json
+++ b/cameras/hikvision/ds-2cd2047g2-l.json
@@ -107,6 +107,6 @@
     ]
   },
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 179.2",
+  "dimensions_mm": "Ø74.4 x 179.2",
   "weight_g": 510
 }

--- a/cameras/hikvision/ds-2cd2047g2-l.json
+++ b/cameras/hikvision/ds-2cd2047g2-l.json
@@ -82,5 +82,31 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  },
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 179.2",
+  "weight_g": 510
 }

--- a/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
@@ -94,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 179.2",
+  "weight_g": 510,
   "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu-sl.json
@@ -95,7 +95,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 179.2",
+  "dimensions_mm": "Ø74.4 x 179.2",
   "weight_g": 510,
   "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio."

--- a/cameras/hikvision/ds-2cd2047g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu.json
@@ -94,7 +94,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 179.2",
+  "dimensions_mm": "Ø74.4 x 179.2",
   "weight_g": 525,
   "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence)."

--- a/cameras/hikvision/ds-2cd2047g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2047g2h-liu.json
@@ -93,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 179.2",
+  "weight_g": 525,
   "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence)."
 }

--- a/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
@@ -96,7 +96,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 176.3",
+  "dimensions_mm": "Ø74.4 x 176.3",
   "weight_g": 530,
   "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
   "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."

--- a/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2047g3-li2uy-slrb.json
@@ -95,7 +95,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 176.3",
+  "weight_g": 530,
   "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
   "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
 }

--- a/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
@@ -95,7 +95,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 74.4 x 179.2",
+  "weight_g": 510,
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
   "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2067g2h-liu-sl.json
@@ -96,7 +96,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 74.4 x 179.2",
+  "dimensions_mm": "Ø74.4 x 179.2",
   "weight_g": 510,
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
   "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio."

--- a/cameras/hikvision/ds-2cd2083g2-iu.json
+++ b/cameras/hikvision/ds-2cd2083g2-iu.json
@@ -93,7 +93,7 @@
     "outdoor"
   ],
   "last_verified": "2026-08-03",
-  "dimensions_mm": "Ø 70 x 161.7",
+  "dimensions_mm": "Ø70 x 161.7",
   "weight_g": 495,
   "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
   "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."

--- a/cameras/hikvision/ds-2cd2083g2-iu.json
+++ b/cameras/hikvision/ds-2cd2083g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,7 +92,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø 70 x 161.7",
+  "weight_g": 495,
   "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
   "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."
 }

--- a/cameras/hikvision/ds-2cd2086g2-iu-sl.json
+++ b/cameras/hikvision/ds-2cd2086g2-iu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "72.9 x 73.3 x 191.1",
+  "weight_g": 595,
   "field_of_view_deg": "110 (2.8mm)/88 (4mm)/60 (6mm) horizontal",
   "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2086g2-iu.json
+++ b/cameras/hikvision/ds-2cd2086g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "111 (2.8mm)/87 (4mm)/51 (6mm) horizontal",
-  "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+  "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+  "dimensions_mm": "Ø70 x 161.7",
+  "weight_g": 485
 }

--- a/cameras/hikvision/ds-2cd2086g2h-i2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2086g2h-i2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,7 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio."
+  "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio.",
+  "dimensions_mm": "Ø74.4 x 176.3",
+  "weight_g": 515,
+  "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal"
 }

--- a/cameras/hikvision/ds-2cd2086g2h-iu.json
+++ b/cameras/hikvision/ds-2cd2086g2h-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-  "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U)."
+  "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+  "dimensions_mm": "Ø74.4 x 179.2",
+  "weight_g": 525
 }

--- a/cameras/hikvision/ds-2cd2087g2-l.json
+++ b/cameras/hikvision/ds-2cd2087g2-l.json
@@ -83,7 +83,7 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "video": {
     "codecs": [
       "H.265+",
@@ -113,5 +113,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "78.8 x 78.6 x 215.2",
+  "weight_g": 850
 }

--- a/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
+++ b/cameras/hikvision/ds-2cd2087g2h-liu-sl.json
@@ -81,7 +81,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "102",
   "ip_rating": "IP67",
@@ -114,5 +114,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø74.4 x 179.2",
+  "weight_g": 510
 }

--- a/cameras/hikvision/ds-2cd2087g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2087g2h-liu.json
@@ -93,7 +93,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-  "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U)."
+  "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U).",
+  "dimensions_mm": "Ø74.4 x 179.2",
+  "weight_g": 525
 }

--- a/cameras/hikvision/ds-2cd2087g3-li2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2087g3-li2uy-slrb.json
@@ -95,7 +95,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
-  "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence."
+  "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+  "dimensions_mm": "Ø74.4 x 176.3",
+  "weight_g": 530
 }

--- a/cameras/hikvision/ds-2cd2123g2-is.json
+++ b/cameras/hikvision/ds-2cd2123g2-is.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,7 +94,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
-  "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic)."
+  "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic).",
+  "dimensions_mm": "Ø110.8 x 84.7",
+  "weight_g": 530
 }

--- a/cameras/hikvision/ds-2cd2125g0-ims.json
+++ b/cameras/hikvision/ds-2cd2125g0-ims.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.009
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,7 +96,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108 (2.8mm)/86 (4mm)/52 (6mm) horizontal",
-  "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only."
+  "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only.",
+  "dimensions_mm": "Ø119 x 90",
+  "weight_g": 520
 }

--- a/cameras/hikvision/ds-2cd2126g2-i.json
+++ b/cameras/hikvision/ds-2cd2126g2-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,7 +95,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/86 (4mm) horizontal",
-  "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10."
+  "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10.",
+  "dimensions_mm": "Ø110.8 x 84.7",
+  "weight_g": 550
 }

--- a/cameras/hikvision/ds-2cd2126g2-ims.json
+++ b/cameras/hikvision/ds-2cd2126g2-ims.json
@@ -86,7 +86,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP AcuSense fixed dome with direct HDMI (type D) live-view output; IK10 metal body, 2.8mm F1.4 fixed lens, 30m IR, audio line-in/out & alarm I/O.",
   "configs": {
     "frigate": {
@@ -100,5 +100,7 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
-  }
+  },
+  "dimensions_mm": "Ø119 x 90",
+  "weight_g": 440
 }

--- a/cameras/hikvision/ds-2cd2126g2-isu.json
+++ b/cameras/hikvision/ds-2cd2126g2-isu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,7 +96,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
-  "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O."
+  "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O.",
+  "dimensions_mm": "Ø121.4 x 92.2",
+  "weight_g": 550
 }

--- a/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
@@ -74,6 +74,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 780,
   "operating_temp_c": "-30 to 60",
   "audio": {
     "microphone": true,
@@ -100,7 +102,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2146g2h-isu.json
+++ b/cameras/hikvision/ds-2cd2146g2h-isu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 550,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -95,7 +98,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
   "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
@@ -74,6 +74,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 125.2 (dia x H)",
+  "weight_g": 750,
   "environment": [
     "indoor",
     "outdoor"
@@ -102,7 +104,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2147g2-su.json
+++ b/cameras/hikvision/ds-2cd2147g2-su.json
@@ -37,6 +37,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "121.4 x 100.1 (dia x H)",
+  "weight_g": 580,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -95,7 +97,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
   "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2147g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2147g2h-lisu.json
@@ -38,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 125.2 (dia x H)",
+  "weight_g": 750,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,7 +98,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2147g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2147g3-lis2uy.json
@@ -38,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "140 x 145.6 (dia x H)",
+  "weight_g": 920,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -98,7 +100,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
   "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic."
 }

--- a/cameras/hikvision/ds-2cd2167g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2167g2h-lisu.json
@@ -38,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,7 +98,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
   "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2183g2-is.json
+++ b/cameras/hikvision/ds-2cd2183g2-is.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.2 (dia x H)",
+  "weight_g": 800,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -94,7 +97,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
   "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2186g2-ims.json
+++ b/cameras/hikvision/ds-2cd2186g2-ims.json
@@ -61,6 +61,8 @@
     "onvif"
   ],
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "operating_temp_c": "-10 to 40",
   "audio": {
     "microphone": false,
@@ -85,7 +87,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2186g2-isu.json
+++ b/cameras/hikvision/ds-2cd2186g2-isu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 770,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -95,7 +98,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "111 (2.8mm)/87 (4mm) horizontal",
   "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2186g2h-isu.json
+++ b/cameras/hikvision/ds-2cd2186g2h-isu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -37,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "121.5 x 97.6 (dia x H)",
+  "weight_g": 525,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -96,7 +99,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
   "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2187g2-lsu.json
+++ b/cameras/hikvision/ds-2cd2187g2-lsu.json
@@ -38,6 +38,8 @@
   ],
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -97,7 +99,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "109 (2.8mm)/93 (4mm) horizontal",
   "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2187g2h-li.json
+++ b/cameras/hikvision/ds-2cd2187g2h-li.json
@@ -79,8 +79,10 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
+  "dimensions_mm": "Ø121.5 x 97.6",
+  "weight_g": 525,
   "field_of_view_deg": "105.1",
   "ip_rating": "IP67",
   "ik_rating": "IK10",

--- a/cameras/hikvision/ds-2cd2187g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2187g2h-lisu.json
@@ -97,7 +97,9 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
+  "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+  "weight_g": 525,
   "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2187g2h-lisu.json
+++ b/cameras/hikvision/ds-2cd2187g2h-lisu.json
@@ -99,7 +99,7 @@
   ],
   "last_verified": "2026-08-03",
   "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-  "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+  "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
   "weight_g": 525,
   "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2187g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2187g3-lis2uy.json
@@ -89,7 +89,7 @@
   "field_of_view_deg": "111",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+  "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
   "weight_g": 600,
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2cd2187g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2187g3-lis2uy.json
@@ -84,11 +84,13 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+  "weight_g": 600,
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2cd23126g3-i2uy.json
+++ b/cameras/hikvision/ds-2cd23126g3-i2uy.json
@@ -64,6 +64,8 @@
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "weight_g": 750,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -89,7 +91,7 @@
     "global"
   ],
   "release_year": 2025,
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd23126g3-i2uy.json
+++ b/cameras/hikvision/ds-2cd23126g3-i2uy.json
@@ -64,7 +64,7 @@
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
-  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
   "weight_g": 750,
   "audio": {
     "microphone": true,

--- a/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
+++ b/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
@@ -69,7 +69,7 @@
   ],
   "ip_rating": "IP67",
   "operating_temp_c": "-30 to 60",
-  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
   "weight_g": 820,
   "audio": {
     "microphone": true,

--- a/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
+++ b/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
@@ -69,6 +69,8 @@
   ],
   "ip_rating": "IP67",
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -95,7 +97,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "release_year": 2025,
   "configs": {
     "frigate": {

--- a/cameras/hikvision/ds-2cd2323g2-iu.json
+++ b/cameras/hikvision/ds-2cd2323g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+  "weight_g": 560,
   "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2323g2-iu.json
+++ b/cameras/hikvision/ds-2cd2323g2-iu.json
@@ -95,7 +95,7 @@
   "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
   "ip_rating": "IP67",
-  "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+  "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
   "weight_g": 560,
   "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2326g2-iu.json
+++ b/cameras/hikvision/ds-2cd2326g2-iu.json
@@ -96,7 +96,7 @@
   "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
   "ip_rating": "IP67",
-  "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+  "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
   "weight_g": 570,
   "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2326g2-iu.json
+++ b/cameras/hikvision/ds-2cd2326g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,8 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+  "weight_g": 570,
   "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2327g2-lu.json
+++ b/cameras/hikvision/ds-2cd2327g2-lu.json
@@ -93,8 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "weight_g": 770,
   "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic."
 }

--- a/cameras/hikvision/ds-2cd2327g2-lu.json
+++ b/cameras/hikvision/ds-2cd2327g2-lu.json
@@ -96,7 +96,7 @@
   "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
   "ip_rating": "IP67",
-  "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+  "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
   "weight_g": 770,
   "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic."
 }

--- a/cameras/hikvision/ds-2cd2343g2-iu.json
+++ b/cameras/hikvision/ds-2cd2343g2-iu.json
@@ -95,7 +95,7 @@
   "last_verified": "2026-08-03",
   "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
   "ip_rating": "IP67",
-  "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+  "dimensions_mm": "Ø127.3 x 95.9 (dia x H)",
   "weight_g": 600,
   "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2343g2-iu.json
+++ b/cameras/hikvision/ds-2cd2343g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+  "weight_g": 600,
   "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR."
 }

--- a/cameras/hikvision/ds-2cd2345g0p-i.json
+++ b/cameras/hikvision/ds-2cd2345g0p-i.json
@@ -95,7 +95,7 @@
   ],
   "last_verified": "2026-08-03",
   "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
-  "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+  "dimensions_mm": "Ø127.3 x 104.1 (dia x H)",
   "weight_g": 520,
   "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor)."
 }

--- a/cameras/hikvision/ds-2cd2345g0p-i.json
+++ b/cameras/hikvision/ds-2cd2345g0p-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.028
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,7 +93,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
+  "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+  "weight_g": 520,
   "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor)."
 }

--- a/cameras/hikvision/ds-2cd2346g2-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2346g2-isu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,8 +95,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+  "weight_g": 825,
   "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2346g2-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2346g2-isu-sl.json
@@ -98,7 +98,7 @@
   "last_verified": "2026-08-03",
   "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
   "ip_rating": "IP67",
-  "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+  "dimensions_mm": "Ø138.3 x 124.5 (dia x H)",
   "weight_g": 825,
   "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2346g2h-is2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2346g2h-is2u-slrb.json
@@ -93,8 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
   "ip_rating": "IP67",
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 780,
   "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2346g2h-iu.json
+++ b/cameras/hikvision/ds-2cd2346g2h-iu.json
@@ -92,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
   "ip_rating": "IP67",
-  "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U)."
+  "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U).",
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 550
 }

--- a/cameras/hikvision/ds-2cd2347g2-l.json
+++ b/cameras/hikvision/ds-2cd2347g2-l.json
@@ -79,7 +79,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111.9",
   "ip_rating": "IP67",
@@ -112,5 +112,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø138.3 x 125.2",
+  "weight_g": 750
 }

--- a/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2-lsu-sl.json
@@ -80,7 +80,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "111.9",
   "ip_rating": "IP67",
@@ -113,5 +113,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 760
 }

--- a/cameras/hikvision/ds-2cd2347g2-lu.json
+++ b/cameras/hikvision/ds-2cd2347g2-lu.json
@@ -83,7 +83,7 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "video": {
     "codecs": [
       "H.265+",
@@ -113,5 +113,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø138.3 x 125.2",
+  "weight_g": 750
 }

--- a/cameras/hikvision/ds-2cd2347g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2347g2p-lsu-sl.json
@@ -94,8 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "180 horizontal / 81 vertical (dual-lens panoramic)",
   "ip_rating": "IP67",
-  "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio."
+  "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio.",
+  "dimensions_mm": "Ø140 x 145.6",
+  "weight_g": 920
 }

--- a/cameras/hikvision/ds-2cd2347g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2347g3-lis2uy-slrb.json
@@ -96,8 +96,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
   "ip_rating": "IP67",
-  "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."
+  "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 820
 }

--- a/cameras/hikvision/ds-2cd2367g2-l.json
+++ b/cameras/hikvision/ds-2cd2367g2-l.json
@@ -83,5 +83,37 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø138.3 x 115.2",
+  "weight_g": 800,
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3200x1800",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2h-lisu-sl.json
@@ -79,7 +79,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "112.1",
   "ip_rating": "IP67",
@@ -112,5 +112,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 820
 }

--- a/cameras/hikvision/ds-2cd2367g2h-liu.json
+++ b/cameras/hikvision/ds-2cd2367g2h-liu.json
@@ -92,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
   "ip_rating": "IP67",
-  "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U)."
+  "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U).",
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 770
 }

--- a/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2367g2p-lsu-sl.json
@@ -80,7 +80,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
   "field_of_view_deg": "180",
   "ip_rating": "IP67",
@@ -107,5 +107,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø140 x 145.6",
+  "weight_g": 920
 }

--- a/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2367g3-lis2uy-sl.json
@@ -81,7 +81,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "108.8",
   "ip_rating": "IP67",
@@ -114,5 +114,7 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø138.3 x 115.4",
+  "weight_g": 820
 }

--- a/cameras/hikvision/ds-2cd2383g2-iu.json
+++ b/cameras/hikvision/ds-2cd2383g2-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "127.3 x 95.9 (dia x H)",
+  "weight_g": 600,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -91,7 +94,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
   "ip_rating": "IP67",
   "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U)."

--- a/cameras/hikvision/ds-2cd2386g2h-is2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2386g2h-is2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 780,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -93,7 +96,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
   "ip_rating": "IP67",
   "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence."

--- a/cameras/hikvision/ds-2cd2386g2h-iu.json
+++ b/cameras/hikvision/ds-2cd2386g2h-iu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 775,
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -91,7 +94,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
   "ip_rating": "IP67",
   "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U)."

--- a/cameras/hikvision/ds-2cd2387g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2387g2h-lisu-sl.json
@@ -36,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -94,7 +96,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
   "ip_rating": "IP67",
   "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio."

--- a/cameras/hikvision/ds-2cd2387g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2387g3-lis2uy-sl.json
@@ -34,6 +34,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -81,7 +83,22 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 30,
+        "codec": "H.265"
+      }
+    ]
+  },
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "108.8",
   "ip_rating": "IP67"

--- a/cameras/hikvision/ds-2cd2387g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2387g3-lis2uy-slrb.json
@@ -36,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "138.3 x 115.4 (dia x H)",
+  "weight_g": 820,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -95,7 +97,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
   "ip_rating": "IP67",
   "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence."

--- a/cameras/hikvision/ds-2cd2421g0-idw.json
+++ b/cameras/hikvision/ds-2cd2421g0-idw.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.028
   },
   "power": {
     "method": "DC 12V"
@@ -36,6 +37,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -93,7 +96,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107 (2.8mm) horizontal",
   "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE)."
 }

--- a/cameras/hikvision/ds-2cd2423g2-i.json
+++ b/cameras/hikvision/ds-2cd2423g2-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -93,7 +96,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108.8 (2.8mm)/87.6 (4mm) horizontal",
   "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection."
 }

--- a/cameras/hikvision/ds-2cd2423g2-iw.json
+++ b/cameras/hikvision/ds-2cd2423g2-iw.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -36,6 +37,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -94,7 +97,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "92 (2.8mm)/75 (4mm) horizontal",
   "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2443g2-i.json
+++ b/cameras/hikvision/ds-2cd2443g2-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -93,7 +96,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "104.3 (2.8mm)/83.7 (4mm) horizontal",
   "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I)."
 }

--- a/cameras/hikvision/ds-2cd2446g2-i.json
+++ b/cameras/hikvision/ds-2cd2446g2-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D; 2.8/4mm) / 102.9 x 65.2 x 28.8 (2mm)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -94,7 +97,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
   "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2483g2-i.json
+++ b/cameras/hikvision/ds-2cd2483g2-i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -35,6 +36,8 @@
     "onvif",
     "rtsp"
   ],
+  "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+  "weight_g": 120,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -93,7 +96,7 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "107.8 (2.8mm)/82.8 (4mm) horizontal",
   "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2523g2-is.json
+++ b/cameras/hikvision/ds-2cd2523g2-is.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,9 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "108 (2.8mm)/86 (4mm) horizontal",
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "110 x 57.4 (dia x H)",
+  "weight_g": 380,
   "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S)."
 }

--- a/cameras/hikvision/ds-2cd2546g2-iws.json
+++ b/cameras/hikvision/ds-2cd2546g2-iws.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,9 +96,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "110 x 57.4 (dia x H)",
+  "weight_g": 380,
   "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08."
 }

--- a/cameras/hikvision/ds-2cd2547g2-ls.json
+++ b/cameras/hikvision/ds-2cd2547g2-ls.json
@@ -96,9 +96,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "113.6 x 72.6 (dia x H)",
+  "weight_g": 400,
   "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2583g2-is.json
+++ b/cameras/hikvision/ds-2cd2583g2-is.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,9 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "field_of_view_deg": "106.4 (2.8mm)/87.6 (4mm) horizontal",
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "dimensions_mm": "113.6 x 72.6 (dia x H)",
+  "weight_g": 400,
   "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O."
 }

--- a/cameras/hikvision/ds-2cd2586g2-is.json
+++ b/cameras/hikvision/ds-2cd2586g2-is.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,8 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK08",
+  "field_of_view_deg": "110.0 (2.8mm)/88.0 (4mm) horizontal",
+  "dimensions_mm": "113.6 x 72.6 (dia x H)",
+  "weight_g": 400,
   "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic."
 }

--- a/cameras/hikvision/ds-2cd2623g2-izs.json
+++ b/cameras/hikvision/ds-2cd2623g2-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,9 +93,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "107°-32° (H)",
+  "field_of_view_deg": "107-32 (H)",
+  "dimensions_mm": "308.5 x 97.9 x 93",
+  "weight_g": 1440,
   "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10."
 }

--- a/cameras/hikvision/ds-2cd2643g2-izs.json
+++ b/cameras/hikvision/ds-2cd2643g2-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "95.8-29.2 (H)",
+  "dimensions_mm": "308.5 x 97.9 x 93",
+  "weight_g": 1390,
   "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR."
 }

--- a/cameras/hikvision/ds-2cd2646g2-izs.json
+++ b/cameras/hikvision/ds-2cd2646g2-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,9 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
-  "field_of_view_deg": "108°-30° horizontal",
+  "field_of_view_deg": "108-30 horizontal",
+  "dimensions_mm": "144.1 x 345.7 (dia x L)",
+  "weight_g": 1445,
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio."
 }

--- a/cameras/hikvision/ds-2cd2646g2h-izs.json
+++ b/cameras/hikvision/ds-2cd2646g2h-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,8 +93,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "105.4-34.3 (H)",
+  "dimensions_mm": "140 x 333.8 (dia x L)",
+  "weight_g": 1490,
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H)."
 }

--- a/cameras/hikvision/ds-2cd2646g2ht-izs.json
+++ b/cameras/hikvision/ds-2cd2646g2ht-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "105.4-34.3 (H)",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1490,
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR."
 }

--- a/cameras/hikvision/ds-2cd2646g2t-izs.json
+++ b/cameras/hikvision/ds-2cd2646g2t-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "108-30 (H)",
+  "dimensions_mm": "308.5 x 97.9 x 93",
+  "weight_g": 1355,
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR."
 }

--- a/cameras/hikvision/ds-2cd2647g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2647g2ht-lizs.json
@@ -94,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "114.6-41.8 (H)",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1085,
   "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m."
 }

--- a/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.json
@@ -89,13 +89,28 @@
         "resolution": "2688x1520",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "dimensions_mm": "Ø140 x 333.8",
+  "weight_g": 1555,
+  "field_of_view_deg": "114.6-41.8 (H)",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."

--- a/cameras/hikvision/ds-2cd2667g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2667g2ht-lizs.json
@@ -88,13 +88,28 @@
         "resolution": "3200x1800",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1085,
+  "field_of_view_deg": "112.3-41.2 (H)",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m."

--- a/cameras/hikvision/ds-2cd2686g2h-izs.json
+++ b/cameras/hikvision/ds-2cd2686g2h-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -87,15 +88,29 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "dimensions_mm": "Ø140 x 333.8",
+  "weight_g": 1475,
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "112.3°-41.2° (H)",
+  "field_of_view_deg": "112.3-41.2 (H)",
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2686g2ht-izs.json
+++ b/cameras/hikvision/ds-2cd2686g2ht-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -87,13 +88,28 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1475,
+  "field_of_view_deg": "112.3-41.2 (H)",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K."

--- a/cameras/hikvision/ds-2cd2686g2t-izs.json
+++ b/cameras/hikvision/ds-2cd2686g2t-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,9 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "97.9 x 93 x 308.5",
+  "weight_g": 1380,
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "108°-46° horizontal",
+  "field_of_view_deg": "108-46 horizontal",
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2687g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2687g2ht-lizs.json
@@ -82,9 +82,26 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "112.3-41.2",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1085,
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 24,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      }
+    ]
+  }
 }

--- a/cameras/hikvision/ds-2cd2687g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2687g2t-lzs.json
@@ -92,8 +92,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "298 x 97.9 x 95.7",
+  "weight_g": 1465,
+  "field_of_view_deg": "103.3-40",
   "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.json
@@ -95,8 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø140 x 333.8",
+  "weight_g": 1555,
+  "field_of_view_deg": "112.3-41.2",
   "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2723g2-izs.json
+++ b/cameras/hikvision/ds-2cd2723g2-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,8 +93,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø153.3 x 111.6",
+  "weight_g": 880,
+  "field_of_view_deg": "107-32",
   "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2726g2t-izs.json
+++ b/cameras/hikvision/ds-2cd2726g2t-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø153.3 x 111.6",
+  "weight_g": 880,
+  "field_of_view_deg": "113-31",
   "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2746g2-izs.json
+++ b/cameras/hikvision/ds-2cd2746g2-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø153.5 x 133.1",
+  "weight_g": 845,
+  "field_of_view_deg": "108-30",
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2746g2h-iptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2746g2h-iptrzs2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,8 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø155 x 140.4",
+  "weight_g": 840,
+  "field_of_view_deg": "114.6-41.8",
   "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2746g2ht-izs.json
+++ b/cameras/hikvision/ds-2cd2746g2ht-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,9 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "105.4°-34.3° (H)",
+  "dimensions_mm": "Ø141 x 112",
+  "weight_g": 820,
+  "field_of_view_deg": "105.4-34.3 (H)",
   "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.json
@@ -95,8 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø155 x 140.4",
+  "weight_g": 820,
+  "field_of_view_deg": "114.6-41.8",
   "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2747g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2747g2ht-lizs.json
@@ -95,9 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "114.6°-41.8° horizontal",
+  "dimensions_mm": "Ø141 x 112",
+  "weight_g": 820,
+  "field_of_view_deg": "114.6-41.8 horizontal",
   "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m."
 }

--- a/cameras/hikvision/ds-2cd2747g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2747g2t-lzs.json
@@ -93,8 +93,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø155 x 152",
+  "weight_g": 1600,
+  "field_of_view_deg": "105.4-56.4",
   "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light."
 }

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
@@ -76,6 +76,8 @@
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 1230,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -101,7 +103,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
@@ -79,6 +79,8 @@
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 1230,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -103,7 +105,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
@@ -75,6 +75,8 @@
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 1200,
   "environment": [
     "indoor",
     "outdoor"
@@ -99,7 +101,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2767g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2767g2ht-lizs.json
@@ -23,6 +23,7 @@
     "range_m": 40,
     "min_lux_color": 0.0028
   },
+  "field_of_view_deg": "112.3-41.2",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -86,7 +87,19 @@
       {
         "name": "main",
         "resolution": "3200x1800",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
         "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
         "codec": "H.265"
       }
     ]
@@ -94,8 +107,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "141 x 112 (dia x H)",
+  "weight_g": 820,
   "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m."
 }

--- a/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
@@ -82,6 +82,8 @@
     "outdoor"
   ],
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 1230,
   "audio": {
     "microphone": true,
     "speaker": true,
@@ -103,7 +105,7 @@
   "sources": [
     "https://assets.hikvision.com/prd/normal/all/doc/sm000077895/DS-2CD2767G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
@@ -79,6 +79,8 @@
     "outdoor"
   ],
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 1200,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -101,7 +103,7 @@
     "global"
   ],
   "release_year": 2025,
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2767g3t-lizsy.json
+++ b/cameras/hikvision/ds-2cd2767g3t-lizsy.json
@@ -79,6 +79,8 @@
     "outdoor"
   ],
   "operating_temp_c": "-30 to 60",
+  "dimensions_mm": "141 x 112 (dia x H)",
+  "weight_g": 850,
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -100,7 +102,7 @@
   "sources": [
     "https://assets.hikvision.com/prd/normal/all/doc/sm000106992/DS-2CD2767G3T-LIZSY_Datasheet_20250506.pdf"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2783g2-izs.json
+++ b/cameras/hikvision/ds-2cd2783g2-izs.json
@@ -20,8 +20,10 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
+  "field_of_view_deg": "108-30",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -86,14 +88,28 @@
         "resolution": "3840x2160",
         "fps": 20,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "640x480",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "153.3 x 111.6 (dia x H)",
+  "weight_g": 855,
   "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2786g2-izs.json
+++ b/cameras/hikvision/ds-2cd2786g2-izs.json
@@ -20,8 +20,10 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
+  "field_of_view_deg": "108-46",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -87,14 +89,28 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "dimensions_mm": "153.5 x 133.2 (dia x H)",
+  "weight_g": 1080,
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2786g2h-iptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2786g2h-iptrzs2u-slrb.json
@@ -20,8 +20,10 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
+  "field_of_view_deg": "112.3-41.2",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -87,7 +89,19 @@
       {
         "name": "main",
         "resolution": "3840x2160",
+        "fps": 24,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
         "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
         "codec": "H.265"
       }
     ]
@@ -95,8 +109,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 840,
   "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2786g2ht-izs.json
+++ b/cameras/hikvision/ds-2cd2786g2ht-izs.json
@@ -20,8 +20,10 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.0008
   },
+  "field_of_view_deg": "112.3-41.2",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -87,14 +89,28 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "141 x 112 (dia x H)",
+  "weight_g": 840,
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.json
@@ -90,15 +90,29 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
-  "field_of_view_deg": "112.3°-41.2° (H)",
+  "dimensions_mm": "155 x 140.4 (dia x H)",
+  "weight_g": 820,
+  "field_of_view_deg": "112.3-41.2 (H)",
   "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2787g2ht-lizs.json
+++ b/cameras/hikvision/ds-2cd2787g2ht-lizs.json
@@ -94,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø141 x 112",
+  "weight_g": 820,
+  "field_of_view_deg": "112.3-41.2 horizontal",
   "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2787g2t-lzs.json
+++ b/cameras/hikvision/ds-2cd2787g2t-lzs.json
@@ -95,9 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "103.3°-40° horizontal",
+  "dimensions_mm": "Ø155 x 152",
+  "weight_g": 1525,
+  "field_of_view_deg": "103.3-40 horizontal",
   "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
@@ -107,7 +107,9 @@
     "global"
   ],
   "release_year": 2024,
-  "last_verified": "2026-07-28",
+  "dimensions_mm": "Ø155 x 140.4",
+  "weight_g": 1230,
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
@@ -105,7 +105,9 @@
     "https://assets.hikvision.com/prd/normal/all/doc/sm000106989/DS-2CD2787G3-LIPTRZS2UY_SRBBlack_Datasheet_20260629.pdf",
     "https://assets.hikvision.com/prd/normal/all/doc/sm000077899/DS-2CD2787G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
   ],
-  "last_verified": "2026-07-28",
+  "dimensions_mm": "Ø155 x 140.4",
+  "weight_g": 1230,
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
@@ -101,7 +101,9 @@
   "sources": [
     "https://assets.hikvision.com/prd/normal/all/doc/sm000107003/DS-2CD2787G3-LIPTRZSY_Datasheet_20260629.pdf"
   ],
-  "last_verified": "2026-07-28",
+  "dimensions_mm": "Ø155 x 140.4",
+  "weight_g": 1200,
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2955g0-isu.json
+++ b/cameras/hikvision/ds-2cd2955g0-isu.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 8
+    "range_m": 8,
+    "min_lux_color": 0.017
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,6 +92,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø119.9 x 41.2",
+  "weight_g": 320,
+  "field_of_view_deg": "180 horizontal",
   "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic."
 }

--- a/cameras/hikvision/ds-2cd2d25g1-d-nf.json
+++ b/cameras/hikvision/ds-2cd2d25g1-d-nf.json
@@ -89,6 +89,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "31.5 x 31.5 x 39.7",
+  "weight_g": 93,
+  "field_of_view_deg": "93.9 (2.8mm)/75.5 (3.7mm) horizontal",
   "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only."
 }

--- a/cameras/hikvision/ds-2cd2e23g2-u.json
+++ b/cameras/hikvision/ds-2cd2e23g2-u.json
@@ -91,6 +91,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø93.9 x 117.5",
+  "weight_g": 155,
+  "field_of_view_deg": "107 (2.8mm)/88 (4mm) horizontal",
   "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
 }

--- a/cameras/hikvision/ds-2cd2e43g2-u.json
+++ b/cameras/hikvision/ds-2cd2e43g2-u.json
@@ -91,6 +91,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "Ø93.9 x 117.5",
+  "weight_g": 155,
+  "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
   "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating."
 }

--- a/cameras/hikvision/ds-2cd2h23g2-izs.json
+++ b/cameras/hikvision/ds-2cd2h23g2-izs.json
@@ -92,8 +92,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø138.3 x 126",
+  "weight_g": 830,
+  "field_of_view_deg": "106.6-31.7 horizontal",
   "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2h43g2-izs.json
+++ b/cameras/hikvision/ds-2cd2h43g2-izs.json
@@ -93,8 +93,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø138.3 x 126",
+  "weight_g": 830,
+  "field_of_view_deg": "95.8-29.2 horizontal",
   "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR."
 }

--- a/cameras/hikvision/ds-2cd2h86g2-izs.json
+++ b/cameras/hikvision/ds-2cd2h86g2-izs.json
@@ -94,9 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
-  "field_of_view_deg": "108°-46° (H)",
+  "dimensions_mm": "Ø135.8 x 145.5",
+  "weight_g": 1160,
+  "field_of_view_deg": "108-46 (H)",
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2h86g2t-izs.json
+++ b/cameras/hikvision/ds-2cd2h86g2t-izs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "138.3 diameter x 126",
+  "weight_g": 850,
+  "field_of_view_deg": "108-46 horizontal, 58-26 vertical, 127.4 diagonal",
   "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.json
@@ -96,9 +96,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "112.3°-41.2° horizontal",
+  "field_of_view_deg": "112.3-41.2 horizontal",
+  "dimensions_mm": "143.5 diameter x 142.7",
+  "weight_g": 1265,
   "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
@@ -100,7 +100,9 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "dimensions_mm": "118.6 x 78 x 306.5",
+  "weight_g": 1440,
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
@@ -99,7 +99,9 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "dimensions_mm": "118.6 x 78 x 306.5",
+  "weight_g": 1440,
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd2t23g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t23g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -90,7 +91,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "289 x 93.1 x 91.2",
+  "weight_g": 1100,
+  "field_of_view_deg": "107 horizontal, 57 vertical, 127 diagonal (2.8mm)",
   "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens."
 }

--- a/cameras/hikvision/ds-2cd2t26g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t26g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.002
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,7 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "289 x 93.1 x 91.2",
+  "weight_g": 1020,
+  "field_of_view_deg": "107 horizontal, 57 vertical, 129 diagonal (2.8mm)",
   "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
 }

--- a/cameras/hikvision/ds-2cd2t27g2-l.json
+++ b/cameras/hikvision/ds-2cd2t27g2-l.json
@@ -93,7 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "105 diameter x 289.5",
+  "weight_g": 1090,
+  "field_of_view_deg": "107 horizontal, 56 vertical, 127 diagonal (2.8mm)",
   "release_notes": "2MP ColorVu fixed bullet, 60m white light."
 }

--- a/cameras/hikvision/ds-2cd2t43g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t43g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -90,7 +91,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "105 diameter x 299.7",
+  "weight_g": 1070,
+  "field_of_view_deg": "103 horizontal, 55 vertical, 122 diagonal (2.8mm)",
   "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
 }

--- a/cameras/hikvision/ds-2cd2t45g0p-i.json
+++ b/cameras/hikvision/ds-2cd2t45g0p-i.json
@@ -90,7 +90,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "105 diameter x 278",
+  "weight_g": 570,
+  "field_of_view_deg": "180 horizontal, 101 vertical, 180 diagonal",
   "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR."
 }

--- a/cameras/hikvision/ds-2cd2t46g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t46g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,7 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
+  "dimensions_mm": "105 diameter x 289.5",
+  "weight_g": 1075,
+  "field_of_view_deg": "103 horizontal, 55 vertical, 123 diagonal (2.8mm)",
   "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
 }

--- a/cameras/hikvision/ds-2cd2t46g2-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2t46g2-isu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,8 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "103°/83°/53° (H)",
+  "field_of_view_deg": "103/83/53 (H)",
+  "dimensions_mm": "105 diameter x 287.6",
+  "weight_g": 1135,
   "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR."
 }

--- a/cameras/hikvision/ds-2cd2t46g2h-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t46g2h-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,7 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens."
+  "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+  "field_of_view_deg": "100.2 horizontal (2.8mm), 81.1 horizontal (4mm)",
+  "dimensions_mm": "286.7 x 93.1 x 91.2",
+  "weight_g": 1085
 }

--- a/cameras/hikvision/ds-2cd2t46g2h-is2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2t46g2h-is2u-slrb.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.001
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -92,8 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "100° (2.8mm)/81° (4mm) horizontal",
-  "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio."
+  "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
+  "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio.",
+  "dimensions_mm": "286.7 x 93.1 x 91.2",
+  "weight_g": 1205
 }

--- a/cameras/hikvision/ds-2cd2t46g2p-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2t46g2p-isu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,7 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio."
+  "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio.",
+  "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+  "dimensions_mm": "118.6 x 105.1 x 306.5",
+  "weight_g": 1400
 }

--- a/cameras/hikvision/ds-2cd2t47g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t47g2h-li.json
@@ -30,6 +30,34 @@
     "range_m": 60,
     "min_lux_color": 0.0005
   },
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -84,5 +112,7 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1085
 }

--- a/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.json
@@ -93,7 +93,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio."
+  "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio.",
+  "field_of_view_deg": "104.0 horizontal (2.8mm), 89.2 horizontal (4mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1205
 }

--- a/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.json
@@ -95,7 +95,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio."
+  "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio.",
+  "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+  "dimensions_mm": "118.6 x 105.1 x 306.5",
+  "weight_g": 1400
 }

--- a/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.json
@@ -95,7 +95,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio."
+  "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio.",
+  "field_of_view_deg": "111.1 horizontal (2.8mm), 95.2 horizontal (4mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1250
 }

--- a/cameras/hikvision/ds-2cd2t67g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t67g2h-li.json
@@ -91,7 +91,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP."
+  "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP.",
+  "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1085
 }

--- a/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.json
@@ -94,7 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio."
+  "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio.",
+  "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1205
 }

--- a/cameras/hikvision/ds-2cd2t83g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t83g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,8 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "107°/87°/54° (H)",
-  "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K."
+  "field_of_view_deg": "107/87/54 (H)",
+  "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K.",
+  "dimensions_mm": "105 x 299.7 (dia x H)",
+  "weight_g": 1090
 }

--- a/cameras/hikvision/ds-2cd2t86g2-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t86g2-2i-4i.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -91,7 +92,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
+  "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+  "field_of_view_deg": "111 horizontal (2.8mm), 87 horizontal (4mm), 51 horizontal (6mm)",
+  "dimensions_mm": "105 x 290 (dia x H)",
+  "weight_g": 1270
 }

--- a/cameras/hikvision/ds-2cd2t86g2-isu-sl.json
+++ b/cameras/hikvision/ds-2cd2t86g2-isu-sl.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -93,8 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "110°/88°/59° horizontal",
-  "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K."
+  "field_of_view_deg": "110/88/59 horizontal",
+  "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K.",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1130
 }

--- a/cameras/hikvision/ds-2cd2t86g2h-2i-4i.json
+++ b/cameras/hikvision/ds-2cd2t86g2h-2i-4i.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.0008
   },
+  "field_of_view_deg": "105.1 horizontal (2.8mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1180,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -84,13 +88,25 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2t86g2h-is2u-slrb.json
+++ b/cameras/hikvision/ds-2cd2t86g2h-is2u-slrb.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.0008
   },
+  "field_of_view_deg": "105 horizontal (2.8mm)",
+  "dimensions_mm": "286.7 x 93.1 x 91.2",
+  "weight_g": 1220,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -86,13 +90,25 @@
         "resolution": "3840x2160",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2t87g2h-li.json
+++ b/cameras/hikvision/ds-2cd2t87g2h-li.json
@@ -23,6 +23,9 @@
     "range_m": 60,
     "min_lux_color": 0.0005
   },
+  "field_of_view_deg": "105.1 horizontal (2.8mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1085,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -86,13 +89,25 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.json
@@ -23,6 +23,9 @@
     "range_m": 60,
     "min_lux_color": 0.0005
   },
+  "field_of_view_deg": "105.1 horizontal (2.8mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1205,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -88,13 +91,25 @@
         "resolution": "3840x2160",
         "fps": 24,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.json
@@ -23,6 +23,9 @@
     "range_m": 40,
     "min_lux_color": 0.0005
   },
+  "field_of_view_deg": "180 horizontal / 44 vertical (4mm)",
+  "dimensions_mm": "118.6 x 105.1 x 305.4",
+  "weight_g": 1420,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -89,13 +92,19 @@
         "resolution": "5120x1440",
         "fps": 20,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1920x536",
+        "fps": 20,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio."
 }

--- a/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3-lis2uy-sl.json
@@ -81,9 +81,11 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
   "field_of_view_deg": "108.8",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1250,
   "ip_rating": "IP67",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.json
+++ b/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.json
@@ -23,6 +23,9 @@
     "range_m": 60,
     "min_lux_color": 0.0005
   },
+  "field_of_view_deg": "108.8 horizontal (2.8mm)",
+  "dimensions_mm": "286.7 x 93.3 x 91.2",
+  "weight_g": 1250,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -88,13 +91,25 @@
         "resolution": "3840x2160",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
@@ -70,6 +70,8 @@
     "onvif"
   ],
   "ip_rating": "IP67",
+  "dimensions_mm": "118.6 x 78 x 306.5",
+  "weight_g": 1440,
   "environment": [
     "indoor",
     "outdoor"
@@ -99,7 +101,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-28",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/hikvision/ds-2cd3043g2-iu.json
+++ b/cameras/hikvision/ds-2cd3043g2-iu.json
@@ -20,8 +20,11 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø70 x 161.7",
+  "weight_g": 490,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -85,14 +88,26 @@
         "resolution": "2688x1520",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
-  "field_of_view_deg": "103°/84°/52° (H)",
+  "field_of_view_deg": "103/84/52 (H)",
   "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR."
 }

--- a/cameras/hikvision/ds-2cd3343g2-isu.json
+++ b/cameras/hikvision/ds-2cd3343g2-isu.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.005
   },
+  "field_of_view_deg": "103.6 horizontal (2.8mm)",
+  "dimensions_mm": "Ø127.3 x 96.3",
+  "weight_g": 635,
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -85,13 +89,31 @@
         "resolution": "2688x1520",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      },
+      {
+        "name": "fourth",
+        "resolution": "1280x720",
+        "fps": 10,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR."
 }

--- a/cameras/hikvision/ds-2cd3686g2t-izsy-h.json
+++ b/cameras/hikvision/ds-2cd3686g2t-izsy-h.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.003
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,9 +96,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
-  "field_of_view_deg": "108°-46° horizontal",
+  "field_of_view_deg": "108-46 horizontal",
+  "dimensions_mm": "Ø105 x 332.8",
+  "weight_g": 1475,
   "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K."
 }

--- a/cameras/hikvision/ds-2cd6365g1-ivs.json
+++ b/cameras/hikvision/ds-2cd6365g1-ivs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,8 +96,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "180 horizontal / 180 vertical",
+  "dimensions_mm": "Ø140.3 x 59.4",
+  "weight_g": 715,
   "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR."
 }

--- a/cameras/hikvision/ds-2cd6365g1-s-rc.json
+++ b/cameras/hikvision/ds-2cd6365g1-s-rc.json
@@ -93,6 +93,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "field_of_view_deg": "180 horizontal / 180 vertical",
+  "dimensions_mm": "Ø165 x 48.9",
+  "weight_g": 470,
   "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics."
 }

--- a/cameras/hikvision/ds-2cd63c5g1-s-rc.json
+++ b/cameras/hikvision/ds-2cd63c5g1-s-rc.json
@@ -94,6 +94,9 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "field_of_view_deg": "180 horizontal / 180 vertical",
+  "dimensions_mm": "Ø165 x 48.9",
+  "weight_g": 470,
   "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating."
 }

--- a/cameras/hikvision/ds-2cd6w65g1-ivs.json
+++ b/cameras/hikvision/ds-2cd6w65g1-ivs.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 15
+    "range_m": 15,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -94,8 +95,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "field_of_view_deg": "180 horizontal / 180 vertical",
+  "dimensions_mm": "213.73 x 199.67 x 137.57",
+  "weight_g": 610,
   "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR."
 }

--- a/cameras/hikvision/ds-2ce16d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce16d0t-lfs.json
@@ -50,8 +50,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
   "field_of_view_deg": "101 / 78",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "138.8 x 60.9 x 57.9",
+  "weight_g": 266
 }

--- a/cameras/hikvision/ds-2ce16d0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce16d0t-lpfs.json
@@ -50,8 +50,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
   "field_of_view_deg": "101 / 78",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "138.8 x 60.9 x 57.9",
+  "weight_g": 155
 }

--- a/cameras/hikvision/ds-2ce16h0t-itec.json
+++ b/cameras/hikvision/ds-2ce16h0t-itec.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC / PoC.af"
@@ -51,8 +52,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "5MP CMOS",
   "field_of_view_deg": "93 / 77",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "158.6 x Ø70",
+  "weight_g": 337
 }

--- a/cameras/hikvision/ds-2ce16k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce16k0t-lfs.json
@@ -22,7 +22,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -53,5 +54,7 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "138.8 x Ø70",
+  "weight_g": 270
 }

--- a/cameras/hikvision/ds-2ce16k0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce16k0t-lpfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 25,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
   "field_of_view_deg": "104.9 / 81.3",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "138.8 x Ø70",
+  "weight_g": 160
 }

--- a/cameras/hikvision/ds-2ce16u0t-itpf.json
+++ b/cameras/hikvision/ds-2ce16u0t-itpf.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -52,8 +53,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP CMOS",
   "field_of_view_deg": "102.9 / 79 / 44.7",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "58 x 61 x 158.6",
+  "weight_g": 175
 }

--- a/cameras/hikvision/ds-2ce17d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce17d0t-lfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 40,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
   "field_of_view_deg": "101 / 78 / 49.2",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "216.6 x 78.9 x 75.4",
+  "weight_g": 339
 }

--- a/cameras/hikvision/ds-2ce17k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce17k0t-lfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 40,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
   "field_of_view_deg": "104.9 (2.8mm)",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "216.6 x 78.9 x 75.4",
+  "weight_g": 340
 }

--- a/cameras/hikvision/ds-2ce18k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce18k0t-lfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 60,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -51,8 +52,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
   "field_of_view_deg": "104.9 / 81.3 / 51.8",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "192.6 x 178.3 x 71",
+  "weight_g": 740
 }

--- a/cameras/hikvision/ds-2ce19h0t-it3zec.json
+++ b/cameras/hikvision/ds-2ce19h0t-it3zec.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 40
+    "range_m": 40,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC / PoC.at"
@@ -51,8 +52,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "5MP CMOS",
   "field_of_view_deg": "95-26",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "84.5 x 92 x 255.1",
+  "weight_g": 677
 }

--- a/cameras/hikvision/ds-2ce19u1t-it3zf.json
+++ b/cameras/hikvision/ds-2ce19u1t-it3zf.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 80
+    "range_m": 80,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -52,8 +53,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP progressive-scan CMOS",
   "field_of_view_deg": "108.1-45.6",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "84.5 x 92 x 255.1",
+  "weight_g": 695
 }

--- a/cameras/hikvision/ds-2ce57u0t-vpitf.json
+++ b/cameras/hikvision/ds-2ce57u0t-vpitf.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -51,9 +52,11 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP CMOS",
   "field_of_view_deg": "102.9 / 79 / 44.7",
   "ip_rating": "IP67",
-  "ik_rating": "IK10"
+  "ik_rating": "IK10",
+  "dimensions_mm": "Ø110.8 x 84.7",
+  "weight_g": 365
 }

--- a/cameras/hikvision/ds-2ce76d0t-lmfs.json
+++ b/cameras/hikvision/ds-2ce76d0t-lmfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
   "field_of_view_deg": "101 / 78",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "80 x Ø85.1",
+  "weight_g": 296
 }

--- a/cameras/hikvision/ds-2ce76d0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce76d0t-lpfs.json
@@ -50,7 +50,9 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
-  "field_of_view_deg": "101 / 78"
+  "field_of_view_deg": "101 / 78",
+  "dimensions_mm": "84.6 x Ø85.02",
+  "weight_g": 156
 }

--- a/cameras/hikvision/ds-2ce76k0t-lmfs.json
+++ b/cameras/hikvision/ds-2ce76k0t-lmfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 30,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
   "field_of_view_deg": "104.9 / 81.3",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "80 x Ø85.1",
+  "weight_g": 300
 }

--- a/cameras/hikvision/ds-2ce76k0t-lpfs.json
+++ b/cameras/hikvision/ds-2ce76k0t-lpfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 20,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,7 +51,9 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
-  "field_of_view_deg": "104.9 / 81.3"
+  "field_of_view_deg": "104.9 / 81.3",
+  "dimensions_mm": "84.6 x Ø85.02",
+  "weight_g": 160
 }

--- a/cameras/hikvision/ds-2ce76u0t-itmf.json
+++ b/cameras/hikvision/ds-2ce76u0t-itmf.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -52,8 +53,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP CMOS",
   "field_of_view_deg": "102.9 / 79 / 44.7",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "82.6 x 90 x 79.37",
+  "weight_g": 300
 }

--- a/cameras/hikvision/ds-2ce76u0t-itpf.json
+++ b/cameras/hikvision/ds-2ce76u0t-itpf.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -52,7 +53,9 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP CMOS",
-  "field_of_view_deg": "102.9 / 79 / 44.7"
+  "field_of_view_deg": "102.9 / 79 / 44.7",
+  "dimensions_mm": "Ø84.6 x 78.9",
+  "weight_g": 150
 }

--- a/cameras/hikvision/ds-2ce78d0t-lfs.json
+++ b/cameras/hikvision/ds-2ce78d0t-lfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 40,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "2MP CMOS",
   "field_of_view_deg": "100 / 80",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "97.9 x Ø110",
+  "weight_g": 340
 }

--- a/cameras/hikvision/ds-2ce78k0t-lfs.json
+++ b/cameras/hikvision/ds-2ce78k0t-lfs.json
@@ -20,7 +20,8 @@
   "night_vision": {
     "type": "hybrid",
     "range_m": 40,
-    "min_lux": 0.01
+    "min_lux": 0.01,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -50,8 +51,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "3K CMOS",
   "field_of_view_deg": "104.9 / 81.3",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "97.9 x Ø110",
+  "weight_g": 340
 }

--- a/cameras/hikvision/ds-2ce78u0t-it3f.json
+++ b/cameras/hikvision/ds-2ce78u0t-it3f.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 60
+    "range_m": 60,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "12 VDC"
@@ -51,8 +52,10 @@
   "power_source": [
     "dc"
   ],
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "sensor": "8.29MP CMOS",
   "field_of_view_deg": "102.9 / 79 / 44.7",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "dimensions_mm": "Ø109.82 x 91.03",
+  "weight_g": 315
 }

--- a/cameras/hikvision/ds-2cv2041g2-idw.json
+++ b/cameras/hikvision/ds-2cv2041g2-idw.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.5
   },
   "power": {
     "method": "DC 12V"
@@ -85,13 +86,22 @@
         "resolution": "2560x1440",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "768x432",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "97 / 82",
+  "dimensions_mm": "175.6 x 73 x 89.1",
+  "weight_g": 345,
   "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR."
 }

--- a/cameras/hikvision/ds-2cv2141g2-idw-e.json
+++ b/cameras/hikvision/ds-2cv2141g2-idw-e.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "DC 12V"
@@ -85,13 +86,22 @@
         "resolution": "2560x1440",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "95 / 79",
+  "dimensions_mm": "Ø126 x 96.1",
+  "weight_g": 590,
   "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR."
 }

--- a/cameras/hikvision/ds-2cv2q21g1-idw.json
+++ b/cameras/hikvision/ds-2cv2q21g1-idw.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 10
+    "range_m": 10,
+    "min_lux_color": 0.05
   },
   "power": {
     "method": "DC 12V"
@@ -87,13 +88,21 @@
         "resolution": "1920x1080",
         "fps": 30,
         "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "768x432",
+        "fps": 30,
+        "codec": "H.265"
       }
     ]
   },
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
-  "field_of_view_deg": "75° (H)",
+  "last_verified": "2026-08-03",
+  "field_of_view_deg": "75 (H)",
+  "dimensions_mm": "Ø80 x 122",
+  "weight_g": 216,
   "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor)."
 }

--- a/cameras/hikvision/ds-2de2a404iw-de3-ws6.json
+++ b/cameras/hikvision/ds-2de2a404iw-de3-ws6.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -99,9 +100,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
-  "field_of_view_deg": "96.7°-31.6° horizontal",
+  "field_of_view_deg": "96.7-31.6 horizontal",
+  "dimensions_mm": "Ø130.7 x 101.7",
+  "weight_g": 530,
   "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°."
 }

--- a/cameras/hikvision/ds-2de2a404iw-de3s6.json
+++ b/cameras/hikvision/ds-2de2a404iw-de3s6.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 20
+    "range_m": 20,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -98,8 +99,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "field_of_view_deg": "96.7-31.6 horizontal",
+  "dimensions_mm": "Ø130.7 x 101.7",
+  "weight_g": 530,
   "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic."
 }

--- a/cameras/hikvision/ds-2de2c400iwg.json
+++ b/cameras/hikvision/ds-2de2c400iwg.json
@@ -21,7 +21,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 30
+    "range_m": 30,
+    "min_lux_color": 0.01
   },
   "power": {
     "method": "DC 12V"
@@ -93,7 +94,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "91 horizontal (2.8mm) / 74 horizontal (4mm)",
+  "dimensions_mm": "163.9 x 185.8 x 131.9",
+  "weight_g": 565,
   "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V."
 }

--- a/cameras/hikvision/ds-2de3404w-det5.json
+++ b/cameras/hikvision/ds-2de3404w-det5.json
@@ -19,7 +19,8 @@
     "varifocal": false
   },
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -95,7 +96,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "93.8-31.7 horizontal",
+  "dimensions_mm": "Ø140.7 x 107.2",
+  "weight_g": 950,
   "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR)."
 }

--- a/cameras/hikvision/ds-2de3a400bw-de-wt5.json
+++ b/cameras/hikvision/ds-2de3a400bw-de-wt5.json
@@ -95,7 +95,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "88.7 horizontal",
+  "dimensions_mm": "179.3 x 120 x 182",
+  "weight_g": 1125,
   "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light."
 }

--- a/cameras/hikvision/ds-2de3a400bw-det5.json
+++ b/cameras/hikvision/ds-2de3a400bw-det5.json
@@ -95,7 +95,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "88.7 horizontal",
+  "dimensions_mm": "179.3 x 120 x 182",
+  "weight_g": 1125,
   "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light."
 }

--- a/cameras/hikvision/ds-2de3a404iwg-e-w.json
+++ b/cameras/hikvision/ds-2de3a404iwg-e-w.json
@@ -25,7 +25,8 @@
   "field_of_view_deg": "96.7-31.6 horizontal",
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -102,6 +103,8 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
+  "dimensions_mm": "179.3 x 120.5 x 182",
+  "weight_g": 1125,
   "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR)."
 }

--- a/cameras/hikvision/ds-2de3a404iwg-e.json
+++ b/cameras/hikvision/ds-2de3a404iwg-e.json
@@ -23,7 +23,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -100,7 +101,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "96.7-31.6 horizontal",
+  "dimensions_mm": "179.3 x 120.5 x 182",
+  "weight_g": 1125,
   "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR."
 }

--- a/cameras/hikvision/ds-2de4215iw-det5.json
+++ b/cameras/hikvision/ds-2de4215iw-det5.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -98,8 +99,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
-  "field_of_view_deg": "57.6°-4° (H)",
+  "field_of_view_deg": "57.6-4 (H)",
+  "dimensions_mm": "Ø164.5 x 290",
+  "weight_g": 2000,
   "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°."
 }

--- a/cameras/hikvision/ds-2de4225iw-det5.json
+++ b/cameras/hikvision/ds-2de4225iw-det5.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -96,7 +97,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
+  "field_of_view_deg": "57.6-2.5 horizontal",
+  "dimensions_mm": "Ø164.5 x 290",
+  "weight_g": 2000,
   "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE."
 }

--- a/cameras/hikvision/ds-2de4425iw-det5.json
+++ b/cameras/hikvision/ds-2de4425iw-det5.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 100
+    "range_m": 100,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -97,8 +98,10 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
-  "field_of_view_deg": "55°-2.4° horizontal",
+  "field_of_view_deg": "55-2.4 horizontal",
+  "dimensions_mm": "Ø164.5 x 290",
+  "weight_g": 2000,
   "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°."
 }

--- a/cameras/hikvision/ds-2de4825wg-e3.json
+++ b/cameras/hikvision/ds-2de4825wg-e3.json
@@ -21,6 +21,7 @@
     "type": "color",
     "min_lux_color": 0.005
   },
+  "field_of_view_deg": "58.5-3.7 horizontal",
   "ptz": {
     "autotracking": true
   },
@@ -86,8 +87,10 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP54",
+  "dimensions_mm": "Ø165 x 179.5",
+  "weight_g": 2000,
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2de4a225iw-de.json
+++ b/cameras/hikvision/ds-2de4a225iw-de.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
   "power": {
     "method": "PoE+ / 12 VDC"
   },
@@ -82,7 +86,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2de4a225iw-des6.json
+++ b/cameras/hikvision/ds-2de4a225iw-des6.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -95,7 +99,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR."
 }

--- a/cameras/hikvision/ds-2de4a225iwg-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg-e.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
   "ptz": {
     "autotracking": true
   },
@@ -85,7 +89,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2de4a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a225iwg1-e.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
   "ptz": {
     "autotracking": true
   },
@@ -85,7 +89,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2de4a425iw-de.json
+++ b/cameras/hikvision/ds-2de4a425iw-de.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
   "power": {
     "method": "PoE+ / 12 VDC"
   },
@@ -82,7 +86,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2de4a425iwg1-e.json
+++ b/cameras/hikvision/ds-2de4a425iwg1-e.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 50
+    "range_m": 50,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø169 × 161",
+  "weight_g": 2450,
+  "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
   "ptz": {
     "autotracking": true
   },
@@ -85,7 +89,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "video": {
     "codecs": [

--- a/cameras/hikvision/ds-2de5225w-ae3t5.json
+++ b/cameras/hikvision/ds-2de5225w-ae3t5.json
@@ -19,8 +19,12 @@
     "varifocal": false
   },
   "night_vision": {
-    "type": "none"
+    "type": "none",
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø183 × 246",
+  "weight_g": 3000,
+  "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -98,6 +102,6 @@
   "environment": [
     "indoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE."
 }

--- a/cameras/hikvision/ds-2de5425iw-aet5.json
+++ b/cameras/hikvision/ds-2de5425iw-aet5.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 150
+    "range_m": 150,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø210 × 344.7",
+  "weight_g": 3000,
+  "field_of_view_deg": "55 H / 33 V / 61.5 D",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -96,7 +100,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE."
 }

--- a/cameras/hikvision/ds-2de7a225iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a225iw-aebt5.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø220 × 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -96,7 +100,7 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
   "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."

--- a/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a225iwg-eb-sl.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø220 × 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
   "ptz": {
     "autotracking": true
   },
@@ -85,7 +89,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {

--- a/cameras/hikvision/ds-2de7a225iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a225iwg1-e.json
@@ -19,8 +19,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø220 × 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "55 H / 33 V / 61.5 D",
   "ptz": {
     "autotracking": true
   },
@@ -85,7 +89,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {

--- a/cameras/hikvision/ds-2de7a232iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a232iw-aebt5.json
@@ -20,8 +20,12 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
+  "dimensions_mm": "Ø220 × 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "50.8 H / 29.4 V / 57.4 D",
   "power": {
     "method": "PoE (802.3af) / DC 12V"
   },
@@ -101,5 +105,6 @@
   "last_verified": "2026-07-07",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
+  "last_verified": "2026-08-03",
   "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
 }

--- a/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a232iwg-eb-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true
@@ -85,9 +86,12 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "55 horizontal/33 vertical/62.4 diagonal (wide end)",
   "video": {
     "codecs": [
       "H.265+",

--- a/cameras/hikvision/ds-2de7a232iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a232iwg1-e.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true
@@ -87,7 +88,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -119,5 +120,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)"
 }

--- a/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
+++ b/cameras/hikvision/ds-2de7a425iwg-eb-sl.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true
@@ -86,7 +87,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -118,5 +119,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)"
 }

--- a/cameras/hikvision/ds-2de7a432iw-aebt5.json
+++ b/cameras/hikvision/ds-2de7a432iw-aebt5.json
@@ -20,7 +20,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "power": {
     "method": "PoE (802.3af) / DC 12V"
@@ -98,8 +99,11 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-07",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "ik_rating": "IK10",
-  "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE."
+  "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "50.8 horizontal/29.4 vertical/57.4 diagonal (wide end)"
 }

--- a/cameras/hikvision/ds-2de7a632iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a632iwg1-e.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true
@@ -86,7 +87,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -118,5 +119,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "60.7 horizontal/35.9 vertical/68.4 diagonal (wide end)"
 }

--- a/cameras/hikvision/ds-2de7a825iwg1-e.json
+++ b/cameras/hikvision/ds-2de7a825iwg1-e.json
@@ -19,7 +19,8 @@
   },
   "night_vision": {
     "type": "ir",
-    "range_m": 200
+    "range_m": 200,
+    "min_lux_color": 0.005
   },
   "ptz": {
     "autotracking": true
@@ -86,7 +87,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -118,5 +119,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø220 x 363.3",
+  "weight_g": 5000,
+  "field_of_view_deg": "55.3 horizontal/32.2 vertical/62.3 diagonal (wide end)"
 }

--- a/cameras/hikvision/ds-2se4c215mwg-e.json
+++ b/cameras/hikvision/ds-2se4c215mwg-e.json
@@ -82,7 +82,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [
@@ -113,5 +113,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø166 x 375",
+  "weight_g": 2400,
+  "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)"
 }

--- a/cameras/hikvision/ds-2se4c225mwg-e.json
+++ b/cameras/hikvision/ds-2se4c225mwg-e.json
@@ -83,7 +83,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [
@@ -114,5 +114,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø166 x 302.6",
+  "weight_g": 2400,
+  "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)"
 }

--- a/cameras/hikvision/ds-2se4c425mwg-4g.json
+++ b/cameras/hikvision/ds-2se4c425mwg-4g.json
@@ -88,7 +88,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "video": {
     "codecs": [
@@ -119,5 +119,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø166 x 294.8",
+  "weight_g": 3000,
+  "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (PTZ channel wide end)"
 }

--- a/cameras/hikvision/ds-2se7c432mwg-eb.json
+++ b/cameras/hikvision/ds-2se7c432mwg-eb.json
@@ -82,7 +82,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP66",
   "video": {
     "codecs": [
@@ -107,5 +107,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø222.3 x 387.2",
+  "weight_g": 6000,
+  "field_of_view_deg": "60.2 horizontal/35.2 vertical (PTZ channel wide end)"
 }

--- a/cameras/hikvision/ds-2sf8c442mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c442mxg1-elw.json
@@ -87,7 +87,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -113,5 +113,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø290 x 453.2",
+  "weight_g": 10500,
+  "field_of_view_deg": "59 horizontal/34.2 vertical/67.1 diagonal (PTZ channel wide end)"
 }

--- a/cameras/hikvision/ds-2sf8c848mxg1-elw.json
+++ b/cameras/hikvision/ds-2sf8c848mxg1-elw.json
@@ -88,7 +88,7 @@
       "notes": "Select the 'Hikvision' profile."
     }
   },
-  "last_verified": "2026-07-06",
+  "last_verified": "2026-08-03",
   "ip_rating": "IP67",
   "ik_rating": "IK10",
   "video": {
@@ -120,5 +120,8 @@
         "codec": "H.265"
       }
     ]
-  }
+  },
+  "dimensions_mm": "Ø290 x 453.2",
+  "weight_g": 10500,
+  "field_of_view_deg": "58.5 horizontal/34 vertical/65.8 diagonal (PTZ channel wide end)"
 }

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1493,7 +1493,7 @@ hikvision-ds-2ae7232itg,Hikvision,DS-2AE7232ITG,ptz,1080p,2,"1/2.8"" CMOS",55 ho
 hikvision-ds-2cc12d9t-a,Hikvision,DS-2CC12D9T-A,box,1080p,2,"1/3"" 2MP ultra-low-light CMOS",,none,,,false,
 hikvision-ds-2cc12d9t-ait3ze,Hikvision,DS-2CC12D9T-AIT3ZE,bullet,1080p,2,2MP ultra-low-light CMOS,32.1-98,ir,IP67,,false,
 hikvision-ds-2cd1023g0e-i,Hikvision,DS-2CD1023G0E-I,bullet,1080p,2,"1/2.7"" Progressive Scan CMOS",112.1 horizontal (2.8mm) / 90.2 horizontal (4mm),ir,IP67,,false,
-hikvision-ds-2cd1023g2-iuf,Hikvision,DS-2CD1023G2-IUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",104° (2.8mm)/81° (4mm) horizontal,ir,IP67,,false,2023
+hikvision-ds-2cd1023g2-iuf,Hikvision,DS-2CD1023G2-IUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",104 (2.8mm)/81 (4mm) horizontal,ir,IP67,,false,2023
 hikvision-ds-2cd1023g2-liu,Hikvision,DS-2CD1023G2-LIU,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",107 horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1023g2-liuf,Hikvision,DS-2CD1023G2-LIUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",103 (2.8mm)/83 (4mm) horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1027g2h-liu,Hikvision,DS-2CD1027G2H-LIU(F),bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",115 horizontal (2.8mm) / 94 horizontal (4mm),hybrid,IP67,,false,
@@ -1570,7 +1570,7 @@ hikvision-ds-2cd2083g2-li,Hikvision,DS-2CD2083G2-LI,bullet,4K UHD,8,"1/2.7"" CMO
 hikvision-ds-2cd2085g1-i,Hikvision,DS-2CD2085G1-I,bullet,4K UHD,8,"1/2"" Progressive Scan CMOS",102 horizontal (2.8mm) / 84 horizontal (4mm) / 54 horizontal (6mm),ir,IP67,,false,
 hikvision-ds-2cd2086g2-iu,Hikvision,DS-2CD2086G2-IU,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",111 (2.8mm)/87 (4mm)/51 (6mm) horizontal,ir,IP67,,false,2023
 hikvision-ds-2cd2086g2-iu-sl,Hikvision,DS-2CD2086G2-IU/SL,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",110 (2.8mm)/88 (4mm)/60 (6mm) horizontal,ir,IP67,,true,2023
-hikvision-ds-2cd2086g2h-i2u-slrb,Hikvision,DS-2CD2086G2H-I2U/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,,true,2023
+hikvision-ds-2cd2086g2h-i2u-slrb,Hikvision,DS-2CD2086G2H-I2U/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105 (2.8mm)/90 (4mm) horizontal,ir,IP67,,true,2023
 hikvision-ds-2cd2086g2h-iu,Hikvision,DS-2CD2086G2H-IU,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105.1 (2.8mm)/90 (4mm) horizontal,ir,IP67,,false,2023
 hikvision-ds-2cd2087g2-l,Hikvision,DS-2CD2087G2-L,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS",109 horizontal,color,IP67,,false,2022
 hikvision-ds-2cd2087g2-lu,Hikvision,DS-2CD2087G2-LU,bullet,4K UHD,8,"1/1.2"" Progressive Scan CMOS",102 horizontal (2.8mm),color,IP67,,false,
@@ -1677,16 +1677,16 @@ hikvision-ds-2cd2546g2-iws,Hikvision,DS-2CD2546G2-IWS,dome,4MP (2688x1520),4,"1/
 hikvision-ds-2cd2547g2-ls,Hikvision,DS-2CD2547G2-LS,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",112 (2.8mm)/95 (4mm) horizontal,color,IP67,IK08,false,2023
 hikvision-ds-2cd2566g2-is,Hikvision,DS-2CD2566G2-I(S),dome,6MP,6,"1/2.4"" Progressive Scan CMOS",105 horizontal (2.8mm),ir,IP67,IK08,false,
 hikvision-ds-2cd2583g2-is,Hikvision,DS-2CD2583G2-IS,dome,4K (3840x2160),8,"1/2.8"" Progressive Scan CMOS",106.4 (2.8mm)/87.6 (4mm) horizontal,ir,IP67,IK08,false,2023
-hikvision-ds-2cd2586g2-is,Hikvision,DS-2CD2586G2-IS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK08,false,2023
-hikvision-ds-2cd2623g2-izs,Hikvision,DS-2CD2623G2-IZS,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",107°-32° (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2586g2-is,Hikvision,DS-2CD2586G2-IS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",110.0 (2.8mm)/88.0 (4mm) horizontal,ir,IP67,IK08,false,2023
+hikvision-ds-2cd2623g2-izs,Hikvision,DS-2CD2623G2-IZS,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",107-32 (H),ir,IP67,IK10,false,2023
 hikvision-ds-2cd2626g2-izs,Hikvision,DS-2CD2626G2-IZS,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
-hikvision-ds-2cd2643g2-izs,Hikvision,DS-2CD2643G2-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2646g2-izs,Hikvision,DS-2CD2646G2-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",108°-30° horizontal,ir,IP66,IK10,false,2023
-hikvision-ds-2cd2646g2h-izs,Hikvision,DS-2CD2646G2H-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2646g2ht-izs,Hikvision,DS-2CD2646G2HT-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2646g2t-izs,Hikvision,DS-2CD2646G2T-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2643g2-izs,Hikvision,DS-2CD2643G2-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",95.8-29.2 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2646g2-izs,Hikvision,DS-2CD2646G2-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",108-30 horizontal,ir,IP66,IK10,false,2023
+hikvision-ds-2cd2646g2h-izs,Hikvision,DS-2CD2646G2H-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",105.4-34.3 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2646g2ht-izs,Hikvision,DS-2CD2646G2HT-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",105.4-34.3 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2646g2t-izs,Hikvision,DS-2CD2646G2T-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",108-30 (H),ir,IP67,IK10,false,2023
 hikvision-ds-2cd2647g2-lzs,Hikvision,DS-2CD2647G2-LZS,bullet,4MP,4,"1/1.8"" CMOS",95-44 horizontal,color,IP67,IK10,false,
-hikvision-ds-2cd2647g2ht-lizs,Hikvision,DS-2CD2647G2HT-LIZS,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,false,2023
+hikvision-ds-2cd2647g2ht-lizs,Hikvision,DS-2CD2647G2HT-LIZS,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8 (H),hybrid,IP67,IK10,false,2023
 hikvision-ds-2cd2647g3-lizs2uy-slrb,Hikvision,DS-2CD2647G3-LIZS2UY/SLRB,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,true,2023
 hikvision-ds-2cd2667g2ht-lizs,Hikvision,DS-2CD2667G2HT-LIZS,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,false,2023
 hikvision-ds-2cd2683g2-izs,Hikvision,DS-2CD2683G2-IZS,bullet,4K UHD,8,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1687,132 +1687,132 @@ hikvision-ds-2cd2646g2ht-izs,Hikvision,DS-2CD2646G2HT-IZS,bullet,4MP (2688x1520)
 hikvision-ds-2cd2646g2t-izs,Hikvision,DS-2CD2646G2T-IZS,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",108-30 (H),ir,IP67,IK10,false,2023
 hikvision-ds-2cd2647g2-lzs,Hikvision,DS-2CD2647G2-LZS,bullet,4MP,4,"1/1.8"" CMOS",95-44 horizontal,color,IP67,IK10,false,
 hikvision-ds-2cd2647g2ht-lizs,Hikvision,DS-2CD2647G2HT-LIZS,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8 (H),hybrid,IP67,IK10,false,2023
-hikvision-ds-2cd2647g3-lizs2uy-slrb,Hikvision,DS-2CD2647G3-LIZS2UY/SLRB,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,true,2023
-hikvision-ds-2cd2667g2ht-lizs,Hikvision,DS-2CD2667G2HT-LIZS,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,false,2023
+hikvision-ds-2cd2647g3-lizs2uy-slrb,Hikvision,DS-2CD2647G3-LIZS2UY/SLRB,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8 (H),hybrid,IP67,IK10,true,2023
+hikvision-ds-2cd2667g2ht-lizs,Hikvision,DS-2CD2667G2HT-LIZS,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",112.3-41.2 (H),hybrid,IP67,IK10,false,2023
 hikvision-ds-2cd2683g2-izs,Hikvision,DS-2CD2683G2-IZS,bullet,4K UHD,8,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
 hikvision-ds-2cd2686g2-izs,Hikvision,DS-2CD2686G2-IZS,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS",108-46 horizontal,ir,IP66,IK10,false,
-hikvision-ds-2cd2686g2h-izs,Hikvision,DS-2CD2686G2H-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3°-41.2° (H),ir,IP67,IK10,false,2023
-hikvision-ds-2cd2686g2ht-izs,Hikvision,DS-2CD2686G2HT-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2686g2t-izs,Hikvision,DS-2CD2686G2T-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108°-46° horizontal,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2686g2h-izs,Hikvision,DS-2CD2686G2H-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2686g2ht-izs,Hikvision,DS-2CD2686G2HT-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2686g2t-izs,Hikvision,DS-2CD2686G2T-IZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108-46 horizontal,ir,IP67,IK10,false,2023
 hikvision-ds-2cd2687g2ht-lizs,Hikvision,DS-2CD2687G2HT-LIZS,bullet,4K/8MP,8,"1/1.8"" CMOS",112.3-41.2,hybrid,IP67,IK10,false,
-hikvision-ds-2cd2687g2t-lzs,Hikvision,DS-2CD2687G2T-LZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,color,IP67,IK10,false,2023
-hikvision-ds-2cd2687g3-lizs2uy-slrb,Hikvision,DS-2CD2687G3-LIZS2UY/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,true,2023
-hikvision-ds-2cd2723g2-izs,Hikvision,DS-2CD2723G2-IZS,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2687g2t-lzs,Hikvision,DS-2CD2687G2T-LZS,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",103.3-40,color,IP67,IK10,false,2023
+hikvision-ds-2cd2687g3-lizs2uy-slrb,Hikvision,DS-2CD2687G3-LIZS2UY/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2,hybrid,IP67,IK10,true,2023
+hikvision-ds-2cd2723g2-izs,Hikvision,DS-2CD2723G2-IZS,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",107-32,ir,IP67,IK10,false,2023
 hikvision-ds-2cd2726g2-izs,Hikvision,DS-2CD2726G2-IZS,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
-hikvision-ds-2cd2726g2t-izs,Hikvision,DS-2CD2726G2T-IZS,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2726g2t-izs,Hikvision,DS-2CD2726G2T-IZS,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",113-31,ir,IP67,IK10,false,2023
 hikvision-ds-2cd2743g2-izs,Hikvision,DS-2CD2743G2-IZS,dome,4MP,4,"1/3"" CMOS",106-32 horizontal,ir,IP67,IK10,false,
-hikvision-ds-2cd2746g2-izs,Hikvision,DS-2CD2746G2-IZS,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2cd2746g2h-iptrzs2u-slrb,Hikvision,DS-2CD2746G2H-IPTRZS2U/SLRB,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,ir,IP66,IK10,true,2023
-hikvision-ds-2cd2746g2ht-izs,Hikvision,DS-2CD2746G2HT-IZS,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",105.4°-34.3° (H),ir,IP67,IK10,false,2023
-hikvision-ds-2cd2747g2h-liptrzs2u-slrb,Hikvision,DS-2CD2747G2H-LIPTRZS2U/SLRB,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP66,IK10,true,2023
-hikvision-ds-2cd2747g2ht-lizs,Hikvision,DS-2CD2747G2HT-LIZS,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6°-41.8° horizontal,hybrid,IP67,IK10,false,2023
-hikvision-ds-2cd2747g2t-lzs,Hikvision,DS-2CD2747G2T-LZS,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,color,IP67,IK10,false,2023
+hikvision-ds-2cd2746g2-izs,Hikvision,DS-2CD2746G2-IZS,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",108-30,ir,IP66,IK10,false,2023
+hikvision-ds-2cd2746g2h-iptrzs2u-slrb,Hikvision,DS-2CD2746G2H-IPTRZS2U/SLRB,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8,ir,IP66,IK10,true,2023
+hikvision-ds-2cd2746g2ht-izs,Hikvision,DS-2CD2746G2HT-IZS,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",105.4-34.3 (H),ir,IP67,IK10,false,2023
+hikvision-ds-2cd2747g2h-liptrzs2u-slrb,Hikvision,DS-2CD2747G2H-LIPTRZS2U/SLRB,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8,hybrid,IP66,IK10,true,2023
+hikvision-ds-2cd2747g2ht-lizs,Hikvision,DS-2CD2747G2HT-LIZS,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8 horizontal,hybrid,IP67,IK10,false,2023
+hikvision-ds-2cd2747g2t-lzs,Hikvision,DS-2CD2747G2T-LZS,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",105.4-56.4,color,IP67,IK10,false,2023
 hikvision-ds-2cd2747g3-liptrzs2uy-sl,Hikvision,DS-2CD2747G3-LIPTRZS2UY/SL,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8,hybrid,IP67,IK10,true,
 hikvision-ds-2cd2747g3-liptrzs2uy-srb,Hikvision,DS-2CD2747G3-LIPTRZS2UY/SRB,dome,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",114.6-41.8,hybrid,IP67,IK10,false,2024
 hikvision-ds-2cd2747g3-liptrzsy,Hikvision,DS-2CD2747G3-LIPTRZSY,dome,4MP,4,"1/1.8"" Progressive Scan CMOS",114.6-41.8,hybrid,IP67,IK10,false,
 hikvision-ds-2cd2763g2-izs,Hikvision,DS-2CD2763G2-IZS,dome,6MP,6,"1/2.4"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
-hikvision-ds-2cd2767g2ht-lizs,Hikvision,DS-2CD2767G2HT-LIZS,dome,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,false,2023
+hikvision-ds-2cd2767g2ht-lizs,Hikvision,DS-2CD2767G2HT-LIZS,dome,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",112.3-41.2,hybrid,IP67,IK10,false,2023
 hikvision-ds-2cd2767g3-liptrzs2uy-sl,Hikvision,DS-2CD2767G3-LIPTRZS2UY/SL,dome,6MP,6,"1/1.8"" Progressive Scan CMOS",112.3 to 41.2,hybrid,IP67,IK10,true,
 hikvision-ds-2cd2767g3-liptrzsy,Hikvision,DS-2CD2767G3-LIPTRZSY,dome,6MP,6,"1/1.8"" Progressive Scan CMOS",112.3 to 41.2,hybrid,IP67,IK10,false,2025
 hikvision-ds-2cd2767g3t-lizsy,Hikvision,DS-2CD2767G3T-LIZSY,dome,6MP,6,"1/1.8"" Progressive Scan CMOS",112.3 to 41.2,hybrid,IP67,IK10,false,
-hikvision-ds-2cd2783g2-izs,Hikvision,DS-2CD2783G2-IZS,dome,4K (3840x2160),8,"1/2.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2786g2-izs,Hikvision,DS-2CD2786G2-IZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2cd2786g2h-iptrzs2u-slrb,Hikvision,DS-2CD2786G2H-IPTRZS2U/SLRB,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP66,IK10,true,2023
-hikvision-ds-2cd2786g2ht-izs,Hikvision,DS-2CD2786G2HT-IZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2787g2h-liptrzs2u-slrb,Hikvision,DS-2CD2787G2H-LIPTRZS2U/SLRB,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3°-41.2° (H),hybrid,IP66,IK10,true,2023
-hikvision-ds-2cd2787g2ht-lizs,Hikvision,DS-2CD2787G2HT-LIZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,IK10,false,2023
-hikvision-ds-2cd2787g2t-lzs,Hikvision,DS-2CD2787G2T-LZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",103.3°-40° horizontal,color,IP67,IK10,false,2023
+hikvision-ds-2cd2783g2-izs,Hikvision,DS-2CD2783G2-IZS,dome,4K (3840x2160),8,"1/2.8"" Progressive Scan CMOS",108-30,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2786g2-izs,Hikvision,DS-2CD2786G2-IZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108-46,ir,IP66,IK10,false,2023
+hikvision-ds-2cd2786g2h-iptrzs2u-slrb,Hikvision,DS-2CD2786G2H-IPTRZS2U/SLRB,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2,ir,IP66,IK10,true,2023
+hikvision-ds-2cd2786g2ht-izs,Hikvision,DS-2CD2786G2HT-IZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2787g2h-liptrzs2u-slrb,Hikvision,DS-2CD2787G2H-LIPTRZS2U/SLRB,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2 (H),hybrid,IP66,IK10,true,2023
+hikvision-ds-2cd2787g2ht-lizs,Hikvision,DS-2CD2787G2HT-LIZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2 horizontal,hybrid,IP67,IK10,false,2023
+hikvision-ds-2cd2787g2t-lzs,Hikvision,DS-2CD2787G2T-LZS,dome,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",103.3-40 horizontal,color,IP67,IK10,false,2023
 hikvision-ds-2cd2787g3-izs,Hikvision,DS-2CD2787G3-IZS,dome,4K UHD,8,"1/1.8"" Progressive Scan CMOS",108-33 horizontal,ir,IP67,IK10,false,2025
 hikvision-ds-2cd2787g3-liptrzs2uy-sl,Hikvision,DS-2CD2787G3-LIPTRZS2UY/SL,dome,8MP,8,"1/1.8"" Progressive Scan CMOS",41.2-112.3,hybrid,IP67,IK10,true,2024
 hikvision-ds-2cd2787g3-liptrzs2uy-srb,Hikvision,DS-2CD2787G3-LIPTRZS2UY/SRB,dome,8MP,8,"1/1.8"" Progressive Scan CMOS",112.3 to 41.2,hybrid,IP67,IK10,true,
 hikvision-ds-2cd2787g3-liptrzsy,Hikvision,DS-2CD2787G3-LIPTRZSY,dome,8MP,8,"1/1.8"" Progressive Scan CMOS",112.3 to 41.2,hybrid,IP67,IK10,true,2025
 hikvision-ds-2cd2955fwd-is,Hikvision,DS-2CD2955FWD-IS,fisheye,5MP 360°,5,"1/2.5"" CMOS",360 fisheye,ir,IP67,IK10,true,2021
-hikvision-ds-2cd2955g0-isu,Hikvision,DS-2CD2955G0-ISU,fisheye,5MP fisheye,5,"1/2.7"" Progressive Scan CMOS",,ir,,,false,2023
-hikvision-ds-2cd2d25g1-d-nf,Hikvision,DS-2CD2D25G1-D/NF,box,1080p,2,"1/2.8"" Progressive Scan CMOS",,none,,,false,2023
-hikvision-ds-2cd2e23g2-u,Hikvision,DS-2CD2E23G2-U,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",,none,,,false,2023
-hikvision-ds-2cd2e43g2-u,Hikvision,DS-2CD2E43G2-U,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,none,,,false,2023
-hikvision-ds-2cd2h23g2-izs,Hikvision,DS-2CD2H23G2-IZS,turret,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2h43g2-izs,Hikvision,DS-2CD2H43G2-IZS,turret,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2955g0-isu,Hikvision,DS-2CD2955G0-ISU,fisheye,5MP fisheye,5,"1/2.7"" Progressive Scan CMOS",180 horizontal,ir,,,false,2023
+hikvision-ds-2cd2d25g1-d-nf,Hikvision,DS-2CD2D25G1-D/NF,box,1080p,2,"1/2.8"" Progressive Scan CMOS",93.9 (2.8mm)/75.5 (3.7mm) horizontal,none,,,false,2023
+hikvision-ds-2cd2e23g2-u,Hikvision,DS-2CD2E23G2-U,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",107 (2.8mm)/88 (4mm) horizontal,none,,,false,2023
+hikvision-ds-2cd2e43g2-u,Hikvision,DS-2CD2E43G2-U,dome,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",103 (2.8mm)/84 (4mm) horizontal,none,,,false,2023
+hikvision-ds-2cd2h23g2-izs,Hikvision,DS-2CD2H23G2-IZS,turret,1080p,2,"1/2.8"" Progressive Scan CMOS",106.6-31.7 horizontal,ir,IP67,IK10,false,2023
+hikvision-ds-2cd2h43g2-izs,Hikvision,DS-2CD2H43G2-IZS,turret,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",95.8-29.2 horizontal,ir,IP67,IK10,false,2023
 hikvision-ds-2cd2h43g2-izs-uk,Hikvision,DS-2CD2H43G2-IZS,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,2022
 hikvision-ds-2cd2h46g2-izs,Hikvision,DS-2CD2H46G2-IZS,bullet,4MP,4,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
 hikvision-ds-2cd2h83g2-izs,Hikvision,DS-2CD2H83G2-IZS,bullet,4K UHD,8,"1/2.8"" Progressive Scan CMOS",106-32 horizontal,ir,IP67,IK10,false,
-hikvision-ds-2cd2h86g2-izs,Hikvision,DS-2CD2H86G2-IZS,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108°-46° (H),ir,IP66,IK10,false,2023
-hikvision-ds-2cd2h86g2t-izs,Hikvision,DS-2CD2H86G2T-IZS,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,2023
-hikvision-ds-2cd2h87g3-lizs2uy-slrb,Hikvision,DS-2CD2H87G3-LIZS2UY/SLRB,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3°-41.2° horizontal,hybrid,IP67,IK10,true,2023
+hikvision-ds-2cd2h86g2-izs,Hikvision,DS-2CD2H86G2-IZS,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108-46 (H),ir,IP66,IK10,false,2023
+hikvision-ds-2cd2h86g2t-izs,Hikvision,DS-2CD2H86G2T-IZS,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS","108-46 horizontal, 58-26 vertical, 127.4 diagonal",ir,IP67,IK10,false,2023
+hikvision-ds-2cd2h87g3-lizs2uy-slrb,Hikvision,DS-2CD2H87G3-LIZS2UY/SLRB,turret,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",112.3-41.2 horizontal,hybrid,IP67,IK10,true,2023
 hikvision-ds-2cd2h87g3-lizsy,Hikvision,DS-2CD2H87G3-LIZSY,turret,4K/8MP,8,"1/1.8"" CMOS",112.3-41.2,hybrid,IP67,IK10,false,
 hikvision-ds-2cd2t127g3p-lis2uy-sl,Hikvision,DS-2CD2T127G3P-LIS2UY/SL,panoramic,12MP,12,"1/2.5"" Progressive Scan CMOS",182.6,hybrid,IP67,IK10,true,
 hikvision-ds-2cd2t167g3p-lis2uy-sl,Hikvision,DS-2CD2T167G3P-LIS2UY/SL,bullet,16MP,16,"1/1.8"" Progressive Scan CMOS","182.2 horizontal, 71.2 vertical (2.8mm)",hybrid,IP67,IK10,true,2025
 hikvision-ds-2cd2t23g2-2i,Hikvision,DS-2CD2T23G2-2I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",107 horizontal,ir,IP67,,false,2022
-hikvision-ds-2cd2t23g2-2i-4i,Hikvision,DS-2CD2T23G2-2I/4I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd2t23g2-2i-4i,Hikvision,DS-2CD2T23G2-2I/4I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS","107 horizontal, 57 vertical, 127 diagonal (2.8mm)",ir,IP67,,false,2023
 hikvision-ds-2cd2t23g2-4i,Hikvision,DS-2CD2T23G2-4I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",103 horizontal (2.8mm),ir,IP67,,false,
 hikvision-ds-2cd2t23g2-4is,Hikvision,DS-2CD2T23G2-4I(S),bullet,1080p HD,2,,103h,ir,IP67,,false,2022
-hikvision-ds-2cd2t26g2-2i-4i,Hikvision,DS-2CD2T26G2-2I/4I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd2t26g2-2i-4i,Hikvision,DS-2CD2T26G2-2I/4I,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS","107 horizontal, 57 vertical, 129 diagonal (2.8mm)",ir,IP67,,false,2023
 hikvision-ds-2cd2t26g2-isu-sl,Hikvision,DS-2CD2T26G2-ISU/SL,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",103 horizontal (2.8mm),ir,IP67,,true,
-hikvision-ds-2cd2t27g2-l,Hikvision,DS-2CD2T27G2-L,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",,color,IP67,,false,2023
-hikvision-ds-2cd2t43g2-2i-4i,Hikvision,DS-2CD2T43G2-2I/4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd2t27g2-l,Hikvision,DS-2CD2T27G2-L,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS","107 horizontal, 56 vertical, 127 diagonal (2.8mm)",color,IP67,,false,2023
+hikvision-ds-2cd2t43g2-2i-4i,Hikvision,DS-2CD2T43G2-2I/4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS","103 horizontal, 55 vertical, 122 diagonal (2.8mm)",ir,IP67,,false,2023
 hikvision-ds-2cd2t43g2-4i,Hikvision,DS-2CD2T43G2-4I,bullet,4MP,4,"1/3"" Progressive Scan CMOS",103 horizontal (2.8mm),ir,IP67,,false,
-hikvision-ds-2cd2t45g0p-i,Hikvision,DS-2CD2T45G0P-I,bullet,4MP (2688x1520),4,"1/2.7"" Progressive Scan CMOS",,ir,IP67,,false,2023
-hikvision-ds-2cd2t46g2-2i-4i,Hikvision,DS-2CD2T46G2-2I/4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd2t45g0p-i,Hikvision,DS-2CD2T45G0P-I,bullet,4MP (2688x1520),4,"1/2.7"" Progressive Scan CMOS","180 horizontal, 101 vertical, 180 diagonal",ir,IP67,,false,2023
+hikvision-ds-2cd2t46g2-2i-4i,Hikvision,DS-2CD2T46G2-2I/4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS","103 horizontal, 55 vertical, 123 diagonal (2.8mm)",ir,IP67,,false,2023
 hikvision-ds-2cd2t46g2-4i,Hikvision,DS-2CD2T46G2-4I,bullet,4MP,4,"1/3"" Progressive Scan CMOS",103 horizontal (2.8mm),ir,IP67,,false,
-hikvision-ds-2cd2t46g2-isu-sl,Hikvision,DS-2CD2T46G2-ISU/SL,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",103°/83°/53° (H),ir,IP67,,true,2023
-hikvision-ds-2cd2t46g2h-2i-4i,Hikvision,DS-2CD2T46G2H-2I-4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",,ir,IP67,,false,2023
-hikvision-ds-2cd2t46g2h-is2u-slrb,Hikvision,DS-2CD2T46G2H-IS2U/SLRB,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",100° (2.8mm)/81° (4mm) horizontal,ir,IP67,,true,2023
-hikvision-ds-2cd2t46g2p-isu-sl,Hikvision,DS-2CD2T46G2P-ISU/SL,panoramic,4MP panoramic (3040x1368),4,"2 x 1/2.5"" Progressive Scan CMOS (dual sensor)",,ir,IP67,,true,2023
+hikvision-ds-2cd2t46g2-isu-sl,Hikvision,DS-2CD2T46G2-ISU/SL,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",103/83/53 (H),ir,IP67,,true,2023
+hikvision-ds-2cd2t46g2h-2i-4i,Hikvision,DS-2CD2T46G2H-2I-4I,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS","100.2 horizontal (2.8mm), 81.1 horizontal (4mm)",ir,IP67,,false,2023
+hikvision-ds-2cd2t46g2h-is2u-slrb,Hikvision,DS-2CD2T46G2H-IS2U/SLRB,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",100 (2.8mm)/81 (4mm) horizontal,ir,IP67,,true,2023
+hikvision-ds-2cd2t46g2p-isu-sl,Hikvision,DS-2CD2T46G2P-ISU/SL,panoramic,4MP panoramic (3040x1368),4,"2 x 1/2.5"" Progressive Scan CMOS (dual sensor)","180 horizontal, 81 vertical (2.8mm)",ir,IP67,,true,2023
 hikvision-ds-2cd2t47g2-l,Hikvision,DS-2CD2T47G2-L,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",94 horizontal (4mm lens),color,IP67,,false,
 hikvision-ds-2cd2t47g2-l-sl,Hikvision,DS-2CD2T47G2-L/SL,bullet,4MP,4,"1/1.8"" CMOS",102 horizontal (2.8mm),color,IP67,,true,2024
 hikvision-ds-2cd2t47g2-lse,Hikvision,DS-2CD2T47G2-LSE,bullet,4MP,4,"1/1.8"" CMOS",102 horizontal (2.8mm),color,IP67,,true,2023
 hikvision-ds-2cd2t47g2-lsu-sl,Hikvision,DS-2CD2T47G2-LSU/SL,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",102 horizontal (2.8mm),color,IP67,,true,
 hikvision-ds-2cd2t47g2h-li,Hikvision,DS-2CD2T47G2H-LI,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",102 horizontal (2.8mm),hybrid,IP67,,false,2024
-hikvision-ds-2cd2t47g2h-lisu-sl,Hikvision,DS-2CD2T47G2H-LISU/SL,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,true,2023
+hikvision-ds-2cd2t47g2h-lisu-sl,Hikvision,DS-2CD2T47G2H-LISU/SL,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS","104.0 horizontal (2.8mm), 89.2 horizontal (4mm)",hybrid,IP67,,true,2023
 hikvision-ds-2cd2t47g2h-liu,Hikvision,DS-2CD2T47G2H-LIU,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",102 horizontal (2.8mm),hybrid,IP67,,false,
-hikvision-ds-2cd2t47g2p-lsu-sl,Hikvision,DS-2CD2T47G2P-LSU/SL,panoramic,4MP panoramic (3040x1368),4,"2 x 1/2.5"" Progressive Scan CMOS (dual sensor)",,color,IP67,,true,2023
+hikvision-ds-2cd2t47g2p-lsu-sl,Hikvision,DS-2CD2T47G2P-LSU/SL,panoramic,4MP panoramic (3040x1368),4,"2 x 1/2.5"" Progressive Scan CMOS (dual sensor)","180 horizontal, 81 vertical (2.8mm)",color,IP67,,true,2023
 hikvision-ds-2cd2t47g3-lis2uy-sl,Hikvision,DS-2CD2T47G3-LIS2UY/SL,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",102 horizontal (2.8mm),hybrid,IP67,,true,2025
-hikvision-ds-2cd2t47g3-lis2uy-slrb,Hikvision,DS-2CD2T47G3-LIS2UY/SLRB,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,true,2023
+hikvision-ds-2cd2t47g3-lis2uy-slrb,Hikvision,DS-2CD2T47G3-LIS2UY/SLRB,bullet,4MP (2688x1520),4,"1/1.8"" Progressive Scan CMOS","111.1 horizontal (2.8mm), 95.2 horizontal (4mm)",hybrid,IP67,,true,2023
 hikvision-ds-2cd2t47g3-liy,Hikvision,DS-2CD2T47G3-LIY,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",102 horizontal (2.8mm),hybrid,IP67,,true,2025
 hikvision-ds-2cd2t63g2-4i,Hikvision,DS-2CD2T63G2-4I,bullet,6MP,6,"1/2.4"" Progressive Scan CMOS",103 horizontal (2.8mm),ir,IP67,,false,
 hikvision-ds-2cd2t67g2-l,Hikvision,DS-2CD2T67G2-L,bullet,6MP,6,"1/1.7"" CMOS",103 horizontal (2.8mm),color,IP67,,false,
-hikvision-ds-2cd2t67g2h-li,Hikvision,DS-2CD2T67G2H-LI,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,false,2023
-hikvision-ds-2cd2t67g2h-lisu-sl,Hikvision,DS-2CD2T67G2H-LISU/SL,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,true,2023
-hikvision-ds-2cd2t83g2-2i-4i,Hikvision,DS-2CD2T83G2-2I/4I,bullet,4K (3840x2160),8,"1/2.8"" Progressive Scan CMOS",107°/87°/54° (H),ir,IP67,,false,2023
+hikvision-ds-2cd2t67g2h-li,Hikvision,DS-2CD2T67G2H-LI,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS","105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",hybrid,IP67,,false,2023
+hikvision-ds-2cd2t67g2h-lisu-sl,Hikvision,DS-2CD2T67G2H-LISU/SL,bullet,6MP (3200x1800),6,"1/1.8"" Progressive Scan CMOS","105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",hybrid,IP67,,true,2023
+hikvision-ds-2cd2t83g2-2i-4i,Hikvision,DS-2CD2T83G2-2I/4I,bullet,4K (3840x2160),8,"1/2.8"" Progressive Scan CMOS",107/87/54 (H),ir,IP67,,false,2023
 hikvision-ds-2cd2t83g2-4i,Hikvision,DS-2CD2T83G2-4I,bullet,4K UHD,8,"1/2.8"" Progressive Scan CMOS",102 horizontal (2.8mm),ir,IP67,IK10,false,
 hikvision-ds-2cd2t85g1-i8,Hikvision,DS-2CD2T85G1-I8,bullet,4K UHD,8,"1/2"" Progressive Scan CMOS",102 horizontal (2.8mm),ir,IP67,,false,
-hikvision-ds-2cd2t86g2-2i-4i,Hikvision,DS-2CD2T86G2-2I/4I,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd2t86g2-2i-4i,Hikvision,DS-2CD2T86G2-2I/4I,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS","111 horizontal (2.8mm), 87 horizontal (4mm), 51 horizontal (6mm)",ir,IP67,,false,2023
 hikvision-ds-2cd2t86g2-4i,Hikvision,DS-2CD2T86G2-4I,bullet,4K UHD,8,"1/2.8"" Progressive Scan CMOS",102 horizontal (2.8mm),ir,IP67,IK10,false,
-hikvision-ds-2cd2t86g2-isu-sl,Hikvision,DS-2CD2T86G2-ISU/SL,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",110°/88°/59° horizontal,ir,IP67,,true,2023
-hikvision-ds-2cd2t86g2h-2i-4i,Hikvision,DS-2CD2T86G2H-2I/4I,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,,false,2023
-hikvision-ds-2cd2t86g2h-is2u-slrb,Hikvision,DS-2CD2T86G2H-IS2U/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,ir,IP67,,true,2023
+hikvision-ds-2cd2t86g2-isu-sl,Hikvision,DS-2CD2T86G2-ISU/SL,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",110/88/59 horizontal,ir,IP67,,true,2023
+hikvision-ds-2cd2t86g2h-2i-4i,Hikvision,DS-2CD2T86G2H-2I/4I,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105.1 horizontal (2.8mm),ir,IP67,,false,2023
+hikvision-ds-2cd2t86g2h-is2u-slrb,Hikvision,DS-2CD2T86G2H-IS2U/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105 horizontal (2.8mm),ir,IP67,,true,2023
 hikvision-ds-2cd2t87g2-4i,Hikvision,DS-2CD2T87G2-4I,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS",109 horizontal,ir,IP67,,false,2022
 hikvision-ds-2cd2t87g2-l,Hikvision,DS-2CD2T87G2-L,bullet,4K UHD,8,"1/2"" Progressive Scan CMOS",102 horizontal / 52 vertical (2.8mm),color,IP67,IK10,false,
 hikvision-ds-2cd2t87g2-lsu-sl,Hikvision,DS-2CD2T87G2-LSU/SL,bullet,4K UHD,8,"1/2"" Progressive Scan CMOS",102 horizontal (2.8mm),color,IP67,,true,
-hikvision-ds-2cd2t87g2h-li,Hikvision,DS-2CD2T87G2H-LI,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,false,2023
-hikvision-ds-2cd2t87g2h-lisu-sl,Hikvision,DS-2CD2T87G2H-LISU/SL,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,true,2023
-hikvision-ds-2cd2t87g2p-lsu-sl,Hikvision,DS-2CD2T87G2P-LSU/SL,panoramic,8MP panoramic (5120x1440),8,"2 x 1/1.8"" Progressive Scan CMOS (dual sensor)",,color,IP67,,true,2023
+hikvision-ds-2cd2t87g2h-li,Hikvision,DS-2CD2T87G2H-LI,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105.1 horizontal (2.8mm),hybrid,IP67,,false,2023
+hikvision-ds-2cd2t87g2h-lisu-sl,Hikvision,DS-2CD2T87G2H-LISU/SL,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",105.1 horizontal (2.8mm),hybrid,IP67,,true,2023
+hikvision-ds-2cd2t87g2p-lsu-sl,Hikvision,DS-2CD2T87G2P-LSU/SL,panoramic,8MP panoramic (5120x1440),8,"2 x 1/1.8"" Progressive Scan CMOS (dual sensor)",180 horizontal / 44 vertical (4mm),color,IP67,,true,2023
 hikvision-ds-2cd2t87g3-li,Hikvision,DS-2CD2T87G3-LI,bullet,4K UHD,8,"1/1.2"" Progressive Scan CMOS",102 horizontal (2.8mm),hybrid,IP67,,false,2025
 hikvision-ds-2cd2t87g3-lis2uy-sl,Hikvision,DS-2CD2T87G3-LIS2UY/SL,bullet,4K/8MP,8,"1/1.8"" CMOS",108.8,hybrid,IP67,,true,
-hikvision-ds-2cd2t87g3-lis2uy-slrb,Hikvision,DS-2CD2T87G3-LIS2UY/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",,hybrid,IP67,,true,2023
+hikvision-ds-2cd2t87g3-lis2uy-slrb,Hikvision,DS-2CD2T87G3-LIS2UY/SLRB,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108.8 horizontal (2.8mm),hybrid,IP67,,true,2023
 hikvision-ds-2cd2t87g3p-lis2uy-sl,Hikvision,DS-2CD2T87G3P-LIS2UY/SL,bullet,8MP,8,"1/2.5"" Progressive Scan CMOS",182.6,hybrid,IP67,,true,
-hikvision-ds-2cd3043g2-iu,Hikvision,DS-2CD3043G2-IU,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",103°/84°/52° (H),ir,IP67,,false,2023
+hikvision-ds-2cd3043g2-iu,Hikvision,DS-2CD3043G2-IU,bullet,4MP (2688x1520),4,"1/3"" Progressive Scan CMOS",103/84/52 (H),ir,IP67,,false,2023
 hikvision-ds-2cd3056g2-is,Hikvision,DS-2CD3056G2-IS,bullet,5MP,5,"1/2.7"" Progressive Scan CMOS",98 horizontal (2.8mm),ir,IP67,,false,
 hikvision-ds-2cd3086g2-is,Hikvision,DS-2CD3086G2-IS,bullet,4K UHD,8,"1/1.8"" Progressive Scan CMOS",108 horizontal (2.8mm),ir,IP67,,false,
 hikvision-ds-2cd3143g2-iu,Hikvision,DS-2CD3143G2-IU,dome,4MP,4,,103h,ir,IP67,IK10,false,2022
 hikvision-ds-2cd3156g2-is-u,Hikvision,DS-2CD3156G2-IS(U),dome,5MP,5,"1/2.7"" Progressive Scan CMOS",98 horizontal (2.8mm),ir,IP67,IK10,false,
-hikvision-ds-2cd3343g2-isu,Hikvision,DS-2CD3343G2-ISU,turret,4MP (2688x1520),4,"1/2.9"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd3343g2-isu,Hikvision,DS-2CD3343G2-ISU,turret,4MP (2688x1520),4,"1/2.9"" Progressive Scan CMOS",103.6 horizontal (2.8mm),ir,IP67,,false,2023
 hikvision-ds-2cd3347g2-lu,Hikvision,DS-2CD3347G2-LU,turret,4MP,4,,103h,color,IP67,,false,2023
 hikvision-ds-2cd3386g2-is-u,Hikvision,DS-2CD3386G2-IS(U),turret,4K UHD,8,"1/1.8"" Progressive Scan CMOS",107 horizontal (2.8mm),ir,IP67,,false,
 hikvision-ds-2cd3387g2-lu,Hikvision,DS-2CD3387G2-LU,turret,4K UHD,8,,103h,color,IP67,,false,2023
 hikvision-ds-2cd3523g2-is,Hikvision,DS-2CD3523G2-IS,dome,1080p HD,2,,88-34h,ir,IP67,IK10,false,2022
-hikvision-ds-2cd3686g2t-izsy-h,Hikvision,DS-2CD3686G2T-IZSY-H,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108°-46° horizontal,ir,IP67,IK10,false,2023
+hikvision-ds-2cd3686g2t-izsy-h,Hikvision,DS-2CD3686G2T-IZSY-H,bullet,4K (3840x2160),8,"1/1.8"" Progressive Scan CMOS",108-46 horizontal,ir,IP67,IK10,false,2023
 hikvision-ds-2cd3746g2-izs,Hikvision,DS-2CD3746G2-IZS,dome,4MP,4,"1/3"" Progressive Scan CMOS","107.6-32.9 horizontal (2.7-13.5mm), 28.7-10.5 (7-35mm)",ir,IP66,IK10,true,
 hikvision-ds-2cd3766g2t-izs-y,Hikvision,DS-2CD3766G2T-IZS(Y),dome,6MP,6,"1/2.4"" Progressive Scan CMOS","106-35.6 horizontal (2.7-13.5mm), 34.4-12.5 (7-35mm)",ir,IP67,IK10,true,
 hikvision-ds-2cd3t47g2-lzs,Hikvision,DS-2CD3T47G2-LZS,bullet,4MP,4,,103-32h,color,IP67,,false,2023
 hikvision-ds-2cd3t87g2-lzs,Hikvision,DS-2CD3T87G2-LZS,bullet,4K UHD,8,,103-32h,color,IP67,,false,2023
 hikvision-ds-2cd6365g0e-ivs,Hikvision,DS-2CD6365G0E-IVS,fisheye,6MP 360°,6,,360 fisheye,ir,IP66,,false,2020
-hikvision-ds-2cd6365g1-ivs,Hikvision,DS-2CD6365G1-IVS,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,true,2023
-hikvision-ds-2cd6365g1-s-rc,Hikvision,DS-2CD6365G1-S/RC,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",,none,,,false,2023
+hikvision-ds-2cd6365g1-ivs,Hikvision,DS-2CD6365G1-IVS,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",180 horizontal / 180 vertical,ir,IP67,IK10,true,2023
+hikvision-ds-2cd6365g1-s-rc,Hikvision,DS-2CD6365G1-S/RC,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",180 horizontal / 180 vertical,none,,,false,2023
 hikvision-ds-2cd63c5g1-ivs,Hikvision,DS-2CD63C5G1-IVS,fisheye,12MP UHD,12,"1/1.7"" Progressive Scan CMOS",360,ir,IP66,IK10,true,
-hikvision-ds-2cd63c5g1-s-rc,Hikvision,DS-2CD63C5G1-S/RC,fisheye,12MP fisheye,12,"1/1.8"" Progressive Scan CMOS",,none,,,false,2023
+hikvision-ds-2cd63c5g1-s-rc,Hikvision,DS-2CD63C5G1-S/RC,fisheye,12MP fisheye,12,"1/1.8"" Progressive Scan CMOS",180 horizontal / 180 vertical,none,,,false,2023
 hikvision-ds-2cd6944g0-ihs,Hikvision,DS-2CD6944G0-IHS,panoramic,16MP (4×4MP multisensor),16,,180h,none,IP66,,false,2021
-hikvision-ds-2cd6w65g1-ivs,Hikvision,DS-2CD6W65G1-IVS,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,true,2023
+hikvision-ds-2cd6w65g1-ivs,Hikvision,DS-2CD6W65G1-IVS,fisheye,6MP fisheye,6,"1/1.8"" Progressive Scan CMOS",180 horizontal / 180 vertical,ir,IP67,IK10,true,2023
 hikvision-ds-2cd7a87g0-xzs,Hikvision,DS-2CD7A87G0-XZS,bullet,4K UHD,8,,106-32h,color,IP67,,false,2022
 hikvision-ds-2ce16d0t-exif,Hikvision,DS-2CE16D0T-EXIF,bullet,1080p,2,2MP CMOS,96.5 horizontal (2.8mm) / 76.9 horizontal (3.6mm),ir,IP67,,false,
 hikvision-ds-2ce16d0t-it3e,Hikvision,DS-2CE16D0T-IT3E,bullet,1080p HD,2,2MP Progressive Scan CMOS,103.55-24.36 horizontal (2.8mm-12mm options),ir,IP67,,false,2023

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1477,41 +1477,41 @@ hifocus-hipc-t4512-adls-i2,Hi-Focus,HIPC-T4512-ADLS-I2,turret,4MP,4,"1/3"" CMOS"
 hifocus-hipc-t4515-adls-i2,Hi-Focus,HIPC-T4515-ADLS-I2,turret,5MP,5,"1/2.7"" Sony CMOS",102.9,hybrid,IP67,,true,
 hifocus-hipc-t4804-dls-r1,Hi-Focus,HIPC-T4804-DLS-R1,bullet,4MP,4,"1/3"" CMOS",,hybrid,IP67,,true,
 hifocus-hipc-t4815-kdls-i2,Hi-Focus,HIPC-T4815-KDLS-I2,turret,5MP,5,"1/2.7"" Sony CMOS",102.9,hybrid,IP67,,true,
-hikvision-ds-2ae4215itg,Hikvision,DS-2AE4215ITG,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae4215tg,Hikvision,DS-2AE4215TG,ptz,1080p,2,"1/2.8"" CMOS",,none,IP66,,false,
-hikvision-ds-2ae4215tg-3,Hikvision,DS-2AE4215TG-3,ptz,1080p,2,"1/2.8"" CMOS",,none,,,false,
-hikvision-ds-2ae4225itg,Hikvision,DS-2AE4225ITG,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae4225tg,Hikvision,DS-2AE4225TG,ptz,1080p,2,"1/2.8"" CMOS",,none,IP66,,false,
-hikvision-ds-2ae4225tg-3,Hikvision,DS-2AE4225TG-3,ptz,1080p,2,"1/2.8"" CMOS",,none,,,false,
-hikvision-ds-2ae4425itg,Hikvision,DS-2AE4425ITG,ptz,4MP,4,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae5225itg,Hikvision,DS-2AE5225ITG,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae5225tg,Hikvision,DS-2AE5225TG,ptz,1080p,2,"1/2.8"" CMOS",,none,IP66,IK10,false,
-hikvision-ds-2ae5232itg,Hikvision,DS-2AE5232ITG,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae5232tg,Hikvision,DS-2AE5232TG,ptz,1080p,2,"1/2.8"" CMOS",,none,IP66,IK10,false,
-hikvision-ds-2ae5425itg,Hikvision,DS-2AE5425ITG,ptz,4MP,4,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2ae7232itg,Hikvision,DS-2AE7232ITG,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
+hikvision-ds-2ae4215itg,Hikvision,DS-2AE4215ITG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,ir,IP66,,false,
+hikvision-ds-2ae4215tg,Hikvision,DS-2AE4215TG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,none,IP66,,false,
+hikvision-ds-2ae4215tg-3,Hikvision,DS-2AE4215TG-3,ptz,1080p,2,"1/2.8"" CMOS",57.6h,none,,,false,
+hikvision-ds-2ae4225itg,Hikvision,DS-2AE4225ITG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,ir,IP66,,false,
+hikvision-ds-2ae4225tg,Hikvision,DS-2AE4225TG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,none,IP66,,false,
+hikvision-ds-2ae4225tg-3,Hikvision,DS-2AE4225TG-3,ptz,1080p,2,"1/2.8"" CMOS",57.6h,none,,,false,
+hikvision-ds-2ae4425itg,Hikvision,DS-2AE4425ITG,ptz,4MP,4,"1/2.8"" CMOS",55h,ir,IP66,,false,
+hikvision-ds-2ae5225itg,Hikvision,DS-2AE5225ITG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,ir,IP66,,false,
+hikvision-ds-2ae5225tg,Hikvision,DS-2AE5225TG,ptz,1080p,2,"1/2.8"" CMOS",57.6h,none,IP66,IK10,false,
+hikvision-ds-2ae5232itg,Hikvision,DS-2AE5232ITG,ptz,1080p,2,"1/2.8"" CMOS",55h,ir,IP66,,false,
+hikvision-ds-2ae5232tg,Hikvision,DS-2AE5232TG,ptz,1080p,2,"1/2.8"" CMOS",55h,none,IP66,IK10,false,
+hikvision-ds-2ae5425itg,Hikvision,DS-2AE5425ITG,ptz,4MP,4,"1/2.8"" CMOS",55h,ir,IP66,,false,
+hikvision-ds-2ae7232itg,Hikvision,DS-2AE7232ITG,ptz,1080p,2,"1/2.8"" CMOS",55 horizontal/33 vertical/61.5 diagonal (wide end),ir,IP66,,false,
 hikvision-ds-2cc12d9t-a,Hikvision,DS-2CC12D9T-A,box,1080p,2,"1/3"" 2MP ultra-low-light CMOS",,none,,,false,
 hikvision-ds-2cc12d9t-ait3ze,Hikvision,DS-2CC12D9T-AIT3ZE,bullet,1080p,2,2MP ultra-low-light CMOS,32.1-98,ir,IP67,,false,
 hikvision-ds-2cd1023g0e-i,Hikvision,DS-2CD1023G0E-I,bullet,1080p,2,"1/2.7"" Progressive Scan CMOS",112.1 horizontal (2.8mm) / 90.2 horizontal (4mm),ir,IP67,,false,
 hikvision-ds-2cd1023g2-iuf,Hikvision,DS-2CD1023G2-IUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",104° (2.8mm)/81° (4mm) horizontal,ir,IP67,,false,2023
 hikvision-ds-2cd1023g2-liu,Hikvision,DS-2CD1023G2-LIU,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",107 horizontal,hybrid,IP67,,false,2023
-hikvision-ds-2cd1023g2-liuf,Hikvision,DS-2CD1023G2-LIUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",,hybrid,IP67,,false,2023
+hikvision-ds-2cd1023g2-liuf,Hikvision,DS-2CD1023G2-LIUF,bullet,1080p,2,"1/2.9"" Progressive Scan CMOS",103 (2.8mm)/83 (4mm) horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1027g2h-liu,Hikvision,DS-2CD1027G2H-LIU(F),bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",115 horizontal (2.8mm) / 94 horizontal (4mm),hybrid,IP67,,false,
-hikvision-ds-2cd1027g2h-liuf,Hikvision,DS-2CD1027G2H-LIUF,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",,hybrid,IP67,,false,2023
-hikvision-ds-2cd1043g2-iuf,Hikvision,DS-2CD1043G2-IUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",,ir,IP67,,false,2023
+hikvision-ds-2cd1027g2h-liuf,Hikvision,DS-2CD1027G2H-LIUF,bullet,1080p,2,"1/2.8"" Progressive Scan CMOS",115 (2.8mm)/94 (4mm) horizontal,hybrid,IP67,,false,2023
+hikvision-ds-2cd1043g2-iuf,Hikvision,DS-2CD1043G2-IUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",99 (2.8mm)/76 (4mm) horizontal,ir,IP67,,false,2023
 hikvision-ds-2cd1043g2-liu,Hikvision,DS-2CD1043G2-LIU,bullet,4MP,4,"1/3"" Progressive Scan CMOS",106 horizontal,hybrid,IP67,,false,2023
-hikvision-ds-2cd1043g2-liuf,Hikvision,DS-2CD1043G2-LIUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",,hybrid,IP67,,false,2023
+hikvision-ds-2cd1043g2-liuf,Hikvision,DS-2CD1043G2-LIUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",98 (2.8mm)/78 (4mm) horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1047g0-luf,Hikvision,DS-2CD1047G0-LUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",96.5 (2.8mm)/75.8 (4mm) horizontal,color,IP67,,false,2023
 hikvision-ds-2cd1047g2h-liuf,Hikvision,DS-2CD1047G2H-LIUF,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",115 (2.8mm)/94 (4mm) horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1067g2h-liuf,Hikvision,DS-2CD1067G2H-LIUF,bullet,6MP (3200x1800),6,"1/2.4"" Progressive Scan CMOS",115 (2.8mm)/94 (4mm) horizontal,hybrid,IP67,,false,2023
 hikvision-ds-2cd1123g2-i,Hikvision,DS-2CD1123G2-I,dome,1080p (2MP),2,"1/2.9"" Progressive Scan CMOS",104 (2.8mm)/81 (4mm) horizontal,ir,IP67,IK10,false,2023
-hikvision-ds-2cd1123g2-liu,Hikvision,DS-2CD1123G2-LIU,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",107 horizontal,hybrid,IP67,,false,2023
+hikvision-ds-2cd1123g2-liu,Hikvision,DS-2CD1123G2-LIU,dome,1080p,2,"1/2.8"" Progressive Scan CMOS",107 horizontal,hybrid,IP67,IK08,false,2023
 hikvision-ds-2cd1123g2-liuf,Hikvision,DS-2CD1123G2-LIUF,dome,1080p (2MP),2,"1/2.9"" Progressive Scan CMOS",103 (2.8mm)/83 (4mm) horizontal,hybrid,IP67,IK08,false,2023
 hikvision-ds-2cd1127g0-luf-d,Hikvision,DS-2CD1127G0-LUF-D,dome,1080p (2MP),2,"1/2.8"" Progressive Scan CMOS",105 (2.8mm)/83 (4mm) horizontal,color,IP67,IK08,false,2023
 hikvision-ds-2cd1127g2h-liuf,Hikvision,DS-2CD1127G2H-LIUF,dome,1080p (2MP),2,"1/2.8"" Progressive Scan CMOS",106 (2.8mm)/88 (4mm) horizontal,hybrid,IP67,IK08,false,2023
 hikvision-ds-2cd1143g2-i,Hikvision,DS-2CD1143G2-I,dome,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",99 (2.8mm)/76 (4mm) horizontal,ir,IP67,IK10,false,2023
 hikvision-ds-2cd1143g2-iuf,Hikvision,DS-2CD1143G2-IUF,dome,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",99 (2.8mm)/76 (4mm) horizontal,ir,IP67,IK10,false,2023
-hikvision-ds-2cd1143g2-liu,Hikvision,DS-2CD1143G2-LIU,dome,4MP,4,"1/3"" Progressive Scan CMOS",106 horizontal,hybrid,IP67,,false,2023
+hikvision-ds-2cd1143g2-liu,Hikvision,DS-2CD1143G2-LIU,dome,4MP,4,"1/3"" Progressive Scan CMOS",106 horizontal,hybrid,IP67,IK08,false,2023
 hikvision-ds-2cd1143g2-liuf,Hikvision,DS-2CD1143G2-LIUF,dome,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",98 (2.8mm)/78 (4mm) horizontal,hybrid,IP67,IK08,false,2023
 hikvision-ds-2cd1143g2-liuf-india,Hikvision,DS-2CD1143G2-LIUF (India),dome,4MP,4,"1/3"" CMOS",106 horizontal,hybrid,IP67,IK10,false,2023
 hikvision-ds-2cd1143g2-liuf-n,Hikvision,DS-2CD1143G2-LIUF,turret,4MP,4,,107h,hybrid,IP67,,false,2023

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1847,59 +1847,59 @@ hikvision-ds-2ce76u0t-itpf,Hikvision,DS-2CE76U0T-ITPF,turret,4K/8MP,8,8.29MP CMO
 hikvision-ds-2ce78d0t-lfs,Hikvision,DS-2CE78D0T-LFS,turret,1080p,2,2MP CMOS,100 / 80,hybrid,IP67,,false,
 hikvision-ds-2ce78k0t-lfs,Hikvision,DS-2CE78K0T-LFS,turret,3K (~5MP),5,3K CMOS,104.9 / 81.3,hybrid,IP67,,false,
 hikvision-ds-2ce78u0t-it3f,Hikvision,DS-2CE78U0T-IT3F,turret,4K/8MP,8,8.29MP CMOS,102.9 / 79 / 44.7,ir,IP67,,false,
-hikvision-ds-2cv2041g2-idw,Hikvision,DS-2CV2041G2-IDW,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",,ir,IP66,,true,2023
-hikvision-ds-2cv2141g2-idw-e,Hikvision,DS-2CV2141G2-IDW-E,dome,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",,ir,IP66,,true,2023
-hikvision-ds-2cv2q21g1-idw,Hikvision,DS-2CV2Q21G1-IDW,box,1080p,2,"1/3"" Progressive Scan CMOS",75° (H),ir,,,true,2023
+hikvision-ds-2cv2041g2-idw,Hikvision,DS-2CV2041G2-IDW,bullet,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",97 / 82,ir,IP66,,true,2023
+hikvision-ds-2cv2141g2-idw-e,Hikvision,DS-2CV2141G2-IDW-E,dome,4MP (2560x1440),4,"1/3"" Progressive Scan CMOS",95 / 79,ir,IP66,,true,2023
+hikvision-ds-2cv2q21g1-idw,Hikvision,DS-2CV2Q21G1-IDW,box,1080p,2,"1/3"" Progressive Scan CMOS",75 (H),ir,,,true,2023
 hikvision-ds-2de2a204iw-de3-w,Hikvision,DS-2DE2A204IW-DE3/W,ptz,1080p,2,"1/2.7"" Progressive Scan CMOS",103-29 horizontal,ir,IP66,,true,
-hikvision-ds-2de2a404iw-de3-ws6,Hikvision,DS-2DE2A404IW-DE3/WS6,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",96.7°-31.6° horizontal,ir,IP66,IK10,false,2023
-hikvision-ds-2de2a404iw-de3s6,Hikvision,DS-2DE2A404IW-DE3S6,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2de2c400iwg,Hikvision,DS-2DE2C400IWG,ptz,4MP (2560x1440),4,"1/2.9"" Progressive Scan CMOS",,ir,IP66,,true,2023
-hikvision-ds-2de3404w-det5,Hikvision,DS-2DE3404W-DET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",,none,IP66,,false,2023
+hikvision-ds-2de2a404iw-de3-ws6,Hikvision,DS-2DE2A404IW-DE3/WS6,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",96.7-31.6 horizontal,ir,IP66,IK10,false,2023
+hikvision-ds-2de2a404iw-de3s6,Hikvision,DS-2DE2A404IW-DE3S6,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",96.7-31.6 horizontal,ir,IP66,IK10,false,2023
+hikvision-ds-2de2c400iwg,Hikvision,DS-2DE2C400IWG,ptz,4MP (2560x1440),4,"1/2.9"" Progressive Scan CMOS",91 horizontal (2.8mm) / 74 horizontal (4mm),ir,IP66,,true,2023
+hikvision-ds-2de3404w-det5,Hikvision,DS-2DE3404W-DET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",93.8-31.7 horizontal,none,IP66,,false,2023
 hikvision-ds-2de3a400bw-de,Hikvision,DS-2DE3A400BW-DE,ptz,4MP,4,"1/1.8"" Progressive Scan CMOS",103-31 horizontal,color,IP66,,true,
-hikvision-ds-2de3a400bw-de-wt5,Hikvision,DS-2DE3A400BW-DE/WT5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",,color,IP66,,true,2023
-hikvision-ds-2de3a400bw-det5,Hikvision,DS-2DE3A400BW-DET5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",,color,IP66,,true,2023
+hikvision-ds-2de3a400bw-de-wt5,Hikvision,DS-2DE3A400BW-DE/WT5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",88.7 horizontal,color,IP66,,true,2023
+hikvision-ds-2de3a400bw-det5,Hikvision,DS-2DE3A400BW-DET5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",88.7 horizontal,color,IP66,,true,2023
 hikvision-ds-2de3a400bwg-e,Hikvision,DS-2DE3A400BWG-E,ptz,4MP,4,"1/1.8"" Progressive Scan CMOS",103-31 horizontal,color,IP66,,true,
-hikvision-ds-2de3a404iwg-e,Hikvision,DS-2DE3A404IWG-E,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",,ir,IP66,,true,2023
+hikvision-ds-2de3a404iwg-e,Hikvision,DS-2DE3A404IWG-E,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",96.7-31.6 horizontal,ir,IP66,,true,2023
 hikvision-ds-2de3a404iwg-e-w,Hikvision,DS-2DE3A404IWG-E/W,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",96.7-31.6 horizontal,ir,IP66,,true,2023
-hikvision-ds-2de4215iw-det5,Hikvision,DS-2DE4215IW-DET5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",57.6°-4° (H),ir,IP66,,false,2023
-hikvision-ds-2de4225iw-det5,Hikvision,DS-2DE4225IW-DET5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP66,,false,2023
+hikvision-ds-2de4215iw-det5,Hikvision,DS-2DE4215IW-DET5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",57.6-4 (H),ir,IP66,,false,2023
+hikvision-ds-2de4225iw-det5,Hikvision,DS-2DE4225IW-DET5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",57.6-2.5 horizontal,ir,IP66,,false,2023
 hikvision-ds-2de4425iw-de,Hikvision,DS-2DE4425IW-DE,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",59.5-2.6 horizontal (wide-tele),ir,IP66,,false,
 hikvision-ds-2de4425iw-de-t5-india,Hikvision,DS-2DE4425IWG-E,ptz,4MP,4,"1/2.8"" CMOS",58-2.8 horizontal (25x zoom),ir,IP66,,false,2022
-hikvision-ds-2de4425iw-det5,Hikvision,DS-2DE4425IW-DET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",55°-2.4° horizontal,ir,IP66,,false,2023
-hikvision-ds-2de4825wg-e3,Hikvision,DS-2DE4825WG-E3,ptz,4K,8,"1/1.8"" CMOS",,color,IP54,,false,
-hikvision-ds-2de4a225iw-de,Hikvision,DS-2DE4A225IW-DE,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2de4a225iw-des6,Hikvision,DS-2DE4A225IW-DES6,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP66,,false,2023
-hikvision-ds-2de4a225iwg-e,Hikvision,DS-2DE4A225IWG-E,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP66,,false,
-hikvision-ds-2de4a225iwg1-e,Hikvision,DS-2DE4A225IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,,false,
+hikvision-ds-2de4425iw-det5,Hikvision,DS-2DE4425IW-DET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",55-2.4 horizontal,ir,IP66,,false,2023
+hikvision-ds-2de4825wg-e3,Hikvision,DS-2DE4825WG-E3,ptz,4K,8,"1/1.8"" CMOS",58.5-3.7 horizontal,color,IP54,,false,
+hikvision-ds-2de4a225iw-de,Hikvision,DS-2DE4A225IW-DE,ptz,1080p,2,"1/2.8"" CMOS",54.9 H / 31.5 V / 62.3 D,ir,IP66,,false,
+hikvision-ds-2de4a225iw-des6,Hikvision,DS-2DE4A225IW-DES6,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",54.9 H / 31.5 V / 62.3 D,ir,IP66,,false,2023
+hikvision-ds-2de4a225iwg-e,Hikvision,DS-2DE4A225IWG-E,ptz,1080p,2,"1/2.8"" CMOS",54.9 H / 31.5 V / 62.3 D,ir,IP66,,false,
+hikvision-ds-2de4a225iwg1-e,Hikvision,DS-2DE4A225IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",54.9 H / 31.5 V / 62.3 D,ir,IP67,,false,
 hikvision-ds-2de4a404iwg-e,Hikvision,DS-2DE4A404IWG-E,ptz,4MP,4,"1/3"" CMOS",94-28 horizontal,ir,IP66,,false,2022
-hikvision-ds-2de4a425iw-de,Hikvision,DS-2DE4A425IW-DE,ptz,4MP,4,"1/2.8"" CMOS",,ir,IP66,,false,
+hikvision-ds-2de4a425iw-de,Hikvision,DS-2DE4A425IW-DE,ptz,4MP,4,"1/2.8"" CMOS",53.3 H / 30.6 V / 60.5 D,ir,IP66,,false,
 hikvision-ds-2de4a425iwg-e,Hikvision,DS-2DE4A425IWG-E,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",59.5-2.6 horizontal,ir,IP66,,false,
-hikvision-ds-2de4a425iwg1-e,Hikvision,DS-2DE4A425IWG1-E,ptz,4MP,4,"1/2.8"" CMOS",,ir,IP67,,false,
-hikvision-ds-2de5225w-ae3t5,Hikvision,DS-2DE5225W-AE3T5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",,none,,IK10,false,2023
-hikvision-ds-2de5425iw-aet5,Hikvision,DS-2DE5425IW-AET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",,ir,IP66,,false,2023
+hikvision-ds-2de4a425iwg1-e,Hikvision,DS-2DE4A425IWG1-E,ptz,4MP,4,"1/2.8"" CMOS",53.3 H / 30.6 V / 60.5 D,ir,IP67,,false,
+hikvision-ds-2de5225w-ae3t5,Hikvision,DS-2DE5225W-AE3T5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",57.6 H / 34.4 V / 64.5 D,none,,IK10,false,2023
+hikvision-ds-2de5425iw-aet5,Hikvision,DS-2DE5425IW-AET5,ptz,4MP (2560x1440),4,"1/2.8"" Progressive Scan CMOS",55 H / 33 V / 61.5 D,ir,IP66,,false,2023
 hikvision-ds-2de5a425iwg-e,Hikvision,DS-2DE5A425IWG-E,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",59.5-2.6 horizontal,ir,IP66,,false,
 hikvision-ds-2de5a425iwg-eb,Hikvision,DS-2DE5A425IWG-E(B),ptz,4MP,4,"1/2.8"" CMOS",60-2.5h,ir,IP66,,false,2022
-hikvision-ds-2de7a225iw-aebt5,Hikvision,DS-2DE7A225IW-AEBT5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2de7a225iwg-eb-sl,Hikvision,DS-2DE7A225IWG-EB/SL,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,IK10,false,
-hikvision-ds-2de7a225iwg1-e,Hikvision,DS-2DE7A225IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,IK10,true,
-hikvision-ds-2de7a232iw-aebt5,Hikvision,DS-2DE7A232IW-AEBT5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2de7a232iwg-eb-sl,Hikvision,DS-2DE7A232IWG-EB/SL,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,IK10,false,
-hikvision-ds-2de7a232iwg1-e,Hikvision,DS-2DE7A232IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,IK10,true,
-hikvision-ds-2de7a425iwg-eb-sl,Hikvision,DS-2DE7A425IWG-EB/SL,ptz,4MP,4,"1/2.8"" CMOS",,ir,IP67,IK10,true,
+hikvision-ds-2de7a225iw-aebt5,Hikvision,DS-2DE7A225IW-AEBT5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",57.6 H / 34.4 V / 64.5 D,ir,IP66,IK10,false,2023
+hikvision-ds-2de7a225iwg-eb-sl,Hikvision,DS-2DE7A225IWG-EB/SL,ptz,1080p,2,"1/2.8"" CMOS",57.6 H / 34.4 V / 64.5 D,ir,IP67,IK10,false,
+hikvision-ds-2de7a225iwg1-e,Hikvision,DS-2DE7A225IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",55 H / 33 V / 61.5 D,ir,IP67,IK10,true,
+hikvision-ds-2de7a232iw-aebt5,Hikvision,DS-2DE7A232IW-AEBT5,ptz,1080p,2,"1/2.8"" Progressive Scan CMOS",50.8 H / 29.4 V / 57.4 D,ir,IP66,IK10,false,2023
+hikvision-ds-2de7a232iwg-eb-sl,Hikvision,DS-2DE7A232IWG-EB/SL,ptz,1080p,2,"1/2.8"" CMOS",55 horizontal/33 vertical/62.4 diagonal (wide end),ir,IP67,IK10,false,
+hikvision-ds-2de7a232iwg1-e,Hikvision,DS-2DE7A232IWG1-E,ptz,1080p,2,"1/2.8"" CMOS",55 horizontal/33 vertical/61.5 diagonal (wide end),ir,IP67,IK10,true,
+hikvision-ds-2de7a425iwg-eb-sl,Hikvision,DS-2DE7A425IWG-EB/SL,ptz,4MP,4,"1/2.8"" CMOS",55 horizontal/33 vertical/61.5 diagonal (wide end),ir,IP67,IK10,true,
 hikvision-ds-2de7a432iw-aeb,Hikvision,DS-2DE7A432IW-AEB,ptz,4MP,4,"1/2.8"" Progressive Scan CMOS",60.6-2.4 horizontal,ir,IP66,IK10,true,2023
-hikvision-ds-2de7a432iw-aebt5,Hikvision,DS-2DE7A432IW-AEBT5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",,ir,IP66,IK10,false,2023
-hikvision-ds-2de7a632iwg1-e,Hikvision,DS-2DE7A632IWG1-E,ptz,6MP,6,"1/2.5"" CMOS",,ir,IP67,IK10,true,
-hikvision-ds-2de7a825iwg1-e,Hikvision,DS-2DE7A825IWG1-E,ptz,4K/8MP,8,"1/1.8"" CMOS",,ir,IP67,IK10,true,
+hikvision-ds-2de7a432iw-aebt5,Hikvision,DS-2DE7A432IW-AEBT5,ptz,4MP (2560x1440),4,"1/1.8"" Progressive Scan CMOS",50.8 horizontal/29.4 vertical/57.4 diagonal (wide end),ir,IP66,IK10,false,2023
+hikvision-ds-2de7a632iwg1-e,Hikvision,DS-2DE7A632IWG1-E,ptz,6MP,6,"1/2.5"" CMOS",60.7 horizontal/35.9 vertical/68.4 diagonal (wide end),ir,IP67,IK10,true,
+hikvision-ds-2de7a825iwg1-e,Hikvision,DS-2DE7A825IWG1-E,ptz,4K/8MP,8,"1/1.8"" CMOS",55.3 horizontal/32.2 vertical/62.3 diagonal (wide end),ir,IP67,IK10,true,
 hikvision-ds-2pt3q27iwx-de,Hikvision,DS-2PT3Q27IWX-DE,dual-lens,4MP panoramic + 2MP PTZ,8,"1/2.7"" CMOS + 1/2.8"" CMOS",180 panoramic + 94-28 PTZ,ir,IP66,,false,2023
-hikvision-ds-2se4c215mwg-e,Hikvision,DS-2SE4C215MWG-E,ptz,1080p (dual-channel),2,"1/2.8"" CMOS (dual-channel)",,hybrid,IP66,,false,
-hikvision-ds-2se4c225mwg-e,Hikvision,DS-2SE4C225MWG-E,ptz,1080p (2MP PTZ) + 6MP ColorVu bullet,2,"1/2.8"" + 1/2.5"" CMOS (dual-channel)",,hybrid,IP66,,false,
-hikvision-ds-2se4c425mwg-4g,Hikvision,DS-2SE4C425MWG-4G,ptz,4MP,4,"1/2.8"" CMOS (dual-channel)",,hybrid,IP67,,true,
+hikvision-ds-2se4c215mwg-e,Hikvision,DS-2SE4C215MWG-E,ptz,1080p (dual-channel),2,"1/2.8"" CMOS (dual-channel)",54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end),hybrid,IP66,,false,
+hikvision-ds-2se4c225mwg-e,Hikvision,DS-2SE4C225MWG-E,ptz,1080p (2MP PTZ) + 6MP ColorVu bullet,2,"1/2.8"" + 1/2.5"" CMOS (dual-channel)",54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end),hybrid,IP66,,false,
+hikvision-ds-2se4c425mwg-4g,Hikvision,DS-2SE4C425MWG-4G,ptz,4MP,4,"1/2.8"" CMOS (dual-channel)",55 horizontal/33 vertical/61.5 diagonal (PTZ channel wide end),hybrid,IP67,,true,
 hikvision-ds-2se4c425mwg-e,Hikvision,DS-2SE4C425MWG-E,ptz,4MP+4MP TandemVu,4,Dual CMOS,60-2.5h,color,IP66,,false,2023
 hikvision-ds-2se4c430mwg-e,Hikvision,DS-2SE4C430MWG-E,ptz,4MP+4MP TandemVu 30x,4,Dual CMOS,60-2h,ir,IP66,,false,2023
-hikvision-ds-2se7c432mwg-eb,Hikvision,DS-2SE7C432MWG-EB,panoramic,6MP panoramic + 4MP 32x PTZ,6,"1/2.5"" + 1/2.8"" CMOS (dual-channel)",,hybrid,IP66,,true,
+hikvision-ds-2se7c432mwg-eb,Hikvision,DS-2SE7C432MWG-EB,panoramic,6MP panoramic + 4MP 32x PTZ,6,"1/2.5"" + 1/2.8"" CMOS (dual-channel)",60.2 horizontal/35.2 vertical (PTZ channel wide end),hybrid,IP66,,true,
 hikvision-ds-2sf7c425mxg2-lm-el,Hikvision,DS-2SF7C425MXG2/LM-EL,ptz,6MP panoramic + 4MP 25x PTZ (TandemVu),10,"1/2.5"" CMOS (panoramic channel) + 1/1.8"" CMOS (PTZ channel)",190 horizontal (panoramic) / 60.2-2.3 horizontal (PTZ),hybrid,IP67,IK10,false,2026
-hikvision-ds-2sf8c442mxg1-elw,Hikvision,DS-2SF8C442MXG1-ELW,panoramic,6MP panoramic + 4MP 42x PTZ,6,"1/2.5"" + 1/1.8"" CMOS (dual-channel)",,hybrid,IP67,IK10,true,
-hikvision-ds-2sf8c848mxg1-elw,Hikvision,DS-2SF8C848MXG1-ELW,panoramic,6MP panoramic + 8MP 48x laser PTZ,8,"1/2.5"" + 1/1.2"" CMOS (dual-channel)",,hybrid,IP67,IK10,true,
+hikvision-ds-2sf8c442mxg1-elw,Hikvision,DS-2SF8C442MXG1-ELW,panoramic,6MP panoramic + 4MP 42x PTZ,6,"1/2.5"" + 1/1.8"" CMOS (dual-channel)",59 horizontal/34.2 vertical/67.1 diagonal (PTZ channel wide end),hybrid,IP67,IK10,true,
+hikvision-ds-2sf8c848mxg1-elw,Hikvision,DS-2SF8C848MXG1-ELW,panoramic,6MP panoramic + 8MP 48x laser PTZ,8,"1/2.5"" + 1/1.2"" CMOS (dual-channel)",58.5 horizontal/34 vertical/65.8 diagonal (PTZ channel wide end),hybrid,IP67,IK10,true,
 hikvision-ds-2xs6a25g0-i,Hikvision,DS-2XS6A25G0-I/CH20S40,bullet,1080p HD,2,,103h,ir,IP67,,false,2022
 hikvision-ids-2cd7a46g0-p-izhs-y,Hikvision,iDS-2CD7A46G0/P-IZHS(Y),bullet,4MP,4,"1/1.8"" Progressive Scan CMOS","114.5-41.8 horizontal (2.8-12mm), 42.5-15.1 (8-32mm)",ir,IP67,IK10,true,
 hilook-ipc-b129haa-lu,HiLook,IPC-B129HAA-LU,bullet,1080p,2,"1/2.8"" CMOS",106 (2.8mm) / 88 (4mm),hybrid,IP67,,true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -177104,7 +177104,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC / PoC.af"
@@ -177136,10 +177137,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "93 / 77",
     "ip_rating": "IP67",
+    "dimensions_mm": "158.6 x Ø70",
+    "weight_g": 337,
     "added": "2026-07-06"
   },
   {
@@ -177264,7 +177267,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177295,7 +177299,9 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "138.8 x Ø70",
+    "weight_g": 270,
     "added": "2026-07-06"
   },
   {
@@ -177320,7 +177326,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 25,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177350,10 +177357,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x Ø70",
+    "weight_g": 160,
     "added": "2026-07-06"
   },
   {
@@ -177436,7 +177445,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177469,10 +177479,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "58 x 61 x 158.6",
+    "weight_g": 175,
     "added": "2026-07-06"
   },
   {
@@ -177497,7 +177509,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177527,10 +177540,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78 / 49.2",
     "ip_rating": "IP67",
+    "dimensions_mm": "216.6 x 78.9 x 75.4",
+    "weight_g": 339,
     "added": "2026-07-06"
   },
   {
@@ -177555,7 +177570,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177585,10 +177601,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 (2.8mm)",
     "ip_rating": "IP67",
+    "dimensions_mm": "216.6 x 78.9 x 75.4",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -177613,7 +177631,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 60,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177644,10 +177663,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3 / 51.8",
     "ip_rating": "IP67",
+    "dimensions_mm": "192.6 x 178.3 x 71",
+    "weight_g": 740,
     "added": "2026-07-06"
   },
   {
@@ -177671,7 +177692,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC / PoC.at"
@@ -177703,10 +177725,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "95-26",
     "ip_rating": "IP67",
+    "dimensions_mm": "84.5 x 92 x 255.1",
+    "weight_g": 677,
     "added": "2026-07-06"
   },
   {
@@ -177730,7 +177754,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177763,10 +177788,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP progressive-scan CMOS",
     "field_of_view_deg": "108.1-45.6",
     "ip_rating": "IP67",
+    "dimensions_mm": "84.5 x 92 x 255.1",
+    "weight_g": 695,
     "added": "2026-07-06"
   },
   {
@@ -177851,7 +177878,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177883,11 +177911,13 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 365,
     "added": "2026-07-06"
   },
   {
@@ -177912,7 +177942,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177942,10 +177973,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "80 x Ø85.1",
+    "weight_g": 296,
     "added": "2026-07-06"
   },
   {
@@ -178000,9 +178033,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
+    "dimensions_mm": "84.6 x Ø85.02",
+    "weight_g": 156,
     "added": "2026-07-06"
   },
   {
@@ -178077,7 +178112,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178107,10 +178143,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "80 x Ø85.1",
+    "weight_g": 300,
     "added": "2026-06-06"
   },
   {
@@ -178135,7 +178173,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178165,9 +178204,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
+    "dimensions_mm": "84.6 x Ø85.02",
+    "weight_g": 160,
     "added": "2026-07-06"
   },
   {
@@ -178191,7 +178232,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178224,10 +178266,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "82.6 x 90 x 79.37",
+    "weight_g": 300,
     "added": "2026-07-06"
   },
   {
@@ -178251,7 +178295,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178284,9 +178329,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
+    "dimensions_mm": "Ø84.6 x 78.9",
+    "weight_g": 150,
     "added": "2026-07-06"
   },
   {
@@ -178311,7 +178358,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178341,10 +178389,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "100 / 80",
     "ip_rating": "IP67",
+    "dimensions_mm": "97.9 x Ø110",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -178369,7 +178419,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178399,10 +178450,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "97.9 x Ø110",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -178426,7 +178479,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178458,10 +178512,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø109.82 x 91.03",
+    "weight_g": 315,
     "added": "2026-07-06"
   },
   {
@@ -178487,7 +178543,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.5
     },
     "power": {
       "method": "DC 12V"
@@ -178551,14 +178608,23 @@
           "resolution": "2560x1440",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "768x432",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "97 / 82",
+    "dimensions_mm": "175.6 x 73 x 89.1",
+    "weight_g": 345,
     "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR.",
     "added": "2026-07-07"
   },
@@ -178585,7 +178651,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V"
@@ -178649,14 +178716,23 @@
           "resolution": "2560x1440",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "95 / 79",
+    "dimensions_mm": "Ø126 x 96.1",
+    "weight_g": 590,
     "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR.",
     "added": "2026-07-07"
   },
@@ -178683,7 +178759,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.05
     },
     "power": {
       "method": "DC 12V"
@@ -178749,14 +178826,22 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "768x432",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
-    "field_of_view_deg": "75° (H)",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "75 (H)",
+    "dimensions_mm": "Ø80 x 122",
+    "weight_g": 216,
     "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor).",
     "added": "2026-07-07"
   },
@@ -178872,7 +178957,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -178950,10 +179036,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "96.7°-31.6° horizontal",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "Ø130.7 x 101.7",
+    "weight_g": 530,
     "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°.",
     "added": "2026-07-07"
   },
@@ -178979,7 +179067,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179057,9 +179146,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "Ø130.7 x 101.7",
+    "weight_g": 530,
     "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic.",
     "added": "2026-07-07"
   },
@@ -179086,7 +179178,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "DC 12V"
@@ -179158,8 +179251,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "91 horizontal (2.8mm) / 74 horizontal (4mm)",
+    "dimensions_mm": "163.9 x 185.8 x 131.9",
+    "weight_g": 565,
     "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V.",
     "added": "2026-07-07"
   },
@@ -179184,7 +179280,8 @@
       "varifocal": false
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179260,8 +179357,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "93.8-31.7 horizontal",
+    "dimensions_mm": "Ø140.7 x 107.2",
+    "weight_g": 950,
     "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR).",
     "added": "2026-07-07"
   },
@@ -179453,8 +179553,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "88.7 horizontal",
+    "dimensions_mm": "179.3 x 120 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light.",
     "added": "2026-07-07"
   },
@@ -179555,8 +179658,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "88.7 horizontal",
+    "dimensions_mm": "179.3 x 120 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light.",
     "added": "2026-07-07"
   },
@@ -179676,7 +179782,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179753,8 +179860,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "179.3 x 120.5 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR.",
     "added": "2026-07-07"
   },
@@ -179785,7 +179895,8 @@
     "field_of_view_deg": "96.7-31.6 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179862,7 +179973,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "179.3 x 120.5 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR).",
     "added": "2026-07-07"
   },
@@ -179888,7 +180001,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179966,9 +180080,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "field_of_view_deg": "57.6°-4° (H)",
+    "field_of_view_deg": "57.6-4 (H)",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°.",
     "added": "2026-07-07"
   },
@@ -179994,7 +180110,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -180070,8 +180187,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "57.6-2.5 horizontal",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE.",
     "added": "2026-07-07"
   },
@@ -180287,7 +180407,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -180364,9 +180485,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "field_of_view_deg": "55°-2.4° horizontal",
+    "field_of_view_deg": "55-2.4 horizontal",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°.",
     "added": "2026-07-07"
   },
@@ -180393,6 +180516,7 @@
       "type": "color",
       "min_lux_color": 0.005
     },
+    "field_of_view_deg": "58.5-3.7 horizontal",
     "ptz": {
       "autotracking": true
     },
@@ -180458,8 +180582,10 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP54",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "video": {
       "codecs": [
         "H.265+",
@@ -180513,8 +180639,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -180576,7 +180706,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -180632,8 +180762,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -180707,7 +180841,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR.",
     "added": "2026-07-07"
@@ -180733,8 +180867,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "ptz": {
       "autotracking": true
     },
@@ -180799,7 +180937,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -180854,8 +180992,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "ptz": {
       "autotracking": true
     },
@@ -180920,7 +181062,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -181066,8 +181208,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -181129,7 +181275,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -181274,8 +181420,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -181340,7 +181490,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -181395,8 +181545,12 @@
       "varifocal": false
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø183 × 246",
+    "weight_g": 3000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181474,7 +181628,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE.",
     "added": "2026-07-07"
   },
@@ -181500,8 +181654,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø210 × 344.7",
+    "weight_g": 3000,
+    "field_of_view_deg": "55 H / 33 V / 61.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181576,7 +181734,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE.",
     "added": "2026-07-07"
@@ -181778,8 +181936,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181854,7 +182016,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
@@ -181881,8 +182043,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -181947,7 +182113,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182003,8 +182169,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 H / 33 V / 61.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -182069,7 +182239,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182126,8 +182296,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "50.8 H / 29.4 V / 57.4 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -182204,7 +182378,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
@@ -182231,7 +182405,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182297,9 +182472,12 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/62.4 diagonal (wide end)",
     "video": {
       "codecs": [
         "H.265+",
@@ -182353,7 +182531,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182421,7 +182600,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182454,6 +182633,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182477,7 +182659,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182544,7 +182727,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182577,6 +182760,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182693,7 +182879,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -182771,10 +182958,13 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "50.8 horizontal/29.4 vertical/57.4 diagonal (wide end)",
     "added": "2026-07-07"
   },
   {
@@ -182798,7 +182988,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182865,7 +183056,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182898,6 +183089,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "60.7 horizontal/35.9 vertical/68.4 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182921,7 +183115,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182988,7 +183183,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -183021,6 +183216,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55.3 horizontal/32.2 vertical/62.3 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183190,7 +183388,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183222,6 +183420,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 375",
+    "weight_g": 2400,
+    "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183309,7 +183510,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183341,6 +183542,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 302.6",
+    "weight_g": 2400,
+    "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183433,7 +183637,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -183465,6 +183669,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 294.8",
+    "weight_g": 3000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183714,7 +183921,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183740,6 +183947,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø222.3 x 387.2",
+    "weight_g": 6000,
+    "field_of_view_deg": "60.2 horizontal/35.2 vertical (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183968,7 +184178,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -183995,6 +184205,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø290 x 453.2",
+    "weight_g": 10500,
+    "field_of_view_deg": "59 horizontal/34.2 vertical/67.1 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -184087,7 +184300,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -184120,6 +184333,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø290 x 453.2",
+    "weight_g": 10500,
+    "field_of_view_deg": "58.5 horizontal/34 vertical/65.8 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -143300,7 +143300,7 @@
     ],
     "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+    "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
     "dimensions_mm": "170.8 x 66 x 69.1",
     "weight_g": 285,
     "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
@@ -147097,7 +147097,8 @@
     "field_of_view_deg": "95.9-29.2 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -147170,7 +147171,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "129.4 x 116.4 (dia x H)",
+    "weight_g": 595,
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD.",
     "added": "2026-07-07"
   },
@@ -147271,7 +147274,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "205.6 x 83.7 x 80.7",
+    "weight_g": 420,
     "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic.",
     "added": "2026-07-07"
   },
@@ -147367,7 +147372,9 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147474,7 +147481,9 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147699,8 +147708,10 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_year": 2025,
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147738,7 +147749,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -147810,7 +147822,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "171.4 x 69.7 x 67.9",
+    "weight_g": 350,
     "field_of_view_deg": "111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal",
     "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense.",
     "added": "2026-07-07"
@@ -148061,7 +148075,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148133,7 +148148,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 179.2 (dia x H)",
+    "weight_g": 500,
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U).",
     "added": "2026-07-07"
@@ -148223,7 +148240,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "215.2 x 78.8 x 78.6",
+    "weight_g": 680,
     "video": {
       "codecs": [
         "H.265+",
@@ -148481,7 +148500,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148553,7 +148573,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "70 x 161.7 (dia x H)",
+    "weight_g": 490,
     "field_of_view_deg": "103 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U).",
     "added": "2026-07-07"
@@ -148654,7 +148676,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "215.2 x 78.8 x 78.6",
+    "weight_g": 695,
     "field_of_view_deg": "102 (2.8mm) horizontal",
     "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR).",
     "added": "2026-07-07"
@@ -148839,7 +148863,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 515,
     "field_of_view_deg": "104 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
     "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone.",
     "added": "2026-07-07"
@@ -149093,7 +149119,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -149165,7 +149192,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 176.3",
+    "weight_g": 515,
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -149192,7 +149221,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -149264,7 +149294,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 525,
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
     "added": "2026-07-07"
@@ -149353,7 +149385,33 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "added": "2026-06-09"
   },
   {
@@ -149717,7 +149775,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 525,
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
     "added": "2026-07-07"
@@ -149818,7 +149878,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -149920,7 +149982,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 176.3",
+    "weight_g": 530,
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
     "added": "2026-07-07"
@@ -150325,7 +150389,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -150467,7 +150533,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150538,7 +150605,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 70 x 161.7",
+    "weight_g": 495,
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
     "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
     "added": "2026-07-07"
@@ -150764,7 +150833,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150836,9 +150906,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm)/51 (6mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 485,
     "added": "2026-07-07"
   },
   {
@@ -150863,7 +150935,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150936,7 +151009,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "72.9 x 73.3 x 191.1",
+    "weight_g": 595,
     "field_of_view_deg": "110 (2.8mm)/88 (4mm)/60 (6mm) horizontal",
     "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR.",
     "added": "2026-07-07"
@@ -150963,7 +151038,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -151036,9 +151112,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio.",
+    "dimensions_mm": "Ø74.4 x 176.3",
+    "weight_g": 515,
+    "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "added": "2026-07-07"
   },
   {
@@ -151063,7 +151142,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -151135,9 +151215,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 525,
     "added": "2026-07-07"
   },
   {
@@ -151225,7 +151307,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -151256,6 +151338,8 @@
         }
       ]
     },
+    "dimensions_mm": "78.8 x 78.6 x 215.2",
+    "weight_g": 850,
     "added": "2026-06-09"
   },
   {
@@ -151644,9 +151728,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 525,
     "added": "2026-07-07"
   },
   {
@@ -151732,7 +151818,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
     "ip_rating": "IP67",
@@ -151766,6 +151852,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 510,
     "added": "2026-07-06"
   },
   {
@@ -151955,9 +152043,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "dimensions_mm": "Ø74.4 x 176.3",
+    "weight_g": 530,
     "added": "2026-07-07"
   },
   {
@@ -152174,7 +152264,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152247,9 +152338,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic).",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 530,
     "added": "2026-07-07"
   },
   {
@@ -152350,7 +152443,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.009
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152425,9 +152519,11 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm)/52 (6mm) horizontal",
     "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only.",
+    "dimensions_mm": "Ø119 x 90",
+    "weight_g": 520,
     "added": "2026-07-07"
   },
   {
@@ -152452,7 +152548,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152526,9 +152623,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10.",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -152619,7 +152718,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense fixed dome with direct HDMI (type D) live-view output; IK10 metal body, 2.8mm F1.4 fixed lens, 30m IR, audio line-in/out & alarm I/O.",
     "configs": {
       "frigate": {
@@ -152634,6 +152733,8 @@
         "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
       }
     },
+    "dimensions_mm": "Ø119 x 90",
+    "weight_g": 440,
     "added": "2026-07-28"
   },
   {
@@ -152658,7 +152759,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152733,9 +152835,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O.",
+    "dimensions_mm": "Ø121.4 x 92.2",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -153212,6 +153316,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 780,
     "operating_temp_c": "-30 to 60",
     "audio": {
       "microphone": true,
@@ -153238,7 +153344,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -153390,7 +153496,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -153407,6 +153514,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153465,7 +153574,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -153546,6 +153655,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 125.2 (dia x H)",
+    "weight_g": 750,
     "environment": [
       "indoor",
       "outdoor"
@@ -153574,7 +153685,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -153629,6 +153740,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.4 x 100.1 (dia x H)",
+    "weight_g": 580,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153687,7 +153800,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -153854,6 +153967,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 125.2 (dia x H)",
+    "weight_g": 750,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153912,7 +154027,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -154058,6 +154173,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "140 x 145.6 (dia x H)",
+    "weight_g": 920,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -154118,7 +154235,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic.",
     "added": "2026-07-07"
@@ -154481,6 +154598,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -154539,7 +154658,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -154658,7 +154777,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -154675,6 +154795,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.2 (dia x H)",
+    "weight_g": 800,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -154732,7 +154854,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O.",
     "added": "2026-07-07"
@@ -155081,6 +155203,8 @@
       "onvif"
     ],
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "operating_temp_c": "-10 to 40",
     "audio": {
       "microphone": false,
@@ -155105,7 +155229,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -155143,7 +155267,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -155160,6 +155285,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 770,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155218,7 +155345,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155245,7 +155372,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -155262,6 +155390,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 525,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155321,7 +155451,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155366,6 +155496,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155425,7 +155557,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "109 (2.8mm)/93 (4mm) horizontal",
     "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155647,8 +155779,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
+    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "weight_g": 525,
     "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -155861,11 +155995,13 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "weight_g": 600,
     "video": {
       "codecs": [
         "H.265+",
@@ -155964,6 +156100,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 750,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -155989,7 +156127,7 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -156076,6 +156214,8 @@
     ],
     "ip_rating": "IP67",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -156102,7 +156242,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_year": 2025,
     "configs": {
       "frigate": {
@@ -156413,7 +156553,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156484,9 +156625,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "weight_g": 560,
     "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
   },
@@ -156512,7 +156655,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156584,9 +156728,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "weight_g": 570,
     "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
     "added": "2026-07-07"
   },
@@ -156685,9 +156831,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 770,
     "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
     "added": "2026-07-07"
   },
@@ -156713,7 +156861,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156784,9 +156933,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+    "weight_g": 600,
     "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
   },
@@ -156896,7 +157047,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.028
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156968,8 +157120,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
+    "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+    "weight_g": 520,
     "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
     "added": "2026-07-07"
   },
@@ -156995,7 +157149,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -157069,9 +157224,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+    "weight_g": 825,
     "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
     "added": "2026-07-07"
   },
@@ -157286,9 +157443,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 780,
     "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio.",
     "added": "2026-07-07"
   },
@@ -157386,10 +157545,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U).",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -157558,7 +157719,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
@@ -157592,6 +157753,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 125.2",
+    "weight_g": 750,
     "added": "2026-07-06"
   },
   {
@@ -157676,7 +157839,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
@@ -157710,6 +157873,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 760,
     "added": "2026-07-06"
   },
   {
@@ -157797,7 +157962,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -157828,6 +157993,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 125.2",
+    "weight_g": 750,
     "added": "2026-06-06"
   },
   {
@@ -158163,10 +158330,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal / 81 vertical (dual-lens panoramic)",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio.",
+    "dimensions_mm": "Ø140 x 145.6",
+    "weight_g": 920,
     "added": "2026-07-07"
   },
   {
@@ -158267,10 +158436,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-07"
   },
   {
@@ -158358,7 +158529,39 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø138.3 x 115.2",
+    "weight_g": 800,
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -158442,7 +158645,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.1",
     "ip_rating": "IP67",
@@ -158476,6 +158679,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-06"
   },
   {
@@ -158572,10 +158777,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U).",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 770,
     "added": "2026-07-07"
   },
   {
@@ -158660,7 +158867,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
@@ -158688,6 +158895,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø140 x 145.6",
+    "weight_g": 920,
     "added": "2026-07-06"
   },
   {
@@ -158773,7 +158982,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
@@ -158807,6 +159016,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-06"
   },
   {
@@ -158917,7 +159128,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -158932,6 +159144,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "127.3 x 95.9 (dia x H)",
+    "weight_g": 600,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -158988,7 +159202,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
@@ -159562,7 +159776,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159577,6 +159792,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 780,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -159635,7 +159852,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence.",
@@ -159663,7 +159880,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159678,6 +159896,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 775,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -159734,7 +159954,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U).",
@@ -159895,6 +160115,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -159953,7 +160175,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio.",
@@ -160227,6 +160449,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160274,7 +160498,22 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
@@ -160318,6 +160557,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160377,7 +160618,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
@@ -160406,7 +160647,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.028
     },
     "power": {
       "method": "DC 12V"
@@ -160421,6 +160663,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160478,7 +160722,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm) horizontal",
     "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE).",
     "added": "2026-07-07"
@@ -160505,7 +160749,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160520,6 +160765,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160578,7 +160825,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/87.6 (4mm) horizontal",
     "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection.",
     "added": "2026-07-07"
@@ -160606,7 +160853,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160621,6 +160869,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160679,7 +160929,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "92 (2.8mm)/75 (4mm) horizontal",
     "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio.",
     "added": "2026-07-07"
@@ -160706,7 +160956,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160721,6 +160972,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160779,7 +161032,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "104.3 (2.8mm)/83.7 (4mm) horizontal",
     "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I).",
     "added": "2026-07-07"
@@ -160882,7 +161135,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160897,6 +161151,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D; 2.8/4mm) / 102.9 x 65.2 x 28.8 (2mm)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160956,7 +161212,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio.",
     "added": "2026-07-07"
@@ -161069,7 +161325,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161084,6 +161341,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -161142,7 +161401,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107.8 (2.8mm)/82.8 (4mm) horizontal",
     "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio.",
     "added": "2026-07-07"
@@ -161169,7 +161428,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161242,10 +161502,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "110 x 57.4 (dia x H)",
+    "weight_g": 380,
     "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S).",
     "added": "2026-07-07"
   },
@@ -161654,7 +161916,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161728,10 +161991,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "110 x 57.4 (dia x H)",
+    "weight_g": 380,
     "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08.",
     "added": "2026-07-07"
   },
@@ -161833,10 +162098,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -161991,7 +162258,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162064,10 +162332,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "106.4 (2.8mm)/87.6 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -162093,7 +162363,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162167,9 +162438,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "field_of_view_deg": "110.0 (2.8mm)/88.0 (4mm) horizontal",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic.",
     "added": "2026-07-07"
   },
@@ -162195,7 +162469,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162267,10 +162542,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "107°-32° (H)",
+    "field_of_view_deg": "107-32 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1440,
     "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10.",
     "added": "2026-07-07"
   },
@@ -162411,7 +162688,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162484,9 +162762,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "95.8-29.2 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1390,
     "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR.",
     "added": "2026-07-07"
   },
@@ -162512,7 +162793,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162585,10 +162867,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-30° horizontal",
+    "field_of_view_deg": "108-30 horizontal",
+    "dimensions_mm": "144.1 x 345.7 (dia x L)",
+    "weight_g": 1445,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio.",
     "added": "2026-07-07"
   },
@@ -162614,7 +162898,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162686,9 +162971,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "105.4-34.3 (H)",
+    "dimensions_mm": "140 x 333.8 (dia x L)",
+    "weight_g": 1490,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H).",
     "added": "2026-07-07"
   },
@@ -162714,7 +163002,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162787,9 +163076,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "105.4-34.3 (H)",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1490,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR.",
     "added": "2026-07-07"
   },
@@ -162815,7 +163107,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162888,9 +163181,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "108-30 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1355,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR.",
     "added": "2026-07-07"
   },
@@ -163077,9 +163373,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "114.6-41.8 (H)",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
     "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m.",
     "added": "2026-07-07"
   },

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -142168,8 +142168,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142203,7 +142207,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142230,6 +142234,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø180 x 239.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142262,7 +142269,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142289,6 +142296,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142322,7 +142332,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "added": "2026-07-06"
   },
   {
@@ -142347,8 +142357,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142382,7 +142396,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142409,6 +142423,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø180 x 239.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142441,7 +142458,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142468,6 +142485,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142501,7 +142521,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "added": "2026-07-06"
   },
   {
@@ -142526,8 +142546,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142561,7 +142585,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142589,6 +142613,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142621,7 +142648,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142648,6 +142675,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø220 x 280",
+    "weight_g": 3000,
     "power": {
       "method": "36 VDC"
     },
@@ -142680,7 +142710,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "added": "2026-07-06"
@@ -142709,6 +142739,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142741,7 +142774,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142768,6 +142801,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø220 x 280",
+    "weight_g": 3000,
     "power": {
       "method": "36 VDC"
     },
@@ -142800,7 +142836,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "added": "2026-07-06"
@@ -142829,6 +142865,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142861,7 +142900,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142885,9 +142924,11 @@
       "focal_length_mm": "4.8-153.6",
       "varifocal": true
     },
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "36 VDC"
@@ -142922,8 +142963,10 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "dimensions_mm": "Ø 220 x 356.9",
+    "weight_g": 4500,
     "added": "2026-07-06"
   },
   {
@@ -143183,7 +143226,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -143254,9 +143298,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 285,
     "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
     "added": "2026-07-07"
   },
@@ -143343,7 +143389,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 265,
     "video": {
       "codecs": [
         "H.265+",
@@ -143390,6 +143438,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143463,8 +143512,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 265,
     "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m.",
     "added": "2026-07-07"
   },
@@ -143613,6 +143664,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143687,8 +143739,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic.",
     "added": "2026-07-07"
   },
@@ -143712,9 +143766,11 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -143786,8 +143842,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD.",
     "added": "2026-07-07"
   },
@@ -143874,7 +143932,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "video": {
       "codecs": [
         "H.265+",
@@ -143921,6 +143981,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143996,8 +144057,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic.",
     "added": "2026-07-07"
   },
@@ -144097,7 +144160,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 76.6 x 164.4",
+    "weight_g": 430,
     "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
     "added": "2026-07-07"
   },
@@ -144198,7 +144263,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense.",
     "added": "2026-07-07"
   },
@@ -144242,6 +144309,8 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144299,7 +144368,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res.",
     "added": "2026-07-07"
   },
@@ -144326,7 +144395,8 @@
     "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144342,6 +144412,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "110.8 x 84.7 (dia x H)",
+    "weight_g": 520,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -144398,7 +144470,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot.",
     "added": "2026-07-07"
   },
@@ -144447,6 +144519,9 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144485,7 +144560,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -144553,6 +144628,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144610,7 +144687,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08.",
     "added": "2026-07-07"
   },
@@ -144655,6 +144732,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 500,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144712,7 +144791,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR.",
     "added": "2026-07-07"
   },
@@ -144757,6 +144836,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144814,7 +144895,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08.",
     "added": "2026-07-07"
   },
@@ -144841,7 +144922,8 @@
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144857,6 +144939,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "110.8 x 84.7 (dia x H)",
+    "weight_g": 520,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -144915,7 +144999,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD.",
     "added": "2026-07-07"
   },
@@ -144942,7 +145026,8 @@
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144959,6 +145044,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.4 x 92.2 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145018,7 +145105,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I.",
     "added": "2026-07-07"
   },
@@ -145067,6 +145154,9 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145105,7 +145195,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -145173,6 +145263,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145230,7 +145322,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08.",
     "added": "2026-07-07"
   },
@@ -145440,6 +145532,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 500,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145497,7 +145591,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic.",
     "added": "2026-07-07"
   },
@@ -145542,6 +145636,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145599,7 +145695,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08.",
     "added": "2026-07-07"
   },
@@ -145696,6 +145792,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+    "dimensions_mm": "Ø121.5 x 97.6",
+    "weight_g": 550,
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
@@ -145773,7 +145871,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps.",
     "added": "2026-07-07"
   },
@@ -145870,6 +145968,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 85.3",
+    "weight_g": 340,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -145944,7 +146044,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR.",
     "added": "2026-07-07"
   },
@@ -145969,6 +146069,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 89.2",
+    "weight_g": 340,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146044,7 +146146,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
     "added": "2026-07-07"
   },
@@ -146069,6 +146171,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 380,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146144,7 +146248,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic.",
     "added": "2026-07-07"
   },
@@ -146169,6 +146273,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 85.3",
+    "weight_g": 340,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146244,7 +146350,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP.",
     "added": "2026-07-07"
   },
@@ -146269,6 +146375,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 89.2",
+    "weight_g": 340,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146344,7 +146452,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
     "added": "2026-07-07"
   },
@@ -146369,6 +146477,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 420,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146444,7 +146554,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic.",
     "added": "2026-07-07"
   },
@@ -146469,6 +146579,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 415,
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
@@ -146545,7 +146657,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps.",
     "added": "2026-07-07"
   },
@@ -146570,6 +146682,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "102.4-31.2 horizontal",
+    "dimensions_mm": "Ø105 x 244.4",
+    "weight_g": 720,
     "night_vision": {
       "type": "ir",
       "range_m": 50
@@ -146646,7 +146760,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD.",
     "added": "2026-07-07"
   },
@@ -146671,6 +146785,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "95.9-29.2 horizontal",
+    "dimensions_mm": "Ø105 x 244.4",
+    "weight_g": 745,
     "night_vision": {
       "type": "ir",
       "range_m": 50
@@ -146747,7 +146863,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP.",
     "added": "2026-07-07"
   },
@@ -146772,6 +146888,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "102.4-31.2 horizontal",
+    "dimensions_mm": "Ø141 x 99.9",
+    "weight_g": 820,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146848,7 +146966,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10.",
     "added": "2026-07-07"
   },
@@ -146873,6 +146991,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "95.9-29.2 horizontal",
+    "dimensions_mm": "Ø141 x 99.9",
+    "weight_g": 820,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146950,7 +147070,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10.",
     "added": "2026-07-07"
   },

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -142965,7 +142965,7 @@
     ],
     "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "dimensions_mm": "Ø 220 x 356.9",
+    "dimensions_mm": "Ø220 x 356.9",
     "weight_g": 4500,
     "added": "2026-07-06"
   },
@@ -143114,7 +143114,8 @@
     "field_of_view_deg": "112.1 horizontal (2.8mm) / 90.2 horizontal (4mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -143154,7 +143155,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/m000007714/DS-2CD1023G0E-I_Datasheet_20260409.pdf"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -144161,7 +144162,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 76.6 x 164.4",
+    "dimensions_mm": "Ø76.6 x 164.4",
     "weight_g": 430,
     "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
     "added": "2026-07-07"
@@ -147543,6 +147544,18 @@
           "resolution": "4608x3456",
           "fps": 15,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
@@ -147589,7 +147602,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -148892,7 +148905,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148959,13 +148973,27 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 485,
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U).",
     "added": "2026-07-07"
@@ -149193,7 +149221,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 176.3",
+    "dimensions_mm": "Ø74.4 x 176.3",
     "weight_g": 515,
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
@@ -149295,7 +149323,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 525,
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
@@ -149410,7 +149438,7 @@
       ]
     },
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "added": "2026-06-09"
   },
@@ -149776,7 +149804,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 525,
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
@@ -149879,7 +149907,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
@@ -149983,7 +150011,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 176.3",
+    "dimensions_mm": "Ø74.4 x 176.3",
     "weight_g": 530,
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
@@ -150390,7 +150418,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
@@ -150606,7 +150634,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 70 x 161.7",
+    "dimensions_mm": "Ø70 x 161.7",
     "weight_g": 495,
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
     "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
@@ -155643,8 +155671,10 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
+    "dimensions_mm": "Ø121.5 x 97.6",
+    "weight_g": 525,
     "field_of_view_deg": "105.1",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
@@ -155781,7 +155811,7 @@
     ],
     "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
     "weight_g": 525,
     "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -156000,7 +156030,7 @@
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
     "weight_g": 600,
     "video": {
       "codecs": [
@@ -156100,7 +156130,7 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 750,
     "audio": {
       "microphone": true,
@@ -156214,7 +156244,7 @@
     ],
     "ip_rating": "IP67",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 820,
     "audio": {
       "microphone": true,
@@ -156628,7 +156658,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
     "weight_g": 560,
     "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
@@ -156731,7 +156761,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
     "weight_g": 570,
     "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
     "added": "2026-07-07"
@@ -156834,7 +156864,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 770,
     "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
     "added": "2026-07-07"
@@ -156936,7 +156966,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 95.9 (dia x H)",
     "weight_g": 600,
     "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
@@ -157122,7 +157152,7 @@
     ],
     "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
-    "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 104.1 (dia x H)",
     "weight_g": 520,
     "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
     "added": "2026-07-07"
@@ -157227,7 +157257,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 124.5 (dia x H)",
     "weight_g": 825,
     "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
     "added": "2026-07-07"
@@ -163473,13 +163503,28 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1555,
+    "field_of_view_deg": "114.6-41.8 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
@@ -163575,13 +163620,28 @@
           "resolution": "3200x1800",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
+    "field_of_view_deg": "112.3-41.2 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m.",
@@ -163823,7 +163883,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -163890,16 +163951,30 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1475,
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° (H)",
+    "field_of_view_deg": "112.3-41.2 (H)",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -163925,7 +164000,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -163992,13 +164068,28 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1475,
+    "field_of_view_deg": "112.3-41.2 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K.",
@@ -164026,7 +164117,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164099,10 +164191,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "97.9 x 93 x 308.5",
+    "weight_g": 1380,
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° horizontal",
+    "field_of_view_deg": "108-46 horizontal",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -164190,11 +164284,28 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -164291,9 +164402,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1465,
+    "field_of_view_deg": "103.3-40",
     "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -164394,9 +164508,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1555,
+    "field_of_view_deg": "112.3-41.2",
     "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -164422,7 +164539,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164494,9 +164612,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.3 x 111.6",
+    "weight_g": 880,
+    "field_of_view_deg": "107-32",
     "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164607,7 +164728,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164680,9 +164802,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.3 x 111.6",
+    "weight_g": 880,
+    "field_of_view_deg": "113-31",
     "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164793,7 +164918,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164866,9 +164992,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.5 x 133.1",
+    "weight_g": 845,
+    "field_of_view_deg": "108-30",
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164894,7 +165023,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164968,9 +165098,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 840,
+    "field_of_view_deg": "114.6-41.8",
     "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -164996,7 +165129,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -165070,10 +165204,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "105.4°-34.3° (H)",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "105.4-34.3 (H)",
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -165174,9 +165310,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 820,
+    "field_of_view_deg": "114.6-41.8",
     "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -165277,10 +165416,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "114.6°-41.8° horizontal",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "114.6-41.8 horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m.",
     "added": "2026-07-07"
   },
@@ -165379,9 +165520,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 152",
+    "weight_g": 1600,
+    "field_of_view_deg": "105.4-56.4",
     "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light.",
     "added": "2026-07-07"
   },
@@ -165463,6 +165607,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -165488,7 +165634,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165585,6 +165731,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -165609,7 +165757,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165702,6 +165850,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1200,
     "environment": [
       "indoor",
       "outdoor"
@@ -165726,7 +165876,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165855,6 +166005,7 @@
       "range_m": 40,
       "min_lux_color": 0.0028
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -165918,7 +166069,19 @@
         {
           "name": "main",
           "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
           "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
           "codec": "H.265"
         }
       ]
@@ -165926,9 +166089,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 820,
     "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m.",
     "added": "2026-07-07"
   },
@@ -166016,6 +166181,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -166037,7 +166204,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000077895/DS-2CD2767G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166134,6 +166301,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1200,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -166156,7 +166325,7 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166253,6 +166422,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 850,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -166274,7 +166445,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000106992/DS-2CD2767G3T-LIZSY_Datasheet_20250506.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166312,8 +166483,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "108-30",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166378,15 +166551,29 @@
           "resolution": "3840x2160",
           "fps": 20,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "153.3 x 111.6 (dia x H)",
+    "weight_g": 855,
     "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR.",
     "added": "2026-07-07"
   },
@@ -166412,8 +166599,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
+    "field_of_view_deg": "108-46",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166479,15 +166668,29 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "153.5 x 133.2 (dia x H)",
+    "weight_g": 1080,
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166513,8 +166716,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166580,7 +166785,19 @@
         {
           "name": "main",
           "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
           "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
           "codec": "H.265"
         }
       ]
@@ -166588,9 +166805,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 840,
     "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -166616,8 +166835,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166683,15 +166904,29 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 840,
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166787,16 +167022,30 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° (H)",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 820,
+    "field_of_view_deg": "112.3-41.2 (H)",
     "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166896,9 +167145,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "112.3-41.2 horizontal",
     "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166999,10 +167251,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "103.3°-40° horizontal",
+    "dimensions_mm": "Ø155 x 152",
+    "weight_g": 1525,
+    "field_of_view_deg": "103.3-40 horizontal",
     "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -167204,7 +167458,9 @@
       "global"
     ],
     "release_year": 2024,
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1230,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167327,7 +167583,9 @@
       "https://assets.hikvision.com/prd/normal/all/doc/sm000106989/DS-2CD2787G3-LIPTRZS2UY_SRBBlack_Datasheet_20260629.pdf",
       "https://assets.hikvision.com/prd/normal/all/doc/sm000077899/DS-2CD2787G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1230,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167446,7 +167704,9 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000107003/DS-2CD2787G3-LIPTRZSY_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1200,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167575,7 +167835,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 8
+      "range_m": 8,
+      "min_lux_color": 0.017
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -167646,7 +167907,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø119.9 x 41.2",
+    "weight_g": 320,
+    "field_of_view_deg": "180 horizontal",
     "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic.",
     "added": "2026-07-07"
   },
@@ -167741,7 +168005,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "31.5 x 31.5 x 39.7",
+    "weight_g": 93,
+    "field_of_view_deg": "93.9 (2.8mm)/75.5 (3.7mm) horizontal",
     "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only.",
     "added": "2026-07-07"
   },
@@ -167838,7 +168105,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø93.9 x 117.5",
+    "weight_g": 155,
+    "field_of_view_deg": "107 (2.8mm)/88 (4mm) horizontal",
     "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -167935,7 +168205,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø93.9 x 117.5",
+    "weight_g": 155,
+    "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -168033,9 +168306,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø138.3 x 126",
+    "weight_g": 830,
+    "field_of_view_deg": "106.6-31.7 horizontal",
     "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR.",
     "added": "2026-07-07"
   },
@@ -168134,9 +168410,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø138.3 x 126",
+    "weight_g": 830,
+    "field_of_view_deg": "95.8-29.2 horizontal",
     "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR.",
     "added": "2026-07-07"
   },
@@ -168501,10 +168780,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° (H)",
+    "dimensions_mm": "Ø135.8 x 145.5",
+    "weight_g": 1160,
+    "field_of_view_deg": "108-46 (H)",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -168530,7 +168811,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -168603,9 +168885,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 diameter x 126",
+    "weight_g": 850,
+    "field_of_view_deg": "108-46 horizontal, 58-26 vertical, 127.4 diagonal",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -168707,10 +168992,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° horizontal",
+    "field_of_view_deg": "112.3-41.2 horizontal",
+    "dimensions_mm": "143.5 diameter x 142.7",
+    "weight_g": 1265,
     "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -168938,7 +169225,9 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -169055,7 +169344,9 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -169178,7 +169469,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169248,8 +169540,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "289 x 93.1 x 91.2",
+    "weight_g": 1100,
+    "field_of_view_deg": "107 horizontal, 57 vertical, 127 diagonal (2.8mm)",
     "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens.",
     "added": "2026-07-07"
   },
@@ -169431,7 +169726,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169502,8 +169798,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "289 x 93.1 x 91.2",
+    "weight_g": 1020,
+    "field_of_view_deg": "107 horizontal, 57 vertical, 129 diagonal (2.8mm)",
     "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -169686,8 +169985,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 289.5",
+    "weight_g": 1090,
+    "field_of_view_deg": "107 horizontal, 56 vertical, 127 diagonal (2.8mm)",
     "release_notes": "2MP ColorVu fixed bullet, 60m white light.",
     "added": "2026-07-07"
   },
@@ -169713,7 +170015,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169783,8 +170086,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 299.7",
+    "weight_g": 1070,
+    "field_of_view_deg": "103 horizontal, 55 vertical, 122 diagonal (2.8mm)",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -169964,8 +170270,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 278",
+    "weight_g": 570,
+    "field_of_view_deg": "180 horizontal, 101 vertical, 180 diagonal",
     "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR.",
     "added": "2026-07-07"
   },
@@ -169991,7 +170300,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170062,8 +170372,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 289.5",
+    "weight_g": 1075,
+    "field_of_view_deg": "103 horizontal, 55 vertical, 123 diagonal (2.8mm)",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -170172,7 +170485,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170244,9 +170558,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "103°/83°/53° (H)",
+    "field_of_view_deg": "103/83/53 (H)",
+    "dimensions_mm": "105 diameter x 287.6",
+    "weight_g": 1135,
     "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR.",
     "added": "2026-07-07"
   },
@@ -170272,7 +170588,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170343,9 +170660,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "field_of_view_deg": "100.2 horizontal (2.8mm), 81.1 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1085,
     "added": "2026-07-07"
   },
   {
@@ -170370,7 +170690,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170442,10 +170763,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "100° (2.8mm)/81° (4mm) horizontal",
+    "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -170470,7 +170793,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170543,9 +170867,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio.",
+    "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+    "dimensions_mm": "118.6 x 105.1 x 306.5",
+    "weight_g": 1400,
     "added": "2026-07-07"
   },
   {
@@ -170931,6 +171258,34 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -170985,7 +171340,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "added": "2026-06-06"
   },
   {
@@ -171083,9 +171440,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio.",
+    "field_of_view_deg": "104.0 horizontal (2.8mm), 89.2 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -171270,9 +171630,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio.",
+    "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+    "dimensions_mm": "118.6 x 105.1 x 306.5",
+    "weight_g": 1400,
     "added": "2026-07-07"
   },
   {
@@ -171463,9 +171826,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio.",
+    "field_of_view_deg": "111.1 horizontal (2.8mm), 95.2 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "added": "2026-07-07"
   },
   {
@@ -171820,9 +172186,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP.",
+    "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "added": "2026-07-07"
   },
   {
@@ -171921,9 +172290,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio.",
+    "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -171948,7 +172320,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172019,10 +172392,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "107°/87°/54° (H)",
+    "field_of_view_deg": "107/87/54 (H)",
     "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K.",
+    "dimensions_mm": "105 x 299.7 (dia x H)",
+    "weight_g": 1090,
     "added": "2026-07-07"
   },
   {
@@ -172217,7 +172592,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172288,9 +172664,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "field_of_view_deg": "111 horizontal (2.8mm), 87 horizontal (4mm), 51 horizontal (6mm)",
+    "dimensions_mm": "105 x 290 (dia x H)",
+    "weight_g": 1270,
     "added": "2026-07-07"
   },
   {
@@ -172400,7 +172779,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172473,10 +172853,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "110°/88°/59° horizontal",
+    "field_of_view_deg": "110/88/59 horizontal",
     "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K.",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1130,
     "added": "2026-07-07"
   },
   {
@@ -172501,8 +172883,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1180,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -172565,13 +172951,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
     "added": "2026-07-07"
@@ -172598,8 +172996,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "105 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1220,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -172664,13 +173066,25 @@
           "resolution": "3840x2160",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -172992,6 +173406,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173055,13 +173472,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K.",
     "added": "2026-07-07"
@@ -173091,6 +173520,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173156,13 +173588,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K.",
     "added": "2026-07-07"
@@ -173192,6 +173636,9 @@
       "range_m": 40,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "180 horizontal / 44 vertical (4mm)",
+    "dimensions_mm": "118.6 x 105.1 x 305.4",
+    "weight_g": 1420,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173258,13 +173705,19 @@
           "resolution": "5120x1440",
           "fps": 20,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x536",
+          "fps": 20,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio.",
     "added": "2026-07-07"
@@ -173443,9 +173896,11 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -173504,6 +173959,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "108.8 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173569,13 +174027,25 @@
           "resolution": "3840x2160",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K.",
     "added": "2026-07-07"
@@ -173652,6 +174122,8 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
     "environment": [
       "indoor",
       "outdoor"
@@ -173681,7 +174153,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -173719,8 +174191,11 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 490,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173784,15 +174259,27 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "103°/84°/52° (H)",
+    "field_of_view_deg": "103/84/52 (H)",
     "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR.",
     "added": "2026-07-07"
   },
@@ -174299,8 +174786,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "103.6 horizontal (2.8mm)",
+    "dimensions_mm": "Ø127.3 x 96.3",
+    "weight_g": 635,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -174364,13 +174855,31 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        },
+        {
+          "name": "fourth",
+          "resolution": "1280x720",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR.",
     "added": "2026-07-07"
@@ -174752,7 +175261,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -174827,10 +175337,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° horizontal",
+    "field_of_view_deg": "108-46 horizontal",
+    "dimensions_mm": "Ø105 x 332.8",
+    "weight_g": 1475,
     "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -175356,7 +175868,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -175431,9 +175944,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø140.3 x 59.4",
+    "weight_g": 715,
     "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR.",
     "added": "2026-07-07"
   },
@@ -175532,7 +176048,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø165 x 48.9",
+    "weight_g": 470,
     "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics.",
     "added": "2026-07-07"
   },
@@ -175721,7 +176240,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø165 x 48.9",
+    "weight_g": 470,
     "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -175822,7 +176344,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -175896,9 +176419,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "213.73 x 199.67 x 137.57",
+    "weight_g": 610,
     "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR.",
     "added": "2026-07-07"
   },
@@ -176236,10 +176762,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x 60.9 x 57.9",
+    "weight_g": 266,
     "added": "2026-07-06"
   },
   {
@@ -176294,10 +176822,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x 60.9 x 57.9",
+    "weight_g": 155,
     "added": "2026-07-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -177104,7 +177104,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC / PoC.af"
@@ -177136,10 +177137,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "93 / 77",
     "ip_rating": "IP67",
+    "dimensions_mm": "158.6 x Ø70",
+    "weight_g": 337,
     "added": "2026-07-06"
   },
   {
@@ -177264,7 +177267,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177295,7 +177299,9 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "138.8 x Ø70",
+    "weight_g": 270,
     "added": "2026-07-06"
   },
   {
@@ -177320,7 +177326,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 25,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177350,10 +177357,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x Ø70",
+    "weight_g": 160,
     "added": "2026-07-06"
   },
   {
@@ -177436,7 +177445,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177469,10 +177479,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "58 x 61 x 158.6",
+    "weight_g": 175,
     "added": "2026-07-06"
   },
   {
@@ -177497,7 +177509,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177527,10 +177540,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78 / 49.2",
     "ip_rating": "IP67",
+    "dimensions_mm": "216.6 x 78.9 x 75.4",
+    "weight_g": 339,
     "added": "2026-07-06"
   },
   {
@@ -177555,7 +177570,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177585,10 +177601,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 (2.8mm)",
     "ip_rating": "IP67",
+    "dimensions_mm": "216.6 x 78.9 x 75.4",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -177613,7 +177631,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 60,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177644,10 +177663,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3 / 51.8",
     "ip_rating": "IP67",
+    "dimensions_mm": "192.6 x 178.3 x 71",
+    "weight_g": 740,
     "added": "2026-07-06"
   },
   {
@@ -177671,7 +177692,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC / PoC.at"
@@ -177703,10 +177725,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "5MP CMOS",
     "field_of_view_deg": "95-26",
     "ip_rating": "IP67",
+    "dimensions_mm": "84.5 x 92 x 255.1",
+    "weight_g": 677,
     "added": "2026-07-06"
   },
   {
@@ -177730,7 +177754,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177763,10 +177788,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP progressive-scan CMOS",
     "field_of_view_deg": "108.1-45.6",
     "ip_rating": "IP67",
+    "dimensions_mm": "84.5 x 92 x 255.1",
+    "weight_g": 695,
     "added": "2026-07-06"
   },
   {
@@ -177851,7 +177878,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177883,11 +177911,13 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 365,
     "added": "2026-07-06"
   },
   {
@@ -177912,7 +177942,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -177942,10 +177973,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "80 x Ø85.1",
+    "weight_g": 296,
     "added": "2026-07-06"
   },
   {
@@ -178000,9 +178033,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
+    "dimensions_mm": "84.6 x Ø85.02",
+    "weight_g": 156,
     "added": "2026-07-06"
   },
   {
@@ -178077,7 +178112,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178107,10 +178143,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "80 x Ø85.1",
+    "weight_g": 300,
     "added": "2026-06-06"
   },
   {
@@ -178135,7 +178173,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178165,9 +178204,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
+    "dimensions_mm": "84.6 x Ø85.02",
+    "weight_g": 160,
     "added": "2026-07-06"
   },
   {
@@ -178191,7 +178232,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178224,10 +178266,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "82.6 x 90 x 79.37",
+    "weight_g": 300,
     "added": "2026-07-06"
   },
   {
@@ -178251,7 +178295,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178284,9 +178329,11 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
+    "dimensions_mm": "Ø84.6 x 78.9",
+    "weight_g": 150,
     "added": "2026-07-06"
   },
   {
@@ -178311,7 +178358,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178341,10 +178389,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "100 / 80",
     "ip_rating": "IP67",
+    "dimensions_mm": "97.9 x Ø110",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -178369,7 +178419,8 @@
     "night_vision": {
       "type": "hybrid",
       "range_m": 40,
-      "min_lux": 0.01
+      "min_lux": 0.01,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178399,10 +178450,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "3K CMOS",
     "field_of_view_deg": "104.9 / 81.3",
     "ip_rating": "IP67",
+    "dimensions_mm": "97.9 x Ø110",
+    "weight_g": 340,
     "added": "2026-07-06"
   },
   {
@@ -178426,7 +178479,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "12 VDC"
@@ -178458,10 +178512,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "8.29MP CMOS",
     "field_of_view_deg": "102.9 / 79 / 44.7",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø109.82 x 91.03",
+    "weight_g": 315,
     "added": "2026-07-06"
   },
   {
@@ -178487,7 +178543,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.5
     },
     "power": {
       "method": "DC 12V"
@@ -178551,14 +178608,23 @@
           "resolution": "2560x1440",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "768x432",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "97 / 82",
+    "dimensions_mm": "175.6 x 73 x 89.1",
+    "weight_g": 345,
     "release_notes": "4MP Wi-Fi EXIR bullet (DS-2CV series); DC 12V, 30m IR.",
     "added": "2026-07-07"
   },
@@ -178585,7 +178651,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "DC 12V"
@@ -178649,14 +178716,23 @@
           "resolution": "2560x1440",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "95 / 79",
+    "dimensions_mm": "Ø126 x 96.1",
+    "weight_g": 590,
     "release_notes": "4MP Wi-Fi EXIR fixed dome (DS-2CV series); DC power, 30m IR.",
     "added": "2026-07-07"
   },
@@ -178683,7 +178759,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.05
     },
     "power": {
       "method": "DC 12V"
@@ -178749,14 +178826,22 @@
           "resolution": "1920x1080",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "768x432",
+          "fps": 30,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
-    "field_of_view_deg": "75° (H)",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "75 (H)",
+    "dimensions_mm": "Ø80 x 122",
+    "weight_g": 216,
     "release_notes": "2MP indoor WiFi pan/tilt cube with two-way audio; DC 5V, no IP rating (indoor).",
     "added": "2026-07-07"
   },
@@ -178872,7 +178957,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -178950,10 +179036,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "96.7°-31.6° horizontal",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "Ø130.7 x 101.7",
+    "weight_g": 530,
     "release_notes": "4MP mini Wi-Fi PTZ, 4x optical zoom, 20m IR, pan 355°.",
     "added": "2026-07-07"
   },
@@ -178979,7 +179067,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 20
+      "range_m": 20,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179057,9 +179146,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "Ø130.7 x 101.7",
+    "weight_g": 530,
     "release_notes": "4MP mini PTZ, 4x optical zoom, 20m IR, built-in mic.",
     "added": "2026-07-07"
   },
@@ -179086,7 +179178,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "DC 12V"
@@ -179158,8 +179251,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "91 horizontal (2.8mm) / 74 horizontal (4mm)",
+    "dimensions_mm": "163.9 x 185.8 x 131.9",
+    "weight_g": 565,
     "release_notes": "4MP outdoor Wi-Fi pan-tilt camera (fixed lens); DC 12V.",
     "added": "2026-07-07"
   },
@@ -179184,7 +179280,8 @@
       "varifocal": false
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179260,8 +179357,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "93.8-31.7 horizontal",
+    "dimensions_mm": "Ø140.7 x 107.2",
+    "weight_g": 950,
     "release_notes": "4MP mini PTZ dome, 4x optical zoom (Day/Night ICR, no IR).",
     "added": "2026-07-07"
   },
@@ -179453,8 +179553,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "88.7 horizontal",
+    "dimensions_mm": "179.3 x 120 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP ColorVu Wi-Fi mini PTZ (digital zoom only), 30m white light.",
     "added": "2026-07-07"
   },
@@ -179555,8 +179658,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "88.7 horizontal",
+    "dimensions_mm": "179.3 x 120 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP ColorVu mini PTZ (digital zoom only), 30m white light.",
     "added": "2026-07-07"
   },
@@ -179676,7 +179782,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179753,8 +179860,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "96.7-31.6 horizontal",
+    "dimensions_mm": "179.3 x 120.5 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP mini PTZ, 4x optical zoom, 50m IR.",
     "added": "2026-07-07"
   },
@@ -179785,7 +179895,8 @@
     "field_of_view_deg": "96.7-31.6 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179862,7 +179973,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "179.3 x 120.5 x 182",
+    "weight_g": 1125,
     "release_notes": "4MP Wi-Fi variant of the DS-2DE3A404IWG-E mini PTZ (4x optical zoom, 50m IR).",
     "added": "2026-07-07"
   },
@@ -179888,7 +180001,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -179966,9 +180080,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "field_of_view_deg": "57.6°-4° (H)",
+    "field_of_view_deg": "57.6-4 (H)",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "2MP 15X IR network speed dome (PTZ), 100m IR, pan 360°.",
     "added": "2026-07-07"
   },
@@ -179994,7 +180110,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -180070,8 +180187,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "field_of_view_deg": "57.6-2.5 horizontal",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "2MP 25X IR speed dome, 100m IR; 24VAC + PoE.",
     "added": "2026-07-07"
   },
@@ -180287,7 +180407,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -180364,9 +180485,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "field_of_view_deg": "55°-2.4° horizontal",
+    "field_of_view_deg": "55-2.4 horizontal",
+    "dimensions_mm": "Ø164.5 x 290",
+    "weight_g": 2000,
     "release_notes": "4MP 25X IR network speed dome (PTZ), 100m IR, pan 360°.",
     "added": "2026-07-07"
   },
@@ -180393,6 +180516,7 @@
       "type": "color",
       "min_lux_color": 0.005
     },
+    "field_of_view_deg": "58.5-3.7 horizontal",
     "ptz": {
       "autotracking": true
     },
@@ -180458,8 +180582,10 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP54",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "video": {
       "codecs": [
         "H.265+",
@@ -180513,8 +180639,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -180576,7 +180706,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -180632,8 +180762,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -180707,7 +180841,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "release_notes": "2MP 25X DarkFighter PTZ speed dome, 50m IR.",
     "added": "2026-07-07"
@@ -180733,8 +180867,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "ptz": {
       "autotracking": true
     },
@@ -180799,7 +180937,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -180854,8 +180992,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "54.9 H / 31.5 V / 62.3 D",
     "ptz": {
       "autotracking": true
     },
@@ -180920,7 +181062,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -181066,8 +181208,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
     "power": {
       "method": "PoE+ / 12 VDC"
     },
@@ -181129,7 +181275,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -181274,8 +181420,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 50
+      "range_m": 50,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø169 × 161",
+    "weight_g": 2450,
+    "field_of_view_deg": "53.3 H / 30.6 V / 60.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -181340,7 +181490,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -181395,8 +181545,12 @@
       "varifocal": false
     },
     "night_vision": {
-      "type": "none"
+      "type": "none",
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø183 × 246",
+    "weight_g": 3000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181474,7 +181628,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP 5-inch 25X DarkFighter speed dome (non-IR); 24VAC + PoE.",
     "added": "2026-07-07"
   },
@@ -181500,8 +181654,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø210 × 344.7",
+    "weight_g": 3000,
+    "field_of_view_deg": "55 H / 33 V / 61.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181576,7 +181734,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "release_notes": "4MP 25X DarkFighter IR speed dome, 150m IR; 24VAC + PoE.",
     "added": "2026-07-07"
@@ -181778,8 +181936,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -181854,7 +182016,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "2MP 7-inch 25X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
@@ -181881,8 +182043,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "57.6 H / 34.4 V / 64.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -181947,7 +182113,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182003,8 +182169,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 H / 33 V / 61.5 D",
     "ptz": {
       "autotracking": true
     },
@@ -182069,7 +182239,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182126,8 +182296,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø220 × 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "50.8 H / 29.4 V / 57.4 D",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -182204,7 +182378,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "2MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
@@ -182231,7 +182405,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182297,9 +182472,12 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/62.4 diagonal (wide end)",
     "video": {
       "codecs": [
         "H.265+",
@@ -182353,7 +182531,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182421,7 +182600,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182454,6 +182633,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182477,7 +182659,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182544,7 +182727,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182577,6 +182760,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182693,7 +182879,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -182771,10 +182958,13 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "release_notes": "4MP 32X DarkFighter speed dome, 200m IR; 24VAC + Hi-PoE.",
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "50.8 horizontal/29.4 vertical/57.4 diagonal (wide end)",
     "added": "2026-07-07"
   },
   {
@@ -182798,7 +182988,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182865,7 +183056,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -182898,6 +183089,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "60.7 horizontal/35.9 vertical/68.4 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -182921,7 +183115,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 200
+      "range_m": 200,
+      "min_lux_color": 0.005
     },
     "ptz": {
       "autotracking": true
@@ -182988,7 +183183,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -183021,6 +183216,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø220 x 363.3",
+    "weight_g": 5000,
+    "field_of_view_deg": "55.3 horizontal/32.2 vertical/62.3 diagonal (wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183190,7 +183388,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183222,6 +183420,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 375",
+    "weight_g": 2400,
+    "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183309,7 +183510,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183341,6 +183542,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 302.6",
+    "weight_g": 2400,
+    "field_of_view_deg": "54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183433,7 +183637,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -183465,6 +183669,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø166 x 294.8",
+    "weight_g": 3000,
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183714,7 +183921,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "video": {
       "codecs": [
@@ -183740,6 +183947,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø222.3 x 387.2",
+    "weight_g": 6000,
+    "field_of_view_deg": "60.2 horizontal/35.2 vertical (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -183968,7 +184178,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -183995,6 +184205,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø290 x 453.2",
+    "weight_g": 10500,
+    "field_of_view_deg": "59 horizontal/34.2 vertical/67.1 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {
@@ -184087,7 +184300,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "video": {
@@ -184120,6 +184333,9 @@
         }
       ]
     },
+    "dimensions_mm": "Ø290 x 453.2",
+    "weight_g": 10500,
+    "field_of_view_deg": "58.5 horizontal/34 vertical/65.8 diagonal (PTZ channel wide end)",
     "added": "2026-07-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -143300,7 +143300,7 @@
     ],
     "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+    "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
     "dimensions_mm": "170.8 x 66 x 69.1",
     "weight_g": 285,
     "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
@@ -147097,7 +147097,8 @@
     "field_of_view_deg": "95.9-29.2 horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -147170,7 +147171,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "129.4 x 116.4 (dia x H)",
+    "weight_g": 595,
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR turret with 120dB WDR and 30m IR; up to 256GB microSD.",
     "added": "2026-07-07"
   },
@@ -147271,7 +147274,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "205.6 x 83.7 x 80.7",
+    "weight_g": 420,
     "release_notes": "2MP ColorVu fixed-lens (4/6mm) bullet with F1.0 aperture, 24/7 color via 50m white light and built-in mic.",
     "added": "2026-07-07"
   },
@@ -147367,7 +147372,9 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147474,7 +147481,9 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147699,8 +147708,10 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_year": 2025,
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 530,
     "configs": {
       "frigate": {
         "detect": {
@@ -147738,7 +147749,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -147810,7 +147822,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "171.4 x 69.7 x 67.9",
+    "weight_g": 350,
     "field_of_view_deg": "111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal",
     "release_notes": "Older-gen 2MP IR fixed bullet (G1) with basic smart events; no audio, no AcuSense.",
     "added": "2026-07-07"
@@ -148061,7 +148075,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148133,7 +148148,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 179.2 (dia x H)",
+    "weight_g": 500,
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter IR bullet with strong low-light and built-in mic (-U).",
     "added": "2026-07-07"
@@ -148223,7 +148240,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "215.2 x 78.8 x 78.6",
+    "weight_g": 680,
     "video": {
       "codecs": [
         "H.265+",
@@ -148481,7 +148500,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148553,7 +148573,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "70 x 161.7 (dia x H)",
+    "weight_g": 490,
     "field_of_view_deg": "103 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with 40m IR and built-in mic (-U).",
     "added": "2026-07-07"
@@ -148654,7 +148676,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "215.2 x 78.8 x 78.6",
+    "weight_g": 695,
     "field_of_view_deg": "102 (2.8mm) horizontal",
     "release_notes": "4MP ColorVu 24/7-color bullet with F1.0 lens and white light (no IR).",
     "added": "2026-07-07"
@@ -148839,7 +148863,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "74.4 x 176.3 (dia x H)",
+    "weight_g": 515,
     "field_of_view_deg": "104 (2.8mm)/84 (4mm)/52 (6mm) horizontal",
     "release_notes": "4MP AcuSense Smart Hybrid Light bullet with built-in dual microphone.",
     "added": "2026-07-07"
@@ -149093,7 +149119,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -149165,7 +149192,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 176.3",
+    "weight_g": 515,
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -149192,7 +149221,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -149264,7 +149294,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 525,
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
     "added": "2026-07-07"
@@ -149353,7 +149385,33 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "added": "2026-06-09"
   },
   {
@@ -149717,7 +149775,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 525,
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
     "added": "2026-07-07"
@@ -149818,7 +149878,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -149920,7 +149982,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 176.3",
+    "weight_g": 530,
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
     "added": "2026-07-07"
@@ -150325,7 +150389,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 74.4 x 179.2",
+    "weight_g": 510,
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -150467,7 +150533,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150538,7 +150605,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 70 x 161.7",
+    "weight_g": 495,
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
     "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
     "added": "2026-07-07"
@@ -150764,7 +150833,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150836,9 +150906,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm)/51 (6mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 485,
     "added": "2026-07-07"
   },
   {
@@ -150863,7 +150935,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -150936,7 +151009,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "72.9 x 73.3 x 191.1",
+    "weight_g": 595,
     "field_of_view_deg": "110 (2.8mm)/88 (4mm)/60 (6mm) horizontal",
     "release_notes": "8MP AcuSense bullet with active strobe/siren deterrence and two-way audio; 40m IR.",
     "added": "2026-07-07"
@@ -150963,7 +151038,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -151036,9 +151112,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet with red/blue flashing deterrence and two-way audio.",
+    "dimensions_mm": "Ø74.4 x 176.3",
+    "weight_g": 515,
+    "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "added": "2026-07-07"
   },
   {
@@ -151063,7 +151142,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -151135,9 +151215,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter IR mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 525,
     "added": "2026-07-07"
   },
   {
@@ -151225,7 +151307,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -151256,6 +151338,8 @@
         }
       ]
     },
+    "dimensions_mm": "78.8 x 78.6 x 215.2",
+    "weight_g": 850,
     "added": "2026-06-09"
   },
   {
@@ -151644,9 +151728,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP ColorVu Smart Hybrid Light mini bullet with built-in mic (-U).",
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 525,
     "added": "2026-07-07"
   },
   {
@@ -151732,7 +151818,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "102",
     "ip_rating": "IP67",
@@ -151766,6 +151852,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø74.4 x 179.2",
+    "weight_g": 510,
     "added": "2026-07-06"
   },
   {
@@ -151955,9 +152043,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "release_notes": "8MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
+    "dimensions_mm": "Ø74.4 x 176.3",
+    "weight_g": 530,
     "added": "2026-07-07"
   },
   {
@@ -152174,7 +152264,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152247,9 +152338,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "2MP EXIR IR AcuSense vandal dome; -S adds line-level audio + alarm I/O (no built-in mic).",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 530,
     "added": "2026-07-07"
   },
   {
@@ -152350,7 +152443,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.009
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152425,9 +152519,11 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm)/52 (6mm) horizontal",
     "release_notes": "Older-gen 2MP indoor IR dome with HDMI output for public-view-monitor use; IP42 indoor-only.",
+    "dimensions_mm": "Ø119 x 90",
+    "weight_g": 520,
     "added": "2026-07-07"
   },
   {
@@ -152452,7 +152548,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152526,9 +152623,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter vandal dome (plain -I: no audio/alarm); IP67/IK10.",
+    "dimensions_mm": "Ø110.8 x 84.7",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -152619,7 +152718,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense fixed dome with direct HDMI (type D) live-view output; IK10 metal body, 2.8mm F1.4 fixed lens, 30m IR, audio line-in/out & alarm I/O.",
     "configs": {
       "frigate": {
@@ -152634,6 +152733,8 @@
         "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
       }
     },
+    "dimensions_mm": "Ø119 x 90",
+    "weight_g": 440,
     "added": "2026-07-28"
   },
   {
@@ -152658,7 +152759,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -152733,9 +152835,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "release_notes": "2MP AcuSense DarkFighter vandal dome; -ISU adds built-in mic + audio/alarm I/O.",
+    "dimensions_mm": "Ø121.4 x 92.2",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -153212,6 +153316,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 780,
     "operating_temp_c": "-30 to 60",
     "audio": {
       "microphone": true,
@@ -153238,7 +153344,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -153390,7 +153496,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -153407,6 +153514,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153465,7 +153574,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter vandal dome (IR-only despite G2H) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -153546,6 +153655,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 125.2 (dia x H)",
+    "weight_g": 750,
     "environment": [
       "indoor",
       "outdoor"
@@ -153574,7 +153685,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -153629,6 +153740,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.4 x 100.1 (dia x H)",
+    "weight_g": 580,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153687,7 +153800,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "release_notes": "4MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -153854,6 +153967,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 125.2 (dia x H)",
+    "weight_g": 750,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -153912,7 +154027,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -154058,6 +154173,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "140 x 145.6 (dia x H)",
+    "weight_g": 920,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -154118,7 +154235,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light vandal dome with HikAI-ISP, EIS and dual-mic.",
     "added": "2026-07-07"
@@ -154481,6 +154598,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -154539,7 +154658,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -154658,7 +154777,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -154675,6 +154795,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.2 (dia x H)",
+    "weight_g": 800,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -154732,7 +154854,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "8MP AcuSense IR vandal dome (20fps at 4K); -S adds line-level audio + alarm I/O.",
     "added": "2026-07-07"
@@ -155081,6 +155203,8 @@
       "onvif"
     ],
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "operating_temp_c": "-10 to 40",
     "audio": {
       "microphone": false,
@@ -155105,7 +155229,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -155143,7 +155267,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -155160,6 +155285,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 770,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155218,7 +155345,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111 (2.8mm)/87 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter vandal dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155245,7 +155372,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -155262,6 +155390,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 525,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155321,7 +155451,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "8MP AcuSense DarkFighter vandal dome (F1.0, IR-only) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155366,6 +155496,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -155425,7 +155557,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "109 (2.8mm)/93 (4mm) horizontal",
     "release_notes": "8MP ColorVu 24/7-color vandal dome (F1.0) with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -155647,8 +155779,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
+    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "weight_g": 525,
     "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -155861,11 +155995,13 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "weight_g": 600,
     "video": {
       "codecs": [
         "H.265+",
@@ -155964,6 +156100,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 750,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -155989,7 +156127,7 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -156076,6 +156214,8 @@
     ],
     "ip_rating": "IP67",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -156102,7 +156242,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "release_year": 2025,
     "configs": {
       "frigate": {
@@ -156413,7 +156553,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156484,9 +156625,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "weight_g": 560,
     "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
   },
@@ -156512,7 +156655,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156584,9 +156728,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "weight_g": 570,
     "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
     "added": "2026-07-07"
   },
@@ -156685,9 +156831,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "weight_g": 770,
     "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
     "added": "2026-07-07"
   },
@@ -156713,7 +156861,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156784,9 +156933,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+    "weight_g": 600,
     "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
   },
@@ -156896,7 +157047,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.028
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -156968,8 +157120,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
+    "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+    "weight_g": 520,
     "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
     "added": "2026-07-07"
   },
@@ -156995,7 +157149,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -157069,9 +157224,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+    "weight_g": 825,
     "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
     "added": "2026-07-07"
   },
@@ -157286,9 +157443,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "ip_rating": "IP67",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 780,
     "release_notes": "4MP G2H hybrid-light AcuSense turret (F1.0) with red/blue-plus-white flashing strobe, audible warning and two-way audio.",
     "added": "2026-07-07"
   },
@@ -157386,10 +157545,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "4MP G2H DarkFighter AcuSense turret (F1.0, IR supplement) with built-in mic (-U).",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 550,
     "added": "2026-07-07"
   },
   {
@@ -157558,7 +157719,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
@@ -157592,6 +157753,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 125.2",
+    "weight_g": 750,
     "added": "2026-07-06"
   },
   {
@@ -157676,7 +157839,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "111.9",
     "ip_rating": "IP67",
@@ -157710,6 +157873,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 760,
     "added": "2026-07-06"
   },
   {
@@ -157797,7 +157962,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -157828,6 +157993,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 125.2",
+    "weight_g": 750,
     "added": "2026-06-06"
   },
   {
@@ -158163,10 +158330,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal / 81 vertical (dual-lens panoramic)",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-lens panoramic ColorVu turret giving a 180deg stitched image with 24/7 color, strobe/audible deterrence and two-way audio.",
+    "dimensions_mm": "Ø140 x 145.6",
+    "weight_g": 920,
     "added": "2026-07-07"
   },
   {
@@ -158267,10 +158436,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-07"
   },
   {
@@ -158358,7 +158529,39 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø138.3 x 115.2",
+    "weight_g": 800,
+    "video": {
+      "codecs": [
+        "H.265+",
+        "H.265",
+        "H.264+",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-06-06"
   },
   {
@@ -158442,7 +158645,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.1",
     "ip_rating": "IP67",
@@ -158476,6 +158679,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-06"
   },
   {
@@ -158572,10 +158777,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "6MP G2H ColorVu Smart Hybrid Light turret with built-in mic (-U).",
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 770,
     "added": "2026-07-07"
   },
   {
@@ -158660,7 +158867,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "Dual 1/2.5\" Progressive Scan CMOS",
     "field_of_view_deg": "180",
     "ip_rating": "IP67",
@@ -158688,6 +158895,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø140 x 145.6",
+    "weight_g": 920,
     "added": "2026-07-06"
   },
   {
@@ -158773,7 +158982,7 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
@@ -158807,6 +159016,8 @@
         }
       ]
     },
+    "dimensions_mm": "Ø138.3 x 115.4",
+    "weight_g": 820,
     "added": "2026-07-06"
   },
   {
@@ -158917,7 +159128,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -158932,6 +159144,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "127.3 x 95.9 (dia x H)",
+    "weight_g": 600,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -158988,7 +159202,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense IR turret (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
@@ -159562,7 +159776,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159577,6 +159792,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 780,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -159635,7 +159852,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "105 (2.8mm)/90 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G2H AcuSense IR turret with two-way audio and red/blue + white flashing active deterrence.",
@@ -159663,7 +159880,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -159678,6 +159896,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 775,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -159734,7 +159954,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G2H AcuSense DarkFighter IR turret (F1.0) with built-in mic (-U).",
@@ -159895,6 +160115,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -159953,7 +160175,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid Light turret with strobe/audible deterrence and two-way audio.",
@@ -160227,6 +160449,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160274,7 +160498,22 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 30,
+          "codec": "H.265"
+        }
+      ]
+    },
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
     "ip_rating": "IP67",
@@ -160318,6 +160557,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "138.3 x 115.4 (dia x H)",
+    "weight_g": 820,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160377,7 +160618,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/93.3 (4mm) horizontal",
     "ip_rating": "IP67",
     "release_notes": "8MP G3 ColorVu Smart Hybrid Light turret with HikAI-ISP, two-way audio and red/blue + white flashing deterrence.",
@@ -160406,7 +160647,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.028
     },
     "power": {
       "method": "DC 12V"
@@ -160421,6 +160663,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160478,7 +160722,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm) horizontal",
     "release_notes": "2MP indoor IR fixed cube with built-in 2.4GHz Wi-Fi, PIR and two-way audio; DC-powered (no PoE).",
     "added": "2026-07-07"
@@ -160505,7 +160749,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160520,6 +160765,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160578,7 +160825,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108.8 (2.8mm)/87.6 (4mm) horizontal",
     "release_notes": "2MP indoor AcuSense fixed cube with PIR, two-way audio and human/vehicle detection.",
     "added": "2026-07-07"
@@ -160606,7 +160853,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160621,6 +160869,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160679,7 +160929,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "92 (2.8mm)/75 (4mm) horizontal",
     "release_notes": "2MP indoor AcuSense fixed cube with built-in 2.4GHz Wi-Fi and two-way audio.",
     "added": "2026-07-07"
@@ -160706,7 +160956,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160721,6 +160972,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160779,7 +161032,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "104.3 (2.8mm)/83.7 (4mm) horizontal",
     "release_notes": "4MP indoor AcuSense fixed cube with PIR and two-way audio (non-DarkFighter sibling of the 2446G2-I).",
     "added": "2026-07-07"
@@ -160882,7 +161135,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -160897,6 +161151,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D; 2.8/4mm) / 102.9 x 65.2 x 28.8 (2mm)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -160956,7 +161212,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "release_notes": "4MP indoor AcuSense DarkFighter fixed cube with PIR and two-way audio.",
     "added": "2026-07-07"
@@ -161069,7 +161325,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 10
+      "range_m": 10,
+      "min_lux_color": 0.008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161084,6 +161341,8 @@
       "onvif",
       "rtsp"
     ],
+    "dimensions_mm": "102.9 x 65.2 x 32.6 (W x H x D)",
+    "weight_g": 120,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -161142,7 +161401,7 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "107.8 (2.8mm)/82.8 (4mm) horizontal",
     "release_notes": "8MP indoor AcuSense fixed cube (H.265-only, 15fps at 4K) with PIR and two-way audio.",
     "added": "2026-07-07"
@@ -161169,7 +161428,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161242,10 +161502,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "108 (2.8mm)/86 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "110 x 57.4 (dia x H)",
+    "weight_g": 380,
     "release_notes": "2MP AcuSense fixed mini dome with 30m EXIR, IP67/IK08 and audio/alarm I/O (-S).",
     "added": "2026-07-07"
   },
@@ -161654,7 +161916,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -161728,10 +161991,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "102.7 (2.8mm)/82.8 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "110 x 57.4 (dia x H)",
+    "weight_g": 380,
     "release_notes": "4MP AcuSense mini dome with built-in 2.4GHz Wi-Fi, 30m EXIR and IP67/IK08.",
     "added": "2026-07-07"
   },
@@ -161833,10 +162098,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "112 (2.8mm)/95 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "4MP ColorVu 24/7-color mini dome (F1.0) with 30m white light, IP67/IK08 and audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -161991,7 +162258,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162064,10 +162332,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "106.4 (2.8mm)/87.6 (4mm) horizontal",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "8MP (4K) AcuSense fixed mini dome (20fps at 4K) with 30m EXIR, IP67/IK08 and audio/alarm I/O.",
     "added": "2026-07-07"
   },
@@ -162093,7 +162363,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162167,9 +162438,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "field_of_view_deg": "110.0 (2.8mm)/88.0 (4mm) horizontal",
+    "dimensions_mm": "113.6 x 72.6 (dia x H)",
+    "weight_g": 400,
     "release_notes": "8MP AcuSense EXIR fixed mini dome, 30m IR; -IS audio/alarm I/O + mic.",
     "added": "2026-07-07"
   },
@@ -162195,7 +162469,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162267,10 +162542,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "107°-32° (H)",
+    "field_of_view_deg": "107-32 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1440,
     "release_notes": "2MP AcuSense motorized-varifocal bullet, 60m IR, IP67/IK10.",
     "added": "2026-07-07"
   },
@@ -162411,7 +162688,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162484,9 +162762,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "95.8-29.2 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1390,
     "release_notes": "4MP AcuSense motorized-varifocal bullet, 60m IR.",
     "added": "2026-07-07"
   },
@@ -162512,7 +162793,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162585,10 +162867,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-30° horizontal",
+    "field_of_view_deg": "108-30 horizontal",
+    "dimensions_mm": "144.1 x 345.7 (dia x L)",
+    "weight_g": 1445,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; -S line-level audio.",
     "added": "2026-07-07"
   },
@@ -162614,7 +162898,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162686,9 +162971,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "105.4-34.3 (H)",
+    "dimensions_mm": "140 x 333.8 (dia x L)",
+    "weight_g": 1490,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR (IR-only despite G2H).",
     "added": "2026-07-07"
   },
@@ -162714,7 +163002,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162787,9 +163076,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "105.4-34.3 (H)",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1490,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (HT), 60m IR.",
     "added": "2026-07-07"
   },
@@ -162815,7 +163107,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -162888,9 +163181,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "108-30 (H)",
+    "dimensions_mm": "308.5 x 97.9 x 93",
+    "weight_g": 1355,
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal bullet (T), 60m IR.",
     "added": "2026-07-07"
   },
@@ -163077,9 +163373,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "114.6-41.8 (H)",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
     "release_notes": "4MP ColorVu Smart Hybrid motorized-varifocal bullet, 60m.",
     "added": "2026-07-07"
   },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -142168,8 +142168,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142203,7 +142207,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142230,6 +142234,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø180 x 239.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142262,7 +142269,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142289,6 +142296,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142322,7 +142332,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "added": "2026-07-06"
   },
   {
@@ -142347,8 +142357,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142382,7 +142396,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142409,6 +142423,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø180 x 239.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142441,7 +142458,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142468,6 +142485,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø165 x 179.5",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC"
     },
@@ -142501,7 +142521,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "added": "2026-07-06"
   },
   {
@@ -142526,8 +142546,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 100
+      "range_m": 100,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø164.5 x 290.6",
+    "weight_g": 2000,
     "power": {
       "method": "12 VDC (IR 7W)"
     },
@@ -142561,7 +142585,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142589,6 +142613,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142621,7 +142648,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142648,6 +142675,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "57.6h",
+    "dimensions_mm": "Ø220 x 280",
+    "weight_g": 3000,
     "power": {
       "method": "36 VDC"
     },
@@ -142680,7 +142710,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "added": "2026-07-06"
@@ -142709,6 +142739,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142741,7 +142774,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142768,6 +142801,9 @@
     "night_vision": {
       "type": "none"
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø220 x 280",
+    "weight_g": 3000,
     "power": {
       "method": "36 VDC"
     },
@@ -142800,7 +142836,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
     "added": "2026-07-06"
@@ -142829,6 +142865,9 @@
       "type": "ir",
       "range_m": 150
     },
+    "field_of_view_deg": "55h",
+    "dimensions_mm": "Ø208 x 343.9",
+    "weight_g": 3300,
     "power": {
       "method": "36 VDC"
     },
@@ -142861,7 +142900,7 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "added": "2026-07-06"
   },
@@ -142885,9 +142924,11 @@
       "focal_length_mm": "4.8-153.6",
       "varifocal": true
     },
+    "field_of_view_deg": "55 horizontal/33 vertical/61.5 diagonal (wide end)",
     "night_vision": {
       "type": "ir",
-      "range_m": 150
+      "range_m": 150,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "36 VDC"
@@ -142922,8 +142963,10 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
+    "dimensions_mm": "Ø 220 x 356.9",
+    "weight_g": 4500,
     "added": "2026-07-06"
   },
   {
@@ -143183,7 +143226,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -143254,9 +143298,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "field_of_view_deg": "104° (2.8mm)/81° (4mm) horizontal",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 285,
     "release_notes": "Entry 1-series AcuSense fixed bullet; -UF adds mic + microSD.",
     "added": "2026-07-07"
   },
@@ -143343,7 +143389,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 265,
     "video": {
       "codecs": [
         "H.265+",
@@ -143390,6 +143438,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143463,8 +143512,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 265,
     "release_notes": "2MP Smart Hybrid Light (LIU) 1-series bullet; IR+white to 30m.",
     "added": "2026-07-07"
   },
@@ -143613,6 +143664,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143687,8 +143739,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "release_notes": "2MP ColorVu G2H Smart Hybrid 1-series bullet with built-in mic.",
     "added": "2026-07-07"
   },
@@ -143712,9 +143766,11 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -143786,8 +143842,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "release_notes": "4MP AcuSense 1-series fixed bullet; -UF adds mic + microSD.",
     "added": "2026-07-07"
   },
@@ -143874,7 +143932,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "video": {
       "codecs": [
         "H.265+",
@@ -143921,6 +143981,7 @@
       "focal_length_mm": "2.8/4",
       "varifocal": false
     },
+    "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -143996,8 +144057,10 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "170.8 x 66 x 69.1",
+    "weight_g": 270,
     "release_notes": "4MP Smart Hybrid Light 1-series bullet with built-in mic.",
     "added": "2026-07-07"
   },
@@ -144097,7 +144160,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø 76.6 x 164.4",
+    "weight_g": 430,
     "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
     "added": "2026-07-07"
   },
@@ -144198,7 +144263,9 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "release_notes": "4MP ColorVu G2H bullet with Smart Hybrid Light (switchable IR + white light) and AcuSense.",
     "added": "2026-07-07"
   },
@@ -144242,6 +144309,8 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "dimensions_mm": "67.9 x 69.8 x 172.9",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144299,7 +144368,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H bullet (1/2.4\" sensor) with Smart Hybrid Light and AcuSense; 20fps at full res.",
     "added": "2026-07-07"
   },
@@ -144326,7 +144395,8 @@
     "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144342,6 +144412,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "110.8 x 84.7 (dia x H)",
+    "weight_g": 520,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -144398,7 +144470,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense fixed dome with EXIR 2.0 IR (30m) and IK10; base -I has no audio or microSD slot.",
     "added": "2026-07-07"
   },
@@ -144447,6 +144519,9 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144485,7 +144560,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -144553,6 +144628,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144610,7 +144687,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP Smart Hybrid Light dome (IR + white light) with AcuSense, F1.6 lens and built-in mic; IK08.",
     "added": "2026-07-07"
   },
@@ -144655,6 +144732,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 500,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144712,7 +144791,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu fixed dome (G0) with F1.0 lens, 30m white light 24/7 color and IK08; no IR.",
     "added": "2026-07-07"
   },
@@ -144757,6 +144836,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -144814,7 +144895,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu G2H dome with Smart Hybrid Light, F1.0 lens, AcuSense and IK08.",
     "added": "2026-07-07"
   },
@@ -144841,7 +144922,8 @@
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144857,6 +144939,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "110.8 x 84.7 (dia x H)",
+    "weight_g": 520,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -144915,7 +144999,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense fixed dome with 30m EXIR IR, 120dB WDR and IK10; base -I has no audio or microSD.",
     "added": "2026-07-07"
   },
@@ -144942,7 +145026,8 @@
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
     "night_vision": {
       "type": "ir",
-      "range_m": 25
+      "range_m": 25,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -144959,6 +145044,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "121.4 x 92.2 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145018,7 +145105,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense IR dome adding a built-in mic (-U) and up to 256GB microSD (-F) over the base -I.",
     "added": "2026-07-07"
   },
@@ -145067,6 +145154,9 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145105,7 +145195,7 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "video": {
       "codecs": [
         "H.265+",
@@ -145173,6 +145263,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.4 x 97.7 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145230,7 +145322,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP Smart Hybrid Light dome (switchable IR + white light) with F1.6 lens, mic and up to 512GB microSD; IK08.",
     "added": "2026-07-07"
   },
@@ -145440,6 +145532,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 500,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145497,7 +145591,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu 24/7-color dome (G0) with F1.0 lens and 30m white light; IK08, built-in mic.",
     "added": "2026-07-07"
   },
@@ -145542,6 +145636,8 @@
     ],
     "ip_rating": "IP67",
     "ik_rating": "IK08",
+    "dimensions_mm": "121.5 x 97.6 (dia x H)",
+    "weight_g": 550,
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -145599,7 +145695,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu G2H dome combining F1.0 24/7-color with switchable IR, plus AcuSense and mic; IK08.",
     "added": "2026-07-07"
   },
@@ -145696,6 +145792,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+    "dimensions_mm": "Ø121.5 x 97.6",
+    "weight_g": 550,
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
@@ -145773,7 +145871,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H dome (1/2.4\" sensor, 115 wide FOV) with Smart Hybrid Light, AcuSense and mic; 20fps.",
     "added": "2026-07-07"
   },
@@ -145870,6 +145968,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "104 (2.8mm)/81 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 85.3",
+    "weight_g": 340,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -145944,7 +146044,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense EXIR fixed turret with human/vehicle detection and built-in mic (-U); 30m IR.",
     "added": "2026-07-07"
   },
@@ -145969,6 +146069,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "103 (2.8mm)/83 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 89.2",
+    "weight_g": 340,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146044,7 +146146,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
     "added": "2026-07-07"
   },
@@ -146069,6 +146171,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "106 (2.8mm)/88 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 380,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146144,7 +146248,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and built-in mic.",
     "added": "2026-07-07"
   },
@@ -146169,6 +146273,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "99 (2.8mm)/76 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 85.3",
+    "weight_g": 340,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146244,7 +146350,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense EXIR fixed turret with 120dB WDR, human/vehicle detection and mic; 20fps at 4MP.",
     "added": "2026-07-07"
   },
@@ -146269,6 +146375,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "98 (2.8mm)/78 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 89.2",
+    "weight_g": 340,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146344,7 +146452,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP Smart Hybrid Light turret (IR + white light to 30m) with AcuSense, F1.6 lens and mic.",
     "added": "2026-07-07"
   },
@@ -146369,6 +146477,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "96 (2.8mm)/80 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 420,
     "night_vision": {
       "type": "hybrid",
       "range_m": 30,
@@ -146444,7 +146554,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP ColorVu G2H turret with F1.0 lens (0.001 lux color), Smart Hybrid Light to 30m and mic.",
     "added": "2026-07-07"
   },
@@ -146469,6 +146579,8 @@
       "varifocal": false
     },
     "field_of_view_deg": "115 (2.8mm)/94 (4mm) horizontal",
+    "dimensions_mm": "Ø110 x 93",
+    "weight_g": 415,
     "night_vision": {
       "type": "hybrid",
       "range_m": 20,
@@ -146545,7 +146657,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "6MP ColorVu G2H turret (1/2.4\" sensor) with F1.0 lens, Smart Hybrid Light to 30m and mic; 20fps.",
     "added": "2026-07-07"
   },
@@ -146570,6 +146682,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "102.4-31.2 horizontal",
+    "dimensions_mm": "Ø105 x 244.4",
+    "weight_g": 720,
     "night_vision": {
       "type": "ir",
       "range_m": 50
@@ -146646,7 +146760,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 50m IR and up to 256GB microSD.",
     "added": "2026-07-07"
   },
@@ -146671,6 +146785,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "95.9-29.2 horizontal",
+    "dimensions_mm": "Ø105 x 244.4",
+    "weight_g": 745,
     "night_vision": {
       "type": "ir",
       "range_m": 50
@@ -146747,7 +146863,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR bullet with 120dB WDR and 50m IR; 20fps at 4MP.",
     "added": "2026-07-07"
   },
@@ -146772,6 +146888,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "102.4-31.2 horizontal",
+    "dimensions_mm": "Ø141 x 99.9",
+    "weight_g": 820,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146848,7 +146966,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "2MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 30m IR; IP67/IK10.",
     "added": "2026-07-07"
   },
@@ -146873,6 +146991,8 @@
       "varifocal": true
     },
     "field_of_view_deg": "95.9-29.2 horizontal",
+    "dimensions_mm": "Ø141 x 99.9",
+    "weight_g": 820,
     "night_vision": {
       "type": "ir",
       "range_m": 30
@@ -146950,7 +147070,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "release_notes": "4MP AcuSense motorized-varifocal (2.8-12mm) EXIR vandal dome with 120dB WDR, 30m IR; IK10.",
     "added": "2026-07-07"
   },

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -142965,7 +142965,7 @@
     ],
     "last_verified": "2026-08-03",
     "ip_rating": "IP66",
-    "dimensions_mm": "Ø 220 x 356.9",
+    "dimensions_mm": "Ø220 x 356.9",
     "weight_g": 4500,
     "added": "2026-07-06"
   },
@@ -143114,7 +143114,8 @@
     "field_of_view_deg": "112.1 horizontal (2.8mm) / 90.2 horizontal (4mm)",
     "night_vision": {
       "type": "ir",
-      "range_m": 30
+      "range_m": 30,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af, Class 3) / DC 12V",
@@ -143154,7 +143155,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/m000007714/DS-2CD1023G0E-I_Datasheet_20260409.pdf"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -144161,7 +144162,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 76.6 x 164.4",
+    "dimensions_mm": "Ø76.6 x 164.4",
     "weight_g": 430,
     "release_notes": "4MP ColorVu fixed bullet (G0) with F1.0 lens and 30m white-light 24/7 color imaging; no IR, no AcuSense.",
     "added": "2026-07-07"
@@ -147543,6 +147544,18 @@
           "resolution": "4608x3456",
           "fps": 15,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
@@ -147589,7 +147602,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -148892,7 +148905,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -148959,13 +148973,27 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 485,
+    "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet (F1.4, non-'H') with built-in mic (-U).",
     "added": "2026-07-07"
@@ -149193,7 +149221,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 176.3",
+    "dimensions_mm": "Ø74.4 x 176.3",
     "weight_g": 515,
     "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR bullet with red/blue flashing + audible-warning active deterrence and two-way audio.",
@@ -149295,7 +149323,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 525,
     "field_of_view_deg": "100.2 (2.8mm)/81.1 (4mm) horizontal",
     "release_notes": "4MP AcuSense DarkFighter IR bullet with built-in mic (-U).",
@@ -149410,7 +149438,7 @@
       ]
     },
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "added": "2026-06-09"
   },
@@ -149776,7 +149804,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 525,
     "field_of_view_deg": "104 (2.8mm)/89.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light mini bullet; -U adds a built-in mic (no speaker/deterrence).",
@@ -149879,7 +149907,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "field_of_view_deg": "111.9 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light bullet with active strobe/siren deterrence and two-way audio.",
@@ -149983,7 +150011,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 176.3",
+    "dimensions_mm": "Ø74.4 x 176.3",
     "weight_g": 530,
     "field_of_view_deg": "111.1 (2.8mm)/95.2 (4mm) horizontal",
     "release_notes": "4MP G3 ColorVu Smart Hybrid Light bullet with HikAI-ISP and red/blue + white-light flashing deterrence.",
@@ -150390,7 +150418,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 74.4 x 179.2",
+    "dimensions_mm": "Ø74.4 x 179.2",
     "weight_g": 510,
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
     "release_notes": "6MP ColorVu Smart Hybrid Light bullet with active deterrence and two-way audio.",
@@ -150606,7 +150634,7 @@
       "outdoor"
     ],
     "last_verified": "2026-08-03",
-    "dimensions_mm": "Ø 70 x 161.7",
+    "dimensions_mm": "Ø70 x 161.7",
     "weight_g": 495,
     "field_of_view_deg": "107 (2.8mm)/87 (4mm)/54 (6mm) horizontal",
     "release_notes": "Entry 8MP AcuSense IR bullet (1/2.8\" sensor, 20fps at 4K) with built-in mic (-U).",
@@ -155643,8 +155671,10 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
+    "dimensions_mm": "Ø121.5 x 97.6",
+    "weight_g": 525,
     "field_of_view_deg": "105.1",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
@@ -155781,7 +155811,7 @@
     ],
     "last_verified": "2026-08-03",
     "field_of_view_deg": "105.1 (2.8mm)/90 (4mm) horizontal",
-    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
     "weight_g": 525,
     "release_notes": "8MP ColorVu Smart Hybrid Light vandal mini dome with built-in mic + audio/alarm I/O.",
     "added": "2026-07-07"
@@ -156000,7 +156030,7 @@
     "field_of_view_deg": "111",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "dimensions_mm": "Ø 121.5 x 97.6 (dia x H)",
+    "dimensions_mm": "Ø121.5 x 97.6 (dia x H)",
     "weight_g": 600,
     "video": {
       "codecs": [
@@ -156100,7 +156130,7 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 750,
     "audio": {
       "microphone": true,
@@ -156214,7 +156244,7 @@
     ],
     "ip_rating": "IP67",
     "operating_temp_c": "-30 to 60",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 820,
     "audio": {
       "microphone": true,
@@ -156628,7 +156658,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/87 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
     "weight_g": 560,
     "release_notes": "2MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
@@ -156731,7 +156761,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/86 (4mm)/55 (6mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 96.3 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 96.3 (dia x H)",
     "weight_g": 570,
     "release_notes": "2MP AcuSense DarkFighter turret with three lens options and built-in mic; 30m IR.",
     "added": "2026-07-07"
@@ -156834,7 +156864,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "107 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 138.3 x 115.4 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 115.4 (dia x H)",
     "weight_g": 770,
     "release_notes": "2MP ColorVu 24/7-color turret (F1.0) with 30m white light and built-in mic.",
     "added": "2026-07-07"
@@ -156936,7 +156966,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 127.3 x 95.9 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 95.9 (dia x H)",
     "weight_g": 600,
     "release_notes": "4MP AcuSense fixed turret with built-in mic and 30m IR.",
     "added": "2026-07-07"
@@ -157122,7 +157152,7 @@
     ],
     "last_verified": "2026-08-03",
     "field_of_view_deg": "180 horizontal (ultra-wide panoramic)",
-    "dimensions_mm": "Ø 127.3 x 104.1 (dia x H)",
+    "dimensions_mm": "Ø127.3 x 104.1 (dia x H)",
     "weight_g": 520,
     "release_notes": "4MP indoor turret with a 1.68mm 180deg panoramic fisheye lens and short-range 10m IR; no IP rating (indoor).",
     "added": "2026-07-07"
@@ -157227,7 +157257,7 @@
     "last_verified": "2026-08-03",
     "field_of_view_deg": "103 (2.8mm)/83 (4mm)/53 (6mm) horizontal",
     "ip_rating": "IP67",
-    "dimensions_mm": "Ø 138.3 x 124.5 (dia x H)",
+    "dimensions_mm": "Ø138.3 x 124.5 (dia x H)",
     "weight_g": 825,
     "release_notes": "4MP AcuSense active-deterrence turret with 30m IR, strobe light, audible warning and two-way audio.",
     "added": "2026-07-07"
@@ -163473,13 +163503,28 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1555,
+    "field_of_view_deg": "114.6-41.8 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "4MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
@@ -163575,13 +163620,28 @@
           "resolution": "3200x1800",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
+    "field_of_view_deg": "112.3-41.2 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal bullet (HT), 60m.",
@@ -163823,7 +163883,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -163890,16 +163951,30 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1475,
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° (H)",
+    "field_of_view_deg": "112.3-41.2 (H)",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -163925,7 +164000,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -163992,13 +164068,28 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1475,
+    "field_of_view_deg": "112.3-41.2 (H)",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet (HT); 24fps at 4K.",
@@ -164026,7 +164117,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164099,10 +164191,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "97.9 x 93 x 308.5",
+    "weight_g": 1380,
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° horizontal",
+    "field_of_view_deg": "108-46 horizontal",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal bullet, 60m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -164190,11 +164284,28 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "112.3-41.2",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1085,
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 24,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        }
+      ]
+    },
     "added": "2026-07-06"
   },
   {
@@ -164291,9 +164402,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "298 x 97.9 x 95.7",
+    "weight_g": 1465,
+    "field_of_view_deg": "103.3-40",
     "release_notes": "8MP ColorVu motorized-varifocal bullet, 60m white light; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -164394,9 +164508,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø140 x 333.8",
+    "weight_g": 1555,
+    "field_of_view_deg": "112.3-41.2",
     "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal bullet with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -164422,7 +164539,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164494,9 +164612,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.3 x 111.6",
+    "weight_g": 880,
+    "field_of_view_deg": "107-32",
     "release_notes": "2MP AcuSense motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164607,7 +164728,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164680,9 +164802,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.3 x 111.6",
+    "weight_g": 880,
+    "field_of_view_deg": "113-31",
     "release_notes": "2MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164793,7 +164918,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164866,9 +164992,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø153.5 x 133.1",
+    "weight_g": 845,
+    "field_of_view_deg": "108-30",
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -164894,7 +165023,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -164968,9 +165098,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 840,
+    "field_of_view_deg": "114.6-41.8",
     "release_notes": "4MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -164996,7 +165129,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -165070,10 +165204,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "105.4°-34.3° (H)",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "105.4-34.3 (H)",
     "release_notes": "4MP AcuSense DarkFighter motorized-varifocal vandal dome, 40m IR.",
     "added": "2026-07-07"
   },
@@ -165174,9 +165310,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 820,
+    "field_of_view_deg": "114.6-41.8",
     "release_notes": "4MP ColorVu Smart Hybrid PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -165277,10 +165416,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "114.6°-41.8° horizontal",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "114.6-41.8 horizontal",
     "release_notes": "4MP ColorVu Smart Hybrid Light motorized-varifocal vandal dome, 40m.",
     "added": "2026-07-07"
   },
@@ -165379,9 +165520,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø155 x 152",
+    "weight_g": 1600,
+    "field_of_view_deg": "105.4-56.4",
     "release_notes": "4MP ColorVu motorized-varifocal vandal dome, 40m white light.",
     "added": "2026-07-07"
   },
@@ -165463,6 +165607,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -165488,7 +165634,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165585,6 +165731,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -165609,7 +165757,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165702,6 +165850,8 @@
     "ip_rating": "IP67",
     "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1200,
     "environment": [
       "indoor",
       "outdoor"
@@ -165726,7 +165876,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -165855,6 +166005,7 @@
       "range_m": 40,
       "min_lux_color": 0.0028
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -165918,7 +166069,19 @@
         {
           "name": "main",
           "resolution": "3200x1800",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
           "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
           "codec": "H.265"
         }
       ]
@@ -165926,9 +166089,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 820,
     "release_notes": "6MP ColorVu Smart Hybrid motorized-varifocal vandal dome, 40m.",
     "added": "2026-07-07"
   },
@@ -166016,6 +166181,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1230,
     "audio": {
       "microphone": true,
       "speaker": true,
@@ -166037,7 +166204,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000077895/DS-2CD2767G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166134,6 +166301,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 1200,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -166156,7 +166325,7 @@
       "global"
     ],
     "release_year": 2025,
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166253,6 +166422,8 @@
       "outdoor"
     ],
     "operating_temp_c": "-30 to 60",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 850,
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -166274,7 +166445,7 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000106992/DS-2CD2767G3T-LIZSY_Datasheet_20250506.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -166312,8 +166483,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "108-30",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166378,15 +166551,29 @@
           "resolution": "3840x2160",
           "fps": 20,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "640x480",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "153.3 x 111.6 (dia x H)",
+    "weight_g": 855,
     "release_notes": "8MP AcuSense motorized-varifocal vandal dome (20fps at 4K), 40m IR.",
     "added": "2026-07-07"
   },
@@ -166412,8 +166599,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
+    "field_of_view_deg": "108-46",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166479,15 +166668,29 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "153.5 x 133.2 (dia x H)",
+    "weight_g": 1080,
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166513,8 +166716,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166580,7 +166785,19 @@
         {
           "name": "main",
           "resolution": "3840x2160",
+          "fps": 24,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
           "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
           "codec": "H.265"
         }
       ]
@@ -166588,9 +166805,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 840,
     "release_notes": "8MP AcuSense PTRZ varifocal dome with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -166616,8 +166835,10 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "112.3-41.2",
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -166683,15 +166904,29 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "141 x 112 (dia x H)",
+    "weight_g": 840,
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal vandal dome (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166787,16 +167022,30 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° (H)",
+    "dimensions_mm": "155 x 140.4 (dia x H)",
+    "weight_g": 820,
+    "field_of_view_deg": "112.3-41.2 (H)",
     "release_notes": "8MP ColorVu Smart Hybrid PTRZ varifocal dome with strobe/red-blue deterrence and two-way audio; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166896,9 +167145,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø141 x 112",
+    "weight_g": 820,
+    "field_of_view_deg": "112.3-41.2 horizontal",
     "release_notes": "8MP ColorVu Smart Hybrid motorized-varifocal vandal dome (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -166999,10 +167251,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "103.3°-40° horizontal",
+    "dimensions_mm": "Ø155 x 152",
+    "weight_g": 1525,
+    "field_of_view_deg": "103.3-40 horizontal",
     "release_notes": "8MP ColorVu white-light motorized-varifocal vandal dome; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -167204,7 +167458,9 @@
       "global"
     ],
     "release_year": 2024,
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1230,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167327,7 +167583,9 @@
       "https://assets.hikvision.com/prd/normal/all/doc/sm000106989/DS-2CD2787G3-LIPTRZS2UY_SRBBlack_Datasheet_20260629.pdf",
       "https://assets.hikvision.com/prd/normal/all/doc/sm000077899/DS-2CD2787G3-LIPTRZS2UY_SLBlack_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1230,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167446,7 +167704,9 @@
     "sources": [
       "https://assets.hikvision.com/prd/normal/all/doc/sm000107003/DS-2CD2787G3-LIPTRZSY_Datasheet_20260629.pdf"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "Ø155 x 140.4",
+    "weight_g": 1200,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -167575,7 +167835,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 8
+      "range_m": 8,
+      "min_lux_color": 0.017
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -167646,7 +167907,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø119.9 x 41.2",
+    "weight_g": 320,
+    "field_of_view_deg": "180 horizontal",
     "release_notes": "5MP indoor fisheye (no IP/IK rating); 8m IR; built-in mic.",
     "added": "2026-07-07"
   },
@@ -167741,7 +168005,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "31.5 x 31.5 x 39.7",
+    "weight_g": 93,
+    "field_of_view_deg": "93.9 (2.8mm)/75.5 (3.7mm) horizontal",
     "release_notes": "2MP mini modular covert camera; no IR, no IP rating (indoor), DC only.",
     "added": "2026-07-07"
   },
@@ -167838,7 +168105,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø93.9 x 117.5",
+    "weight_g": 155,
+    "field_of_view_deg": "107 (2.8mm)/88 (4mm) horizontal",
     "release_notes": "2MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -167935,7 +168205,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "Ø93.9 x 117.5",
+    "weight_g": 155,
+    "field_of_view_deg": "103 (2.8mm)/84 (4mm) horizontal",
     "release_notes": "4MP AcuSense in-ceiling indoor mini dome; no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -168033,9 +168306,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø138.3 x 126",
+    "weight_g": 830,
+    "field_of_view_deg": "106.6-31.7 horizontal",
     "release_notes": "2MP AcuSense motorized-varifocal turret, 40m IR.",
     "added": "2026-07-07"
   },
@@ -168134,9 +168410,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "Ø138.3 x 126",
+    "weight_g": 830,
+    "field_of_view_deg": "95.8-29.2 horizontal",
     "release_notes": "4MP AcuSense motorized-varifocal turret, 40m IR.",
     "added": "2026-07-07"
   },
@@ -168501,10 +168780,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP66",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° (H)",
+    "dimensions_mm": "Ø135.8 x 145.5",
+    "weight_g": 1160,
+    "field_of_view_deg": "108-46 (H)",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret, 40m IR; 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -168530,7 +168811,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -168603,9 +168885,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "dimensions_mm": "138.3 diameter x 126",
+    "weight_g": 850,
+    "field_of_view_deg": "108-46 horizontal, 58-26 vertical, 127.4 diagonal",
     "release_notes": "8MP AcuSense DarkFighter motorized-varifocal turret (HT); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -168707,10 +168992,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "112.3°-41.2° horizontal",
+    "field_of_view_deg": "112.3-41.2 horizontal",
+    "dimensions_mm": "143.5 diameter x 142.7",
+    "weight_g": 1265,
     "release_notes": "8MP G3 ColorVu Smart Hybrid motorized-varifocal turret with red/blue deterrence + two-way audio.",
     "added": "2026-07-07"
   },
@@ -168938,7 +169225,9 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -169055,7 +169344,9 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -169178,7 +169469,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169248,8 +169540,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "289 x 93.1 x 91.2",
+    "weight_g": 1100,
+    "field_of_view_deg": "107 horizontal, 57 vertical, 127 diagonal (2.8mm)",
     "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants (60m/80m), single-lens.",
     "added": "2026-07-07"
   },
@@ -169431,7 +169726,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.002
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169502,8 +169798,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "289 x 93.1 x 91.2",
+    "weight_g": 1020,
+    "field_of_view_deg": "107 horizontal, 57 vertical, 129 diagonal (2.8mm)",
     "release_notes": "2MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -169686,8 +169985,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 289.5",
+    "weight_g": 1090,
+    "field_of_view_deg": "107 horizontal, 56 vertical, 127 diagonal (2.8mm)",
     "release_notes": "2MP ColorVu fixed bullet, 60m white light.",
     "added": "2026-07-07"
   },
@@ -169713,7 +170015,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -169783,8 +170086,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 299.7",
+    "weight_g": 1070,
+    "field_of_view_deg": "103 horizontal, 55 vertical, 122 diagonal (2.8mm)",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -169964,8 +170270,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 278",
+    "weight_g": 570,
+    "field_of_view_deg": "180 horizontal, 101 vertical, 180 diagonal",
     "release_notes": "4MP ultra-wide 180deg panoramic-style fixed bullet, 20m IR.",
     "added": "2026-07-07"
   },
@@ -169991,7 +170300,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170062,8 +170372,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
+    "dimensions_mm": "105 diameter x 289.5",
+    "weight_g": 1075,
+    "field_of_view_deg": "103 horizontal, 55 vertical, 123 diagonal (2.8mm)",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
     "added": "2026-07-07"
   },
@@ -170172,7 +170485,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170244,9 +170558,11 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "103°/83°/53° (H)",
+    "field_of_view_deg": "103/83/53 (H)",
+    "dimensions_mm": "105 diameter x 287.6",
+    "weight_g": 1135,
     "release_notes": "4MP AcuSense active-deterrence bullet with strobe, audible warning and two-way audio; 60m IR.",
     "added": "2026-07-07"
   },
@@ -170272,7 +170588,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170343,9 +170660,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP AcuSense fixed bullet; 2I/4I = IR-range variants, single-lens.",
+    "field_of_view_deg": "100.2 horizontal (2.8mm), 81.1 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1085,
     "added": "2026-07-07"
   },
   {
@@ -170370,7 +170690,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.001
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170442,10 +170763,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "100° (2.8mm)/81° (4mm) horizontal",
+    "field_of_view_deg": "100 (2.8mm)/81 (4mm) horizontal",
     "release_notes": "4MP AcuSense IR fixed bullet with red/blue flashing active deterrence and two-way audio.",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -170470,7 +170793,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -170543,9 +170867,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-sensor panoramic bullet with strobe/audible deterrence and two-way audio.",
+    "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+    "dimensions_mm": "118.6 x 105.1 x 306.5",
+    "weight_g": 1400,
     "added": "2026-07-07"
   },
   {
@@ -170931,6 +171258,34 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30,
+      "streams": [
+        {
+          "name": "main",
+          "resolution": "2688x1520",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        }
+      ]
+    },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -170985,7 +171340,9 @@
         "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
       }
     },
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "added": "2026-06-06"
   },
   {
@@ -171083,9 +171440,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence and two-way audio.",
+    "field_of_view_deg": "104.0 horizontal (2.8mm), 89.2 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -171270,9 +171630,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP dual-sensor panoramic ColorVu bullet with strobe/audible deterrence + two-way audio.",
+    "field_of_view_deg": "180 horizontal, 81 vertical (2.8mm)",
+    "dimensions_mm": "118.6 x 105.1 x 306.5",
+    "weight_g": 1400,
     "added": "2026-07-07"
   },
   {
@@ -171463,9 +171826,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio.",
+    "field_of_view_deg": "111.1 horizontal (2.8mm), 95.2 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "added": "2026-07-07"
   },
   {
@@ -171820,9 +172186,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "6MP ColorVu Smart Hybrid fixed bullet; 20fps at 6MP.",
+    "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "added": "2026-07-07"
   },
   {
@@ -171921,9 +172290,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "6MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio.",
+    "field_of_view_deg": "105.1 horizontal (2.8mm), 90.0 horizontal (4mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "added": "2026-07-07"
   },
   {
@@ -171948,7 +172320,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.005
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172019,10 +172392,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "107°/87°/54° (H)",
+    "field_of_view_deg": "107/87/54 (H)",
     "release_notes": "8MP AcuSense fixed bullet; -2I to 60m / -4I to 80m IR; 20fps at 4K.",
+    "dimensions_mm": "105 x 299.7 (dia x H)",
+    "weight_g": 1090,
     "added": "2026-07-07"
   },
   {
@@ -172217,7 +172592,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172288,9 +172664,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
+    "field_of_view_deg": "111 horizontal (2.8mm), 87 horizontal (4mm), 51 horizontal (6mm)",
+    "dimensions_mm": "105 x 290 (dia x H)",
+    "weight_g": 1270,
     "added": "2026-07-07"
   },
   {
@@ -172400,7 +172779,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -172473,10 +172853,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "110°/88°/59° horizontal",
+    "field_of_view_deg": "110/88/59 horizontal",
     "release_notes": "8MP AcuSense active-deterrence bullet (white strobe) with two-way audio; 24fps at 4K.",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1130,
     "added": "2026-07-07"
   },
   {
@@ -172501,8 +172883,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 80
+      "range_m": 80,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1180,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -172565,13 +172951,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet; 2I/4I = IR-range variants; 24fps at 4K.",
     "added": "2026-07-07"
@@ -172598,8 +172996,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.0008
     },
+    "field_of_view_deg": "105 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.1 x 91.2",
+    "weight_g": 1220,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -172664,13 +173066,25 @@
           "resolution": "3840x2160",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP AcuSense fixed bullet with red/blue flashing active deterrence and two-way audio.",
     "added": "2026-07-07"
@@ -172992,6 +173406,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1085,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173055,13 +173472,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid fixed bullet; 24fps at 4K.",
     "added": "2026-07-07"
@@ -173091,6 +173520,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "105.1 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1205,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173156,13 +173588,25 @@
           "resolution": "3840x2160",
           "fps": 24,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP ColorVu Smart Hybrid fixed bullet with strobe/audible deterrence + two-way audio; 24fps at 4K.",
     "added": "2026-07-07"
@@ -173192,6 +173636,9 @@
       "range_m": 40,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "180 horizontal / 44 vertical (4mm)",
+    "dimensions_mm": "118.6 x 105.1 x 305.4",
+    "weight_g": 1420,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173258,13 +173705,19 @@
           "resolution": "5120x1440",
           "fps": 20,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1920x536",
+          "fps": 20,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP dual-sensor panoramic ColorVu bullet (5120x1440) with deterrence + two-way audio.",
     "added": "2026-07-07"
@@ -173443,9 +173896,11 @@
         "notes": "Select the 'Hikvision' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "field_of_view_deg": "108.8",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "ip_rating": "IP67",
     "video": {
       "codecs": [
@@ -173504,6 +173959,9 @@
       "range_m": 60,
       "min_lux_color": 0.0005
     },
+    "field_of_view_deg": "108.8 horizontal (2.8mm)",
+    "dimensions_mm": "286.7 x 93.3 x 91.2",
+    "weight_g": 1250,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173569,13 +174027,25 @@
           "resolution": "3840x2160",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "8MP G3 ColorVu Smart Hybrid fixed bullet with red/blue deterrence + two-way audio; 30fps at 4K.",
     "added": "2026-07-07"
@@ -173652,6 +174122,8 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "dimensions_mm": "118.6 x 78 x 306.5",
+    "weight_g": 1440,
     "environment": [
       "indoor",
       "outdoor"
@@ -173681,7 +174153,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-28",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -173719,8 +174191,11 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "dimensions_mm": "Ø70 x 161.7",
+    "weight_g": 490,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -173784,15 +174259,27 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
-    "field_of_view_deg": "103°/84°/52° (H)",
+    "field_of_view_deg": "103/84/52 (H)",
     "release_notes": "4MP AcuSense fixed bullet (3-series) with built-in mic (-U); 40m IR.",
     "added": "2026-07-07"
   },
@@ -174299,8 +174786,12 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 40
+      "range_m": 40,
+      "min_lux_color": 0.005
     },
+    "field_of_view_deg": "103.6 horizontal (2.8mm)",
+    "dimensions_mm": "Ø127.3 x 96.3",
+    "weight_g": 635,
     "power": {
       "method": "PoE (802.3af) / DC 12V"
     },
@@ -174364,13 +174855,31 @@
           "resolution": "2688x1520",
           "fps": 30,
           "codec": "H.265"
+        },
+        {
+          "name": "sub",
+          "resolution": "1280x720",
+          "fps": 30,
+          "codec": "H.265"
+        },
+        {
+          "name": "third",
+          "resolution": "1920x1080",
+          "fps": 10,
+          "codec": "H.265"
+        },
+        {
+          "name": "fourth",
+          "resolution": "1280x720",
+          "fps": 10,
+          "codec": "H.265"
         }
       ]
     },
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "release_notes": "4MP AcuSense fixed turret (3-series) with built-in mic; 40m IR.",
     "added": "2026-07-07"
@@ -174752,7 +175261,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 60
+      "range_m": 60,
+      "min_lux_color": 0.003
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -174827,10 +175337,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
-    "field_of_view_deg": "108°-46° horizontal",
+    "field_of_view_deg": "108-46 horizontal",
+    "dimensions_mm": "Ø105 x 332.8",
+    "weight_g": 1475,
     "release_notes": "8MP AcuSense HEOP motorized-varifocal bullet (3-series); 24fps at 4K.",
     "added": "2026-07-07"
   },
@@ -175356,7 +175868,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -175431,9 +175944,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø140.3 x 59.4",
+    "weight_g": 715,
     "release_notes": "6MP DeepinView fisheye with 4 built-in mics + speaker two-way audio; 15m IR.",
     "added": "2026-07-07"
   },
@@ -175532,7 +176048,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø165 x 48.9",
+    "weight_g": 470,
     "release_notes": "6MP DeepinView indoor fisheye (no IR, no IP rating); 4 built-in mics.",
     "added": "2026-07-07"
   },
@@ -175721,7 +176240,10 @@
     "environment": [
       "indoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "Ø165 x 48.9",
+    "weight_g": 470,
     "release_notes": "12MP DeepinView indoor fisheye (3504x3504); no IR, no IP rating.",
     "added": "2026-07-07"
   },
@@ -175822,7 +176344,8 @@
     },
     "night_vision": {
       "type": "ir",
-      "range_m": 15
+      "range_m": 15,
+      "min_lux_color": 0.01
     },
     "power": {
       "method": "PoE (802.3af) / DC 12V"
@@ -175896,9 +176419,12 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-07",
+    "last_verified": "2026-08-03",
     "ip_rating": "IP67",
     "ik_rating": "IK10",
+    "field_of_view_deg": "180 horizontal / 180 vertical",
+    "dimensions_mm": "213.73 x 199.67 x 137.57",
+    "weight_g": 610,
     "release_notes": "6MP DeepinView fisheye with two-way audio and 15m 940nm IR.",
     "added": "2026-07-07"
   },
@@ -176236,10 +176762,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x 60.9 x 57.9",
+    "weight_g": 266,
     "added": "2026-07-06"
   },
   {
@@ -176294,10 +176822,12 @@
     "power_source": [
       "dc"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-03",
     "sensor": "2MP CMOS",
     "field_of_view_deg": "101 / 78",
     "ip_rating": "IP67",
+    "dimensions_mm": "138.8 x 60.9 x 57.9",
+    "weight_g": 155,
     "added": "2026-07-06"
   },
   {

--- a/docs/cameras/hikvision/ds-2ae4215itg.md
+++ b/docs/cameras/hikvision/ds-2ae4215itg.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-72mm |
-| Night vision | ir (100m) |
+| Field of view | 57.6h° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | 12 VDC (IR 7W) |
 | Storage | NVR |
 | IP rating | IP66 |

--- a/docs/cameras/hikvision/ds-2ae4215tg-3.md
+++ b/docs/cameras/hikvision/ds-2ae4215tg-3.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-72mm |
+| Field of view | 57.6h° |
 | Night vision | none |
 | Power | 12 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae4215tg.md
+++ b/docs/cameras/hikvision/ds-2ae4215tg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-72mm |
+| Field of view | 57.6h° |
 | Night vision | none |
 | Power | 12 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae4225itg.md
+++ b/docs/cameras/hikvision/ds-2ae4225itg.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (100m) |
+| Field of view | 57.6h° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | 12 VDC (IR 7W) |
 | Storage | NVR |
 | IP rating | IP66 |

--- a/docs/cameras/hikvision/ds-2ae4225tg-3.md
+++ b/docs/cameras/hikvision/ds-2ae4225tg-3.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
+| Field of view | 57.6h° |
 | Night vision | none |
 | Power | 12 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae4225tg.md
+++ b/docs/cameras/hikvision/ds-2ae4225tg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
+| Field of view | 57.6h° |
 | Night vision | none |
 | Power | 12 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae4425itg.md
+++ b/docs/cameras/hikvision/ds-2ae4425itg.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (100m) |
+| Field of view | 55h° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | 12 VDC (IR 7W) |
 | Storage | NVR |
 | IP rating | IP66 |

--- a/docs/cameras/hikvision/ds-2ae5225itg.md
+++ b/docs/cameras/hikvision/ds-2ae5225itg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
+| Field of view | 57.6h° |
 | Night vision | ir (150m) |
 | Power | 36 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae5225tg.md
+++ b/docs/cameras/hikvision/ds-2ae5225tg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
+| Field of view | 57.6h° |
 | Night vision | none |
 | Power | 36 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae5232itg.md
+++ b/docs/cameras/hikvision/ds-2ae5232itg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-153.6mm |
+| Field of view | 55h° |
 | Night vision | ir (150m) |
 | Power | 36 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae5232tg.md
+++ b/docs/cameras/hikvision/ds-2ae5232tg.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-153.6mm |
+| Field of view | 55h° |
 | Night vision | none |
 | Power | 36 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae5425itg.md
+++ b/docs/cameras/hikvision/ds-2ae5425itg.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-120mm |
+| Field of view | 55h° |
 | Night vision | ir (150m) |
 | Power | 36 VDC |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2ae7232itg.md
+++ b/docs/cameras/hikvision/ds-2ae7232itg.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× 4.8-153.6mm |
-| Night vision | ir (150m) |
+| Field of view | 55 horizontal/33 vertical/61.5 diagonal (wide end)° |
+| Night vision | ir (150m), 0.005 lux color |
 | Power | 36 VDC |
 | Storage | NVR |
 | IP rating | IP66 |

--- a/docs/cameras/hikvision/ds-2cd1023g0e-i.md
+++ b/docs/cameras/hikvision/ds-2cd1023g0e-i.md
@@ -12,7 +12,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8 / 4 (fixed)mm F2.0 |
 | Field of view | 112.1 horizontal (2.8mm) / 90.2 horizontal (4mm)° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af, Class 3) / DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp, http |

--- a/docs/cameras/hikvision/ds-2cd1023g2-iuf.md
+++ b/docs/cameras/hikvision/ds-2cd1023g2-iuf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 104° (2.8mm)/81° (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1023g2-iuf.md
+++ b/docs/cameras/hikvision/ds-2cd1023g2-iuf.md
@@ -9,7 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Field of view | 104° (2.8mm)/81° (4mm) horizontal° |
+| Field of view | 104 (2.8mm)/81 (4mm) horizontal° |
 | Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd1023g2-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1023g2-liuf.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 103 (2.8mm)/83 (4mm) horizontal° |
 | Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd1027g2h-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1027g2h-liuf.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 115 (2.8mm)/94 (4mm) horizontal° |
 | Night vision | hybrid (30m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd1043g2-iuf.md
+++ b/docs/cameras/hikvision/ds-2cd1043g2-iuf.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (30m) |
+| Field of view | 99 (2.8mm)/76 (4mm) horizontal° |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1043g2-liuf.md
+++ b/docs/cameras/hikvision/ds-2cd1043g2-liuf.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 98 (2.8mm)/78 (4mm) horizontal° |
 | Night vision | hybrid (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd1123g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd1123g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 104 (2.8mm)/81 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1123g2-liu.md
+++ b/docs/cameras/hikvision/ds-2cd1123g2-liu.md
@@ -17,6 +17,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK08 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/hikvision/ds-2cd1143g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd1143g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 99 (2.8mm)/76 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1143g2-iuf.md
+++ b/docs/cameras/hikvision/ds-2cd1143g2-iuf.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 99 (2.8mm)/76 (4mm) horizontal° |
-| Night vision | ir (25m) |
+| Night vision | ir (25m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd1143g2-liu.md
+++ b/docs/cameras/hikvision/ds-2cd1143g2-liu.md
@@ -17,6 +17,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK08 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/hikvision/ds-2cd1h43g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd1h43g2-izs.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
 | Field of view | 95.9-29.2 horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2021g1-i.md
+++ b/docs/cameras/hikvision/ds-2cd2021g1-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 111.6 (2.8mm)/91.5 (4mm)/56 (6mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2026g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2026g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 107 (2.8mm)/86 (4mm)/55 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2043g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2043g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 103 (2.8mm)/84 (4mm)/52 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2046g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2046g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 103 (2.8mm)/83 (4mm)/53 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2046g2h-i2u-slrb.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 100 (2.8mm)/81 (4mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2046g2h-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2046g2h-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 100.2 (2.8mm)/81.1 (4mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2083g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2083g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 107 (2.8mm)/87 (4mm)/54 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2086g2-iu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2086g2-iu-sl.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 110 (2.8mm)/88 (4mm)/60 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2086g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2086g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 111 (2.8mm)/87 (4mm)/51 (6mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2086g2h-i2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2086g2h-i2u-slrb.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (40m) |
+| Field of view | 105 (2.8mm)/90 (4mm) horizontal° |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2086g2h-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2086g2h-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 105.1 (2.8mm)/90 (4mm) horizontal° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2123g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2123g2-is.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107 (2.8mm)/87 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2125g0-ims.md
+++ b/docs/cameras/hikvision/ds-2cd2125g0-ims.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 108 (2.8mm)/86 (4mm)/52 (6mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.009 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 128GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2126g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd2126g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107 (2.8mm)/86 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2126g2-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2126g2-isu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 107 (2.8mm)/86 (4mm)/55 (6mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2146g2h-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2146g2h-isu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 100.2 (2.8mm)/81.1 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2183g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2183g2-is.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107 (2.8mm)/87 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2186g2-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2186g2-isu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 111 (2.8mm)/87 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2186g2h-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2186g2h-isu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 105.1 (2.8mm)/90 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2323g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2323g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107 (2.8mm)/87 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2326g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2326g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 107 (2.8mm)/86 (4mm)/55 (6mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2343g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2343g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 103 (2.8mm)/84 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2345g0p-i.md
+++ b/docs/cameras/hikvision/ds-2cd2345g0p-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 1.68mm |
 | Field of view | 180 horizontal (ultra-wide panoramic)° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2346g2-isu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2346g2-isu-sl.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
 | Field of view | 103 (2.8mm)/83 (4mm)/53 (6mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2383g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2383g2-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107 (2.8mm)/87 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2386g2h-is2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2386g2h-is2u-slrb.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 105 (2.8mm)/90 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2386g2h-iu.md
+++ b/docs/cameras/hikvision/ds-2cd2386g2h-iu.md
@@ -10,7 +10,7 @@
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 108.8 (2.8mm)/93.3 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2421g0-idw.md
+++ b/docs/cameras/hikvision/ds-2cd2421g0-idw.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 2.8mm |
 | Field of view | 107 (2.8mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.028 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2423g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd2423g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 108.8 (2.8mm)/87.6 (4mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2423g2-iw.md
+++ b/docs/cameras/hikvision/ds-2cd2423g2-iw.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 92 (2.8mm)/75 (4mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2443g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd2443g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2/2.8/4mm |
 | Field of view | 104.3 (2.8mm)/83.7 (4mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2446g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd2446g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2/2.8/4mm |
 | Field of view | 102.7 (2.8mm)/82.8 (4mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2483g2-i.md
+++ b/docs/cameras/hikvision/ds-2cd2483g2-i.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 107.8 (2.8mm)/82.8 (4mm) horizontal° |
-| Night vision | ir (10m) |
+| Night vision | ir (10m), 0.008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2523g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2523g2-is.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 108 (2.8mm)/86 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2546g2-iws.md
+++ b/docs/cameras/hikvision/ds-2cd2546g2-iws.md
@@ -10,7 +10,7 @@
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 102.7 (2.8mm)/82.8 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2583g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2583g2-is.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
 | Field of view | 106.4 (2.8mm)/87.6 (4mm) horizontal° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2586g2-is.md
+++ b/docs/cameras/hikvision/ds-2cd2586g2-is.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (30m) |
+| Field of view | 110.0 (2.8mm)/88.0 (4mm) horizontal° |
+| Night vision | ir (30m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2623g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2623g2-izs.md
@@ -9,8 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 107°-32° (H)° |
-| Night vision | ir (60m) |
+| Field of view | 107-32 (H)° |
+| Night vision | ir (60m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2643g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2643g2-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (60m) |
+| Field of view | 95.8-29.2 (H)° |
+| Night vision | ir (60m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2646g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2646g2-izs.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 108°-30° horizontal° |
-| Night vision | ir (60m) |
+| Field of view | 108-30 horizontal° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2646g2h-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2646g2h-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (60m) |
+| Field of view | 105.4-34.3 (H)° |
+| Night vision | ir (60m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2646g2ht-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2646g2ht-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (60m) |
+| Field of view | 105.4-34.3 (H)° |
+| Night vision | ir (60m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2646g2t-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2646g2t-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (60m) |
+| Field of view | 108-30 (H)° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2647g2ht-lizs.md
+++ b/docs/cameras/hikvision/ds-2cd2647g2ht-lizs.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 114.6-41.8 (H)° |
 | Night vision | hybrid (60m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2647g3-lizs2uy-slrb.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 114.6-41.8 (H)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2667g2ht-lizs.md
+++ b/docs/cameras/hikvision/ds-2cd2667g2ht-lizs.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP (3200x1800) (6MP, 3200×1800) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 112.3-41.2 (H)° |
 | Night vision | hybrid (60m), 0.0028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2686g2h-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2686g2h-izs.md
@@ -9,8 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 112.3°-41.2° (H)° |
-| Night vision | ir (60m) |
+| Field of view | 112.3-41.2 (H)° |
+| Night vision | ir (60m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2686g2ht-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2686g2ht-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (60m) |
+| Field of view | 112.3-41.2 (H)° |
+| Night vision | ir (60m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2686g2t-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2686g2t-izs.md
@@ -9,8 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 108°-46° horizontal° |
-| Night vision | ir (60m) |
+| Field of view | 108-46 horizontal° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2687g2t-lzs.md
+++ b/docs/cameras/hikvision/ds-2cd2687g2t-lzs.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 103.3-40° |
 | Night vision | color (60m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2687g3-lizs2uy-slrb.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 112.3-41.2° |
 | Night vision | hybrid (60m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2723g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2723g2-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 107-32° |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2726g2t-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2726g2t-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 113-31° |
+| Night vision | ir (40m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2746g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2746g2-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 108-30° |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2746g2h-iptrzs2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2746g2h-iptrzs2u-slrb.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 114.6-41.8° |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2746g2ht-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2746g2ht-izs.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 105.4°-34.3° (H)° |
-| Night vision | ir (40m) |
+| Field of view | 105.4-34.3 (H)° |
+| Night vision | ir (40m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2747g2h-liptrzs2u-slrb.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 114.6-41.8° |
 | Night vision | hybrid (40m), 0.0028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2747g2ht-lizs.md
+++ b/docs/cameras/hikvision/ds-2cd2747g2ht-lizs.md
@@ -9,7 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 114.6°-41.8° horizontal° |
+| Field of view | 114.6-41.8 horizontal° |
 | Night vision | hybrid (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2747g2t-lzs.md
+++ b/docs/cameras/hikvision/ds-2cd2747g2t-lzs.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 105.4-56.4° |
 | Night vision | color (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2767g2ht-lizs.md
+++ b/docs/cameras/hikvision/ds-2cd2767g2ht-lizs.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP (3200x1800) (6MP, 3200×1800) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 112.3-41.2° |
 | Night vision | hybrid (40m), 0.0028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2783g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2783g2-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 108-30° |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2786g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2786g2-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 108-46° |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2786g2h-iptrzs2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2786g2h-iptrzs2u-slrb.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 112.3-41.2° |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2786g2ht-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2786g2ht-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 112.3-41.2° |
+| Night vision | ir (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2787g2h-liptrzs2u-slrb.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 112.3°-41.2° (H)° |
+| Field of view | 112.3-41.2 (H)° |
 | Night vision | hybrid (40m), 0.0028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2787g2ht-lizs.md
+++ b/docs/cameras/hikvision/ds-2cd2787g2ht-lizs.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 112.3-41.2 horizontal° |
 | Night vision | hybrid (40m), 0.0028 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2787g2t-lzs.md
+++ b/docs/cameras/hikvision/ds-2cd2787g2t-lzs.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 103.3°-40° horizontal° |
+| Field of view | 103.3-40 horizontal° |
 | Night vision | color (40m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2955g0-isu.md
+++ b/docs/cameras/hikvision/ds-2cd2955g0-isu.md
@@ -9,7 +9,8 @@
 | Resolution | 5MP fisheye (5MP, 2560×1920) |
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 1.05mm |
-| Night vision | ir (8m) |
+| Field of view | 180 horizontal° |
+| Night vision | ir (8m), 0.017 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2d25g1-d-nf.md
+++ b/docs/cameras/hikvision/ds-2cd2d25g1-d-nf.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/3.7mm |
+| Field of view | 93.9 (2.8mm)/75.5 (3.7mm) horizontal° |
 | Night vision | none |
 | Power | DC 12V |
 | Storage | NVR |

--- a/docs/cameras/hikvision/ds-2cd2e23g2-u.md
+++ b/docs/cameras/hikvision/ds-2cd2e23g2-u.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 107 (2.8mm)/88 (4mm) horizontal° |
 | Night vision | none |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2e43g2-u.md
+++ b/docs/cameras/hikvision/ds-2cd2e43g2-u.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 103 (2.8mm)/84 (4mm) horizontal° |
 | Night vision | none |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2h23g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2h23g2-izs.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 106.6-31.7 horizontal° |
 | Night vision | ir (40m) |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2h43g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2h43g2-izs.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
+| Field of view | 95.8-29.2 horizontal° |
 | Night vision | ir (40m) |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2h86g2-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2h86g2-izs.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 108°-46° (H)° |
+| Field of view | 108-46 (H)° |
 | Night vision | ir (40m) |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2h86g2t-izs.md
+++ b/docs/cameras/hikvision/ds-2cd2h86g2t-izs.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (40m) |
+| Field of view | 108-46 horizontal, 58-26 vertical, 127.4 diagonal° |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2h87g3-lizs2uy-slrb.md
@@ -9,7 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 112.3°-41.2° horizontal° |
+| Field of view | 112.3-41.2 horizontal° |
 | Night vision | hybrid (40m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t23g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t23g2-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (80m) |
+| Field of view | 107 horizontal, 57 vertical, 127 diagonal (2.8mm)° |
+| Night vision | ir (80m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t26g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t26g2-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (80m) |
+| Field of view | 107 horizontal, 57 vertical, 129 diagonal (2.8mm)° |
+| Night vision | ir (80m), 0.002 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t27g2-l.md
+++ b/docs/cameras/hikvision/ds-2cd2t27g2-l.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
+| Field of view | 107 horizontal, 56 vertical, 127 diagonal (2.8mm)° |
 | Night vision | color (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t43g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t43g2-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (80m) |
+| Field of view | 103 horizontal, 55 vertical, 122 diagonal (2.8mm)° |
+| Night vision | ir (80m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t45g0p-i.md
+++ b/docs/cameras/hikvision/ds-2cd2t45g0p-i.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/2.7" Progressive Scan CMOS |
 | Lens | 1× 1.68mm |
+| Field of view | 180 horizontal, 101 vertical, 180 diagonal° |
 | Night vision | ir (20m) |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t46g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t46g2-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (80m) |
+| Field of view | 103 horizontal, 55 vertical, 123 diagonal (2.8mm)° |
+| Night vision | ir (80m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t46g2-isu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t46g2-isu-sl.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Field of view | 103°/83°/53° (H)° |
-| Night vision | ir (60m) |
+| Field of view | 103/83/53 (H)° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t46g2h-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t46g2h-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (80m) |
+| Field of view | 100.2 horizontal (2.8mm), 81.1 horizontal (4mm)° |
+| Night vision | ir (80m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t46g2h-is2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2t46g2h-is2u-slrb.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Field of view | 100° (2.8mm)/81° (4mm) horizontal° |
-| Night vision | ir (60m) |
+| Field of view | 100 (2.8mm)/81 (4mm) horizontal° |
+| Night vision | ir (60m), 0.001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t46g2p-isu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t46g2p-isu-sl.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP panoramic (3040x1368) (4MP, 3040×1368) |
 | Sensor | 2 x 1/2.5" Progressive Scan CMOS (dual sensor) |
 | Lens | 1× 2.8 (dual lens)mm |
-| Night vision | ir (40m) |
+| Field of view | 180 horizontal, 81 vertical (2.8mm)° |
+| Night vision | ir (40m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g2h-lisu-sl.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 104.0 horizontal (2.8mm), 89.2 horizontal (4mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g2p-lsu-sl.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP panoramic (3040x1368) (4MP, 3040×1368) |
 | Sensor | 2 x 1/2.5" Progressive Scan CMOS (dual sensor) |
 | Lens | 1× 2.8 (dual lens)mm |
+| Field of view | 180 horizontal, 81 vertical (2.8mm)° |
 | Night vision | color (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2t47g3-lis2uy-slrb.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 111.1 horizontal (2.8mm), 95.2 horizontal (4mm)° |
 | Night vision | hybrid (60m), 0.0001 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t67g2h-li.md
+++ b/docs/cameras/hikvision/ds-2cd2t67g2h-li.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP (3200x1800) (6MP, 3200×1800) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 105.1 horizontal (2.8mm), 90.0 horizontal (4mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t67g2h-lisu-sl.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP (3200x1800) (6MP, 3200×1800) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 105.1 horizontal (2.8mm), 90.0 horizontal (4mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t83g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t83g2-2i-4i.md
@@ -9,8 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Field of view | 107°/87°/54° (H)° |
-| Night vision | ir (80m) |
+| Field of view | 107/87/54 (H)° |
+| Night vision | ir (80m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t86g2-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t86g2-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (80m) |
+| Field of view | 111 horizontal (2.8mm), 87 horizontal (4mm), 51 horizontal (6mm)° |
+| Night vision | ir (80m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t86g2-isu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t86g2-isu-sl.md
@@ -9,8 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Field of view | 110°/88°/59° horizontal° |
-| Night vision | ir (60m) |
+| Field of view | 110/88/59 horizontal° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t86g2h-2i-4i.md
+++ b/docs/cameras/hikvision/ds-2cd2t86g2h-2i-4i.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (80m) |
+| Field of view | 105.1 horizontal (2.8mm)° |
+| Night vision | ir (80m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t86g2h-is2u-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2t86g2h-is2u-slrb.md
@@ -9,7 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (60m) |
+| Field of view | 105 horizontal (2.8mm)° |
+| Night vision | ir (60m), 0.0008 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd2t87g2h-li.md
+++ b/docs/cameras/hikvision/ds-2cd2t87g2h-li.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 105.1 horizontal (2.8mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t87g2h-lisu-sl.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 105.1 horizontal (2.8mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.md
+++ b/docs/cameras/hikvision/ds-2cd2t87g2p-lsu-sl.md
@@ -9,6 +9,7 @@
 | Resolution | 8MP panoramic (5120x1440) (8MP, 5120×1440) |
 | Sensor | 2 x 1/1.8" Progressive Scan CMOS (dual sensor) |
 | Lens | 1× 4 (dual lens)mm |
+| Field of view | 180 horizontal / 44 vertical (4mm)° |
 | Night vision | color (40m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.md
+++ b/docs/cameras/hikvision/ds-2cd2t87g3-lis2uy-slrb.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
+| Field of view | 108.8 horizontal (2.8mm)° |
 | Night vision | hybrid (60m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd3043g2-iu.md
+++ b/docs/cameras/hikvision/ds-2cd3043g2-iu.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Field of view | 103°/84°/52° (H)° |
-| Night vision | ir (40m) |
+| Field of view | 103/84/52 (H)° |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd3343g2-isu.md
+++ b/docs/cameras/hikvision/ds-2cd3343g2-isu.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2688x1520) (4MP, 2688×1520) |
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4/6mm |
-| Night vision | ir (40m) |
+| Field of view | 103.6 horizontal (2.8mm)° |
+| Night vision | ir (40m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd3686g2t-izsy-h.md
+++ b/docs/cameras/hikvision/ds-2cd3686g2t-izsy-h.md
@@ -9,8 +9,8 @@
 | Resolution | 4K (3840x2160) (8MP, 3840×2160) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 2.7-13.5mm |
-| Field of view | 108°-46° horizontal° |
-| Night vision | ir (60m) |
+| Field of view | 108-46 horizontal° |
+| Night vision | ir (60m), 0.003 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd6365g1-ivs.md
+++ b/docs/cameras/hikvision/ds-2cd6365g1-ivs.md
@@ -9,7 +9,8 @@
 | Resolution | 6MP fisheye (6MP, 2560×2560) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 1.16mm |
-| Night vision | ir (15m) |
+| Field of view | 180 horizontal / 180 vertical° |
+| Night vision | ir (15m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cd6365g1-s-rc.md
+++ b/docs/cameras/hikvision/ds-2cd6365g1-s-rc.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP fisheye (6MP, 2560×2560) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 1.16mm |
+| Field of view | 180 horizontal / 180 vertical° |
 | Night vision | none |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd63c5g1-s-rc.md
+++ b/docs/cameras/hikvision/ds-2cd63c5g1-s-rc.md
@@ -9,6 +9,7 @@
 | Resolution | 12MP fisheye (12MP, 3504×3504) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 1.29mm |
+| Field of view | 180 horizontal / 180 vertical° |
 | Night vision | none |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2cd6w65g1-ivs.md
+++ b/docs/cameras/hikvision/ds-2cd6w65g1-ivs.md
@@ -9,7 +9,8 @@
 | Resolution | 6MP fisheye (6MP, 2560×2560) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 1.16mm |
-| Night vision | ir (15m) |
+| Field of view | 180 horizontal / 180 vertical° |
+| Night vision | ir (15m), 0.01 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2ce16h0t-itec.md
+++ b/docs/cameras/hikvision/ds-2ce16h0t-itec.md
@@ -10,7 +10,7 @@
 | Sensor | 5MP CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 93 / 77° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | 12 VDC / PoC.af |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce16k0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce16k0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 or 3.6 (fixed)mm |
 | Field of view | 104.9 (2.8mm) / 81.3 (3.6mm)° |
-| Night vision | hybrid (30m), 0.01 lux |
+| Night vision | hybrid (30m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce16k0t-lpfs.md
+++ b/docs/cameras/hikvision/ds-2ce16k0t-lpfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 or 3.6 (fixed)mm |
 | Field of view | 104.9 / 81.3° |
-| Night vision | hybrid (25m), 0.01 lux |
+| Night vision | hybrid (25m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce16u0t-itpf.md
+++ b/docs/cameras/hikvision/ds-2ce16u0t-itpf.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 102.9 / 79 / 44.7° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce17d0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce17d0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 2MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 101 / 78 / 49.2° |
-| Night vision | hybrid (40m), 0.01 lux |
+| Night vision | hybrid (40m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce17k0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce17k0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 104.9 (2.8mm)° |
-| Night vision | hybrid (40m), 0.01 lux |
+| Night vision | hybrid (40m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce18k0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce18k0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 104.9 / 81.3 / 51.8° |
-| Night vision | hybrid (60m), 0.01 lux |
+| Night vision | hybrid (60m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce19h0t-it3zec.md
+++ b/docs/cameras/hikvision/ds-2ce19h0t-it3zec.md
@@ -10,7 +10,7 @@
 | Sensor | 5MP CMOS |
 | Lens | 1× 2.7-13.5 (motorized)mm |
 | Field of view | 95-26° |
-| Night vision | ir (40m) |
+| Night vision | ir (40m), 0.01 lux color |
 | Power | 12 VDC / PoC.at |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce19u1t-it3zf.md
+++ b/docs/cameras/hikvision/ds-2ce19u1t-it3zf.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP progressive-scan CMOS |
 | Lens | 1× 2.7-13.5 (motorized)mm |
 | Field of view | 108.1-45.6° |
-| Night vision | ir (80m) |
+| Night vision | ir (80m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce57u0t-vpitf.md
+++ b/docs/cameras/hikvision/ds-2ce57u0t-vpitf.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 102.9 / 79 / 44.7° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce76d0t-lmfs.md
+++ b/docs/cameras/hikvision/ds-2ce76d0t-lmfs.md
@@ -10,7 +10,7 @@
 | Sensor | 2MP CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 101 / 78° |
-| Night vision | hybrid (30m), 0.01 lux |
+| Night vision | hybrid (30m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce76k0t-lmfs.md
+++ b/docs/cameras/hikvision/ds-2ce76k0t-lmfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 104.9 / 81.3° |
-| Night vision | hybrid (30m), 0.01 lux |
+| Night vision | hybrid (30m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce76k0t-lpfs.md
+++ b/docs/cameras/hikvision/ds-2ce76k0t-lpfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 104.9 / 81.3° |
-| Night vision | hybrid (20m), 0.01 lux |
+| Night vision | hybrid (20m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | Two-way audio | No |

--- a/docs/cameras/hikvision/ds-2ce76u0t-itmf.md
+++ b/docs/cameras/hikvision/ds-2ce76u0t-itmf.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 102.9 / 79 / 44.7° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce76u0t-itpf.md
+++ b/docs/cameras/hikvision/ds-2ce76u0t-itpf.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 102.9 / 79 / 44.7° |
-| Night vision | ir (30m) |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | Two-way audio | No |

--- a/docs/cameras/hikvision/ds-2ce78d0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce78d0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 2MP CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 100 / 80° |
-| Night vision | hybrid (40m), 0.01 lux |
+| Night vision | hybrid (40m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce78k0t-lfs.md
+++ b/docs/cameras/hikvision/ds-2ce78k0t-lfs.md
@@ -10,7 +10,7 @@
 | Sensor | 3K CMOS |
 | Lens | 1× 2.8 / 3.6 (fixed)mm |
 | Field of view | 104.9 / 81.3° |
-| Night vision | hybrid (40m), 0.01 lux |
+| Night vision | hybrid (40m), 0.01 lux, 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2ce78u0t-it3f.md
+++ b/docs/cameras/hikvision/ds-2ce78u0t-it3f.md
@@ -10,7 +10,7 @@
 | Sensor | 8.29MP CMOS |
 | Lens | 1× 2.8 / 3.6 / 6 (fixed)mm |
 | Field of view | 102.9 / 79 / 44.7° |
-| Night vision | ir (60m) |
+| Night vision | ir (60m), 0.01 lux color |
 | Power | 12 VDC |
 | Storage | NVR |
 | IP rating | IP67 |

--- a/docs/cameras/hikvision/ds-2cv2041g2-idw.md
+++ b/docs/cameras/hikvision/ds-2cv2041g2-idw.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (30m) |
+| Field of view | 97 / 82° |
+| Night vision | ir (30m), 0.5 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cv2141g2-idw-e.md
+++ b/docs/cameras/hikvision/ds-2cv2141g2-idw-e.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (30m) |
+| Field of view | 95 / 79° |
+| Night vision | ir (30m), 0.005 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2cv2q21g1-idw.md
+++ b/docs/cameras/hikvision/ds-2cv2q21g1-idw.md
@@ -9,8 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/3" Progressive Scan CMOS |
 | Lens | 1× 4mm |
-| Field of view | 75° (H)° |
-| Night vision | ir (10m) |
+| Field of view | 75 (H)° |
+| Night vision | ir (10m), 0.05 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de2a404iw-de3-ws6.md
+++ b/docs/cameras/hikvision/ds-2de2a404iw-de3-ws6.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Field of view | 96.7°-31.6° horizontal° |
-| Night vision | ir (20m) |
+| Field of view | 96.7-31.6 horizontal° |
+| Night vision | ir (20m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de2a404iw-de3s6.md
+++ b/docs/cameras/hikvision/ds-2de2a404iw-de3s6.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (20m) |
+| Field of view | 96.7-31.6 horizontal° |
+| Night vision | ir (20m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de2c400iwg.md
+++ b/docs/cameras/hikvision/ds-2de2c400iwg.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.9" Progressive Scan CMOS |
 | Lens | 1× 2.8/4mm |
-| Night vision | ir (30m) |
+| Field of view | 91 horizontal (2.8mm) / 74 horizontal (4mm)° |
+| Night vision | ir (30m), 0.01 lux color |
 | Power | DC 12V |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de3404w-det5.md
+++ b/docs/cameras/hikvision/ds-2de3404w-det5.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× |
-| Night vision | none |
+| Field of view | 93.8-31.7 horizontal° |
+| Night vision | none, 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de3a400bw-de-wt5.md
+++ b/docs/cameras/hikvision/ds-2de3a400bw-de-wt5.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 4mm |
+| Field of view | 88.7 horizontal° |
 | Night vision | color (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2de3a400bw-det5.md
+++ b/docs/cameras/hikvision/ds-2de3a400bw-det5.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 4mm |
+| Field of view | 88.7 horizontal° |
 | Night vision | color (30m), 0.0005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2de3a404iwg-e-w.md
+++ b/docs/cameras/hikvision/ds-2de3a404iwg-e-w.md
@@ -10,7 +10,7 @@
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
 | Field of view | 96.7-31.6 horizontal° |
-| Night vision | ir (50m) |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de3a404iwg-e.md
+++ b/docs/cameras/hikvision/ds-2de3a404iwg-e.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 2.8-12mm |
-| Night vision | ir (50m) |
+| Field of view | 96.7-31.6 horizontal° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4215iw-det5.md
+++ b/docs/cameras/hikvision/ds-2de4215iw-det5.md
@@ -9,8 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 5-75mm |
-| Field of view | 57.6°-4° (H)° |
-| Night vision | ir (100m) |
+| Field of view | 57.6-4 (H)° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4225iw-det5.md
+++ b/docs/cameras/hikvision/ds-2de4225iw-det5.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (100m) |
+| Field of view | 57.6-2.5 horizontal° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4425iw-det5.md
+++ b/docs/cameras/hikvision/ds-2de4425iw-det5.md
@@ -9,8 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Field of view | 55°-2.4° horizontal° |
-| Night vision | ir (100m) |
+| Field of view | 55-2.4 horizontal° |
+| Night vision | ir (100m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4825wg-e3.md
+++ b/docs/cameras/hikvision/ds-2de4825wg-e3.md
@@ -9,6 +9,7 @@
 | Resolution | 4K (8MP, 3840×2160) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× |
+| Field of view | 58.5-3.7 horizontal° |
 | Night vision | color, 0.005 lux color |
 | Power | PoE / 12 VDC |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2de4a225iw-de.md
+++ b/docs/cameras/hikvision/ds-2de4a225iw-de.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (50m) |
+| Field of view | 54.9 H / 31.5 V / 62.3 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE+ / 12 VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4a225iw-des6.md
+++ b/docs/cameras/hikvision/ds-2de4a225iw-des6.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (50m) |
+| Field of view | 54.9 H / 31.5 V / 62.3 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4a225iwg-e.md
+++ b/docs/cameras/hikvision/ds-2de4a225iwg-e.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (50m) |
+| Field of view | 54.9 H / 31.5 V / 62.3 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE+ / 12 VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4a225iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de4a225iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (50m) |
+| Field of view | 54.9 H / 31.5 V / 62.3 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE (802.3at) / 12 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4a425iw-de.md
+++ b/docs/cameras/hikvision/ds-2de4a425iw-de.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (50m) |
+| Field of view | 53.3 H / 30.6 V / 60.5 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE+ / 12 VDC |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de4a425iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de4a425iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (50m) |
+| Field of view | 53.3 H / 30.6 V / 60.5 D° |
+| Night vision | ir (50m), 0.005 lux color |
 | Power | PoE (802.3at) / 12 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de5225w-ae3t5.md
+++ b/docs/cameras/hikvision/ds-2de5225w-ae3t5.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | none |
+| Field of view | 57.6 H / 34.4 V / 64.5 D° |
+| Night vision | none, 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de5425iw-aet5.md
+++ b/docs/cameras/hikvision/ds-2de5425iw-aet5.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (150m) |
+| Field of view | 55 H / 33 V / 61.5 D° |
+| Night vision | ir (150m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a225iw-aebt5.md
+++ b/docs/cameras/hikvision/ds-2de7a225iw-aebt5.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-120mm |
-| Night vision | ir (200m) |
+| Field of view | 57.6 H / 34.4 V / 64.5 D° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a225iwg-eb-sl.md
+++ b/docs/cameras/hikvision/ds-2de7a225iwg-eb-sl.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 57.6 H / 34.4 V / 64.5 D° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a225iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de7a225iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 55 H / 33 V / 61.5 D° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a232iw-aebt5.md
+++ b/docs/cameras/hikvision/ds-2de7a232iw-aebt5.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" Progressive Scan CMOS |
 | Lens | 1× 4.8-153mm |
-| Night vision | ir (200m) |
+| Field of view | 50.8 H / 29.4 V / 57.4 D° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a232iwg-eb-sl.md
+++ b/docs/cameras/hikvision/ds-2de7a232iwg-eb-sl.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 55 horizontal/33 vertical/62.4 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a232iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de7a232iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 1080p (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 55 horizontal/33 vertical/61.5 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE (802.3bt Type3) / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a425iwg-eb-sl.md
+++ b/docs/cameras/hikvision/ds-2de7a425iwg-eb-sl.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 55 horizontal/33 vertical/61.5 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a432iw-aebt5.md
+++ b/docs/cameras/hikvision/ds-2de7a432iw-aebt5.md
@@ -9,7 +9,8 @@
 | Resolution | 4MP (2560x1440) (4MP, 2560×1440) |
 | Sensor | 1/1.8" Progressive Scan CMOS |
 | Lens | 1× 5.9-188.8mm |
-| Night vision | ir (200m) |
+| Field of view | 50.8 horizontal/29.4 vertical/57.4 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | PoE (802.3af) / DC 12V |
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a632iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de7a632iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 6MP (6MP, 3200×1800) |
 | Sensor | 1/2.5" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 60.7 horizontal/35.9 vertical/68.4 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE (802.3bt) / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2de7a825iwg1-e.md
+++ b/docs/cameras/hikvision/ds-2de7a825iwg1-e.md
@@ -9,7 +9,8 @@
 | Resolution | 4K/8MP (8MP, 3840×2160) |
 | Sensor | 1/1.8" CMOS |
 | Lens | 1× |
-| Night vision | ir (200m) |
+| Field of view | 55.3 horizontal/32.2 vertical/62.3 diagonal (wide end)° |
+| Night vision | ir (200m), 0.005 lux color |
 | Power | Hi-PoE (802.3bt) / 36 VDC |
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |

--- a/docs/cameras/hikvision/ds-2se4c215mwg-e.md
+++ b/docs/cameras/hikvision/ds-2se4c215mwg-e.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (dual-channel) (2MP, 1920×1080) |
 | Sensor | 1/2.8" CMOS (dual-channel) |
 | Lens | 1× |
+| Field of view | 54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)° |
 | Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ / 12 VDC |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2se4c225mwg-e.md
+++ b/docs/cameras/hikvision/ds-2se4c225mwg-e.md
@@ -9,6 +9,7 @@
 | Resolution | 1080p (2MP PTZ) + 6MP ColorVu bullet (2MP, 1920×1080) |
 | Sensor | 1/2.8" + 1/2.5" CMOS (dual-channel) |
 | Lens | 1× |
+| Field of view | 54.8 horizontal/31.4 vertical/62.2 diagonal (PTZ channel wide end)° |
 | Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE+ / 12 VDC |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2se4c425mwg-4g.md
+++ b/docs/cameras/hikvision/ds-2se4c425mwg-4g.md
@@ -9,6 +9,7 @@
 | Resolution | 4MP (4MP, 2560×1440) |
 | Sensor | 1/2.8" CMOS (dual-channel) |
 | Lens | 1× |
+| Field of view | 55 horizontal/33 vertical/61.5 diagonal (PTZ channel wide end)° |
 | Night vision | hybrid (100m), 0.005 lux color |
 | Power | PoE (802.3at) / 12 VDC |
 | Storage | microSD ≤ 512GB, NVR |

--- a/docs/cameras/hikvision/ds-2se7c432mwg-eb.md
+++ b/docs/cameras/hikvision/ds-2se7c432mwg-eb.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP panoramic + 4MP 32x PTZ (6MP, 3632×1632) |
 | Sensor | 1/2.5" + 1/2.8" CMOS (dual-channel) |
 | Lens | 2× |
+| Field of view | 60.2 horizontal/35.2 vertical (PTZ channel wide end)° |
 | Night vision | hybrid (200m), 0.005 lux color |
 | Power | Hi-PoE / 24 VAC |
 | Storage | microSD ≤ 256GB, NVR |

--- a/docs/cameras/hikvision/ds-2sf8c442mxg1-elw.md
+++ b/docs/cameras/hikvision/ds-2sf8c442mxg1-elw.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP panoramic + 4MP 42x PTZ (6MP, 3680×1656) |
 | Sensor | 1/2.5" + 1/1.8" CMOS (dual-channel) |
 | Lens | 2× |
+| Field of view | 59 horizontal/34.2 vertical/67.1 diagonal (PTZ channel wide end)° |
 | Night vision | hybrid (300m), 0.0003 lux color |
 | Power | Hi-PoE (802.3bt) / 36 VDC |
 | Storage | microSD ≤ 1024GB, NVR |

--- a/docs/cameras/hikvision/ds-2sf8c848mxg1-elw.md
+++ b/docs/cameras/hikvision/ds-2sf8c848mxg1-elw.md
@@ -9,6 +9,7 @@
 | Resolution | 6MP panoramic + 8MP 48x laser PTZ (8MP, 3840×2160) |
 | Sensor | 1/2.5" + 1/1.2" CMOS (dual-channel) |
 | Lens | 2× |
+| Field of view | 58.5 horizontal/34 vertical/65.8 diagonal (PTZ channel wide end)° |
 | Night vision | hybrid (500m), 0.0005 lux color |
 | Power | Hi-PoE (802.3bt Type4) / 36 VDC |
 | Storage | microSD ≤ 1024GB, NVR |


### PR DESCRIPTION
## Hikvision datasheet backfill — #178 / #162 / #179 / #161 / #177

Backfill of physical + FOV + lux + stream fields for **Hikvision** from the official UA-gated datasheet PDFs (`assets.hikvision.com` + axilogi mirror) cited in each record. Agent-driven across **4 waves / 26 batches** — **all 292 pdf-sourced Hikvision cameras processed**. No guessing: every value read from the model's own datasheet, with a model-verify + retry guard against the flaky mirror.

### Coverage (of 425 Hikvision cameras)
| Field | Lane | Before → After |
|-------|------|----------------|
| `dimensions_mm` | #178 | 22 → **298 (70%)** |
| `weight_g` | #178 | 22 → **298 (70%)** |
| `field_of_view_deg` | #179 | 317 → **424 (100%)** |
| `night_vision.min_lux_color` | #161 | ~178 → **287** |
| `video.streams[]` | #177 | 282 → **287** |
| `ik_rating` | #162 | +2 (only where the datasheet states it) |

**dimensions/weight was the headline gap (403 missing) — now 70% covered.** The remaining ~127 without dims/weight are the records that have **no datasheet PDF source at all** (re-sourcing first, per #164/#186).

### Discipline
Fields added **only when absent**; **Color** min-illumination only (never the IR/BW `0 lux` sentinel); analog DS-2AE/DS-2CE streams skipped; FOV degree-symbols normalized. Agents **refused variant-mismatched datasheets** (e.g. SLRB→LIZSY, ColorVu-L→IR-4I) rather than copy another model's specs.

CI: build clean, 0 drift, all values well-formed. Data-quality issues surfaced during the pass are filed on #186.
