### PR TITLE
data: Dahua ik_rating backfill (#162) + UniFi Protect +21 (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CCTV Camera Database
 
-An open, structured database of 2,776 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,797 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
-[![cameras](https://img.shields.io/badge/cameras-2%2C776-blue)](data/cameras.json)
+[![cameras](https://img.shields.io/badge/cameras-2%2C797-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-72-green)](cameras/)
 [![license](https://img.shields.io/badge/license-CC0-lightgrey)](LICENSE)
 
@@ -23,7 +23,7 @@ Camera spec sheets are scattered across vendor PDFs, retailer pages, and paywall
 Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just `demo.html` + `cameras.json`, no build step) is included — serve the `docs/` folder locally with any static server, e.g. `python3 -m http.server` inside `docs/`, then open it.  
 
 <p align="center">
-  <img src="docs/demo.gif" alt="CCTV Camera Database — browse, search, filter, and inspect 2,776 cameras across 72 brands" width="800" />
+  <img src="docs/demo.gif" alt="CCTV Camera Database — browse, search, filter, and inspect 2,797 cameras across 72 brands" width="800" />
 </p>
 
 **What you see above:**
@@ -31,7 +31,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,776 cameras, 25 per page
+- **Pagination** — page through all 2,797 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -64,7 +64,7 @@ cctv-camera-database/
 │   ├── reolink/          # 127 cameras
 │   └── …66 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,776 cameras as one array
+│   ├── cameras.json      # all 2,797 cameras as one array
 │   └── cameras.csv       # flattened, spreadsheet-friendly
 ├── schema/
 │   └── camera.schema.json
@@ -127,7 +127,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,776** |
+| Total cameras | **2,797** |
 | Brands | **72** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
 | PoE wired | 1,669 |
@@ -160,13 +160,13 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | IMOU (Dahua) | 56 | Consumer + prosumer, global |
 | Tapo (TP-Link) | 54 | Consumer budget, global |
 | Eufy (Anker) | 46 | Consumer no-subscription, global |
+| Ubiquiti UniFi | 46 | Prosumer/SMB, US/global |
 | Hanwha | 45 | Enterprise AI, Korea/global |
 | Uniarch (Uniview) | 43 | Budget NDAA sub-brand, global |
 | Lorex | 40 | Consumer NVR systems, CA/US |
 | CP Plus | 26 | India #2 brand, IN |
 | Xiaomi | 26 | Consumer smart home, CN/global |
 | Arlo | 25 | Consumer premium wire-free, global |
-| Ubiquiti UniFi | 25 | Prosumer/SMB, US/global |
 | VIGI (TP-Link) | 25 | Business/SMB PoE, global |
 | HiLook (Hikvision) | 23 | Budget installer, EU/UK/AU |
 | Ajax | 22 | Professional alarm + wired PoE cameras, EU/UK |

--- a/cameras/dahua/ipc-hdw5442tm-ase.json
+++ b/cameras/dahua/ipc-hdw5442tm-ase.json
@@ -39,6 +39,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -82,5 +83,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hdw5842tm-ase.json
+++ b/cameras/dahua/ipc-hdw5842tm-ase.json
@@ -81,7 +81,8 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/1.8\" CMOS",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "ik_rating": "IK10"
 }

--- a/cameras/dahua/ipc-hfw2241t-as.json
+++ b/cameras/dahua/ipc-hfw2241t-as.json
@@ -64,6 +64,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "operating_temp_c": "-40 to +60",
   "audio": {
     "microphone": true,
@@ -84,7 +85,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-27",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/dahua/ipc-hfw2441t-as.json
+++ b/cameras/dahua/ipc-hfw2441t-as.json
@@ -60,6 +60,7 @@
     "onvif"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -84,7 +85,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-27",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/dahua/ipc-hfw2441t-zas.json
+++ b/cameras/dahua/ipc-hfw2441t-zas.json
@@ -64,6 +64,7 @@
     "onvif"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -85,7 +86,7 @@
   "sources": [
     "https://www.dahuasecurity.com/products/network-products/Network-Cameras/WizSense-2-Series/IR/IPC-HFW2441T-ZAS"
   ],
-  "last_verified": "2026-07-27",
+  "last_verified": "2026-08-03",
   "configs": {
     "frigate": {
       "detect": {

--- a/cameras/dahua/ipc-hfw2441t-zs.json
+++ b/cameras/dahua/ipc-hfw2441t-zs.json
@@ -61,6 +61,7 @@
     "onvif"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -108,5 +109,5 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-27"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw2541t-zas.json
+++ b/cameras/dahua/ipc-hfw2541t-zas.json
@@ -61,6 +61,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "operating_temp_c": "-30 to 60",
   "audio": {
     "microphone": true,
@@ -106,5 +107,5 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-27"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw2541t-zs.json
+++ b/cameras/dahua/ipc-hfw2541t-zs.json
@@ -61,6 +61,7 @@
     "onvif"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -106,5 +107,5 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-27"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw2831t-zas-s2.json
+++ b/cameras/dahua/ipc-hfw2831t-zas-s2.json
@@ -39,6 +39,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -80,5 +81,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw2841t-zas-s2.json
+++ b/cameras/dahua/ipc-hfw2841t-zas-s2.json
@@ -30,6 +30,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -71,5 +72,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw3841t-zas-s2.json
+++ b/cameras/dahua/ipc-hfw3841t-zas-s2.json
@@ -30,6 +30,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -72,5 +73,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw3841tp-zas.json
+++ b/cameras/dahua/ipc-hfw3841tp-zas.json
@@ -82,8 +82,9 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/2.8\" CMOS",
   "field_of_view_deg": "113-31",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "ik_rating": "IK10"
 }

--- a/cameras/dahua/ipc-hfw3866tp-zas.json
+++ b/cameras/dahua/ipc-hfw3866tp-zas.json
@@ -80,7 +80,8 @@
       "notes": "Select the 'Dahua' profile."
     }
   },
-  "last_verified": "2026-07-22",
+  "last_verified": "2026-08-03",
   "sensor": "1/2.8\" CMOS",
-  "ip_rating": "IP67"
+  "ip_rating": "IP67",
+  "ik_rating": "IK10"
 }

--- a/cameras/dahua/ipc-hfw5442e-ze-s3.json
+++ b/cameras/dahua/ipc-hfw5442e-ze-s3.json
@@ -31,6 +31,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -75,5 +76,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw7442h-z4-x.json
+++ b/cameras/dahua/ipc-hfw7442h-z4-x.json
@@ -30,6 +30,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -73,5 +74,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/ipc-hfw7842h-z-x.json
+++ b/cameras/dahua/ipc-hfw7842h-z-x.json
@@ -30,6 +30,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": true,
     "speaker": false,
@@ -74,5 +75,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/dahua/itc237-pw1b-irz-lr.json
+++ b/cameras/dahua/itc237-pw1b-irz-lr.json
@@ -40,6 +40,7 @@
     "rtsp"
   ],
   "ip_rating": "IP67",
+  "ik_rating": "IK10",
   "audio": {
     "microphone": false,
     "speaker": false,
@@ -82,5 +83,5 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-07-04"
+  "last_verified": "2026-08-03"
 }

--- a/cameras/ubiquiti/ai-lpr.json
+++ b/cameras/ubiquiti/ai-lpr.json
@@ -1,0 +1,85 @@
+{
+  "id": "ubiquiti-ai-lpr",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI LPR",
+  "aliases": [
+    "UVC-AI-LPR"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.1-12.3",
+    "aperture": "F1.53-F3.3",
+    "varifocal": true
+  },
+  "field_of_view_deg": "109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 15
+  },
+  "power": {
+    "method": "PoE+; 25.5W max, 42.5-57V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "130 x 151.4 x 302.9",
+  "weight_g": 3300,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "License Plate Recognition",
+    "Smart Detections (people/vehicles/animals)",
+    "3x optical zoom",
+    "IR optimized with LPR filter",
+    "MicroSD card slot",
+    "IK04 tamper resistance",
+    "NDAA compliant"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-lpr"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/ai-ms-2.json
+++ b/cameras/ubiquiti/ai-ms-2.json
@@ -1,0 +1,87 @@
+{
+  "id": "ubiquiti-ai-ms-2",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI MS-2",
+  "aliases": [
+    "UVC-AI-MS-2"
+  ],
+  "type": "panoramic",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 16,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "Dual 4K (2x 8MP)"
+  },
+  "sensor": "Dual 1/2.8\" 8MP",
+  "lens": {
+    "count": 2,
+    "focal_length_mm": "3.18-7.42",
+    "aperture": "F1.8-F2.8",
+    "varifocal": true
+  },
+  "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE+; 25W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "218 x 132 x 93.5",
+  "weight_g": 1300,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "dual-sensor multi-sensor, 2x 8MP 4K, 30 FPS max",
+    "2.33x optical zoom",
+    "Face Recognition",
+    "License Plate Recognition",
+    "AI event detection person/vehicle/animal",
+    "MicroSD card slot",
+    "IK10 impact resistance",
+    "UniFi Protect ecosystem",
+    "built-in mic"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-2"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/ai-ms-4.json
+++ b/cameras/ubiquiti/ai-ms-4.json
@@ -1,0 +1,83 @@
+{
+  "id": "ubiquiti-ai-ms-4",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI MS-4",
+  "aliases": [
+    "UVC-AI-MS-4"
+  ],
+  "type": "panoramic",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 32,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD per sensor (32MP total)"
+  },
+  "sensor": "1/2.8\" 8MP (x4)",
+  "lens": {
+    "count": 4,
+    "focal_length_mm": "3.18-7.42",
+    "aperture": "F1.8-F2.8",
+    "varifocal": true
+  },
+  "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE++; 34.6W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "255 (diameter) x 105",
+  "weight_g": 2400,
+  "operating_temp_c": "-20 to 50",
+  "features": [
+    "four 8MP sensors, 32MP total, 24 FPS max",
+    "2.33x optical zoom per sensor",
+    "adaptive IR illumination up to 20m",
+    "face recognition",
+    "license plate recognition",
+    "AI smart detections person/vehicle/animal",
+    "HDR",
+    "2x microSD card slots + M.2 2280 SATA SSD",
+    "IK10 vandal resistance",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-4"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/ai-ptz-precision.json
+++ b/cameras/ubiquiti/ai-ptz-precision.json
@@ -1,0 +1,79 @@
+{
+  "id": "ubiquiti-ai-ptz-precision",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI PTZ Precision",
+  "aliases": [
+    "UVC-AI-PTZ-Precision"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "6.91-214.64",
+    "aperture": "F1.36-F4.6",
+    "varifocal": true
+  },
+  "field_of_view_deg": "59 horizontal / 34.1 vertical / 67.1 diagonal (wide); 1.98 horizontal / 1.12 vertical / 2.27 diagonal (zoom)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE++; 51W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "dimensions_mm": "241 (diameter) x 349",
+  "weight_g": 5500,
+  "operating_temp_c": "-40 to 50",
+  "features": [
+    "31x optical zoom",
+    "pan-tilt-zoom (360 pan / 120 tilt)",
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (person/vehicle/animal)",
+    "microSD storage",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz-precision"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/ai-ptz.json
+++ b/cameras/ubiquiti/ai-ptz.json
@@ -1,0 +1,80 @@
+{
+  "id": "ubiquiti-ai-ptz",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI PTZ",
+  "aliases": [
+    "UVC-AI-PTZ"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "6.36-138.5",
+    "aperture": "F1.5-F3.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "59.8 horizontal / 44.4 vertical / 70 diagonal (wide); 3 horizontal / 2.24 vertical / 3.76 diagonal (zoom)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 100
+  },
+  "power": {
+    "method": "PoE++; 51W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "dimensions_mm": "207 x 223.7 x 341.3",
+  "weight_g": 3800,
+  "operating_temp_c": "-40 to 50",
+  "features": [
+    "22x optical zoom",
+    "pan-tilt-zoom (360 endless pan / 120 tilt)",
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (person/vehicle/animal)",
+    "microSD storage",
+    "NDAA compliant",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/ai-turret.json
+++ b/cameras/ubiquiti/ai-turret.json
@@ -1,0 +1,86 @@
+{
+  "id": "ubiquiti-ai-turret",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect AI Turret",
+  "aliases": [
+    "UVC-AI-Turret"
+  ],
+  "type": "turret",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 20W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK08",
+  "dimensions_mm": "118 (diameter) x 111",
+  "weight_g": 990,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "4K UHD, 30 FPS max",
+    "adaptive IR up to 40m",
+    "Face Recognition",
+    "License Plate Recognition",
+    "AI event detection person/vehicle/animal",
+    "MicroSD card slot",
+    "IK08 tamper resistance",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "two-way audio"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-ai-turret"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/doorbell-lite.json
+++ b/cameras/ubiquiti/doorbell-lite.json
@@ -1,0 +1,76 @@
+{
+  "id": "ubiquiti-doorbell-lite",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect Doorbell Lite",
+  "aliases": [
+    "UVC-Doorbell-Lite"
+  ],
+  "type": "doorbell",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 1920,
+    "max_height": 2560,
+    "label": "5MP"
+  },
+  "sensor": "1/2.7\" 5MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "95.8 horizontal / 131.2 vertical / 175.9 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 5
+  },
+  "power": {
+    "method": "PoE; 8W max"
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IPX5",
+  "dimensions_mm": "137 x 40 x 26.4",
+  "weight_g": 142,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "3:4 vertical aspect ratio for head-to-toe view",
+    "24 FPS max",
+    "Smart Detections (person/vehicle/animal)",
+    "two-way audio",
+    "NDAA compliant",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-doorbell-lite"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g5-ptz.json
+++ b/cameras/ubiquiti/g5-ptz.json
@@ -1,0 +1,80 @@
+{
+  "id": "ubiquiti-g5-ptz",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G5 PTZ",
+  "aliases": [
+    "UVC-G5-PTZ"
+  ],
+  "type": "ptz",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 4,
+    "max_width": 2688,
+    "max_height": 1512,
+    "label": "4MP"
+  },
+  "sensor": "1/2.7\" 5MP CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "3.42-6.85",
+    "aperture": "F1.85-F2.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "99.7 horizontal / 51.9 vertical / 121 diagonal (wide); 45.5 horizontal / 25.4 vertical / 52.4 diagonal (zoom)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE+; 14W max"
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "90 (diameter) x 152.5",
+  "weight_g": 580,
+  "operating_temp_c": "-30 to 45",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "2x optical zoom",
+    "pan-tilt-zoom",
+    "30 FPS max",
+    "built-in IR & white LED illumination",
+    "Smart Detections (person/vehicle/animal)",
+    "IK04 tamper resistance",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g5-ptz"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-180.json
+++ b/cameras/ubiquiti/g6-180.json
@@ -1,0 +1,84 @@
+{
+  "id": "ubiquiti-g6-180",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 180",
+  "aliases": [
+    "UVC-G6-180"
+  ],
+  "type": "panoramic",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 16,
+    "max_width": 7680,
+    "max_height": 2160,
+    "label": "Dual 4K (3.5:1)"
+  },
+  "sensor": "Dual 1/1.8\" 8MP",
+  "lens": {
+    "count": 2,
+    "varifocal": false
+  },
+  "field_of_view_deg": "180 horizontal / 56.7 vertical",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE+; 15W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "136 x 64 x 92",
+  "weight_g": 839,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "16MP dual-lens 180-degree panoramic, 20 FPS max",
+    "Face Recognition",
+    "License Plate Recognition",
+    "AI event detection person/vehicle/animal",
+    "MicroSD card slot",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "two-way audio"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-180"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-bullet.json
+++ b/cameras/ubiquiti/g6-bullet.json
@@ -1,0 +1,81 @@
+{
+  "id": "ubiquiti-g6-bullet",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Bullet",
+  "aliases": [
+    "UVC-G6-Bullet"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "PoE; 9.9W max, 37-57V DC"
+  },
+  "storage": {
+    "onboard": false,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "82 (diameter) x 88.8 (without mount); 82 (diameter) x 153 (with mount)",
+  "weight_g": 587,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (people/vehicles/animals)",
+    "HDR",
+    "built-in mic",
+    "NDAA compliant"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-bullet"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-dome.json
+++ b/cameras/ubiquiti/g6-dome.json
@@ -1,0 +1,85 @@
+{
+  "id": "ubiquiti-g6-dome",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Dome",
+  "aliases": [
+    "UVC-G6-Dome"
+  ],
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "PoE; 9.25W max"
+  },
+  "storage": {
+    "onboard": false,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "144.7 (diameter) x 96.3",
+  "weight_g": 820,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "4K, 30 FPS max",
+    "adaptive IR illumination up to 30m",
+    "face recognition",
+    "license plate recognition",
+    "AI smart detections person/vehicle/animal",
+    "IK10 vandal resistance",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "built-in mic"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-dome"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-edge-bullet.json
+++ b/cameras/ubiquiti/g6-edge-bullet.json
@@ -1,0 +1,85 @@
+{
+  "id": "ubiquiti-g6-edge-bullet",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Edge Bullet",
+  "aliases": [
+    "UVC-G6-Edge-Bullet"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.9-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 60
+  },
+  "power": {
+    "method": "PoE+; 25W max, 42.5-57V DC"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "107 (diameter) x 113 (without mount); 107 (diameter) x 212 (with wall mount)",
+  "weight_g": 780,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (people/vehicles/animals)",
+    "2.36x optical zoom",
+    "HDR",
+    "two-way audio",
+    "MicroSD card slot"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-bullet"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-edge-dome.json
+++ b/cameras/ubiquiti/g6-edge-dome.json
@@ -1,0 +1,87 @@
+{
+  "id": "ubiquiti-g6-edge-dome",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Edge Dome",
+  "aliases": [
+    "UVC-G6-Edge-Dome"
+  ],
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.9-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 15W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "163.8 (diameter) x 108.8",
+  "weight_g": 1200,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "4K UHD, 30 FPS max",
+    "2.36x optical zoom",
+    "adaptive IR up to 40m",
+    "Face Recognition",
+    "License Plate Recognition",
+    "AI event detection person/vehicle/animal",
+    "IK10 impact resistance",
+    "UniFi Protect ecosystem",
+    "built-in mic"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-dome"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-edge-turret.json
+++ b/cameras/ubiquiti/g6-edge-turret.json
@@ -1,0 +1,87 @@
+{
+  "id": "ubiquiti-g6-edge-turret",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Edge Turret",
+  "aliases": [
+    "UVC-G6-Edge-Turret"
+  ],
+  "type": "turret",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.85-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 25W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "117.2 (diameter) x 116.5",
+  "weight_g": 1200,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "4K, 30 FPS max",
+    "2.36x optical zoom",
+    "adaptive IR illumination up to 40m",
+    "face recognition",
+    "license plate recognition",
+    "AI smart detections person/vehicle/animal",
+    "microSD card slot",
+    "two-way audio",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-turret"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-ins.json
+++ b/cameras/ubiquiti/g6-ins.json
@@ -1,0 +1,85 @@
+{
+  "id": "ubiquiti-g6-ins",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Instant",
+  "aliases": [
+    "UVC-G6-Ins"
+  ],
+  "type": "dome",
+  "connectivity": [
+    "ethernet",
+    "wifi"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 6
+  },
+  "power": {
+    "method": "5V/2A USB power adapter (included) or PoE-to-USB-C adapter (not included); 7W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IPX5",
+  "ik_rating": "IK04",
+  "dimensions_mm": "81.7 x 50.1 x 57.2",
+  "weight_g": 180,
+  "operating_temp_c": "-20 to 40",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "compact indoor camera with WiFi and Bluetooth",
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (person/vehicle/animal)",
+    "HDR",
+    "two-way audio",
+    "microSD storage",
+    "UniFi Protect ecosystem"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-ins"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-mini-dome.json
+++ b/cameras/ubiquiti/g6-mini-dome.json
@@ -1,0 +1,83 @@
+{
+  "id": "ubiquiti-g6-mini-dome",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Mini Dome",
+  "aliases": [
+    "UVC-G6-Mini-Dome"
+  ],
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 20
+  },
+  "power": {
+    "method": "PoE; 9W max"
+  },
+  "storage": {
+    "onboard": false,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ik_rating": "IK08",
+  "dimensions_mm": "100.8 (diameter) x 56",
+  "weight_g": 254,
+  "operating_temp_c": "-20 to 40",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "4K UHD, 30 FPS max",
+    "Face Recognition",
+    "License Plate Recognition",
+    "AI event detection person/vehicle/animal",
+    "IK08 tamper resistance",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "two-way audio"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-mini-dome"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-pro-360.json
+++ b/cameras/ubiquiti/g6-pro-360.json
@@ -1,0 +1,84 @@
+{
+  "id": "ubiquiti-g6-pro-360",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Pro 360",
+  "aliases": [
+    "UVC-G6-Pro-360"
+  ],
+  "type": "fisheye",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 12,
+    "max_width": 3504,
+    "max_height": 3504,
+    "label": "12MP (1:1)"
+  },
+  "sensor": "1/1.6\" 12MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "180 horizontal / 180 vertical / 180 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 15
+  },
+  "power": {
+    "method": "PoE+; 13.5W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "147 (diameter) x 65.5",
+  "weight_g": 610,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "12MP fisheye 360-degree, 24 FPS max",
+    "Smart IR with 4 controllable zones",
+    "AI event detection person/vehicle/animal",
+    "MicroSD card slot",
+    "IK10 impact resistance",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "two-way audio"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-360"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-pro-bullet.json
+++ b/cameras/ubiquiti/g6-pro-bullet.json
@@ -1,0 +1,86 @@
+{
+  "id": "ubiquiti-g6-pro-bullet",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Pro Bullet",
+  "aliases": [
+    "UVC-G6-Pro-Bullet"
+  ],
+  "type": "bullet",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.9-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 15W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "85.8 (diameter) x 106.2 (without mount); 85.8 (diameter) x 210 (with wall mount)",
+  "weight_g": 755,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (people/vehicles/animals)",
+    "2.36x optical zoom",
+    "optional Vision Enhancer extends IR range from 40m up to 60m",
+    "two-way audio",
+    "MicroSD card slot",
+    "NDAA compliant"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-bullet"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-pro-dome.json
+++ b/cameras/ubiquiti/g6-pro-dome.json
@@ -1,0 +1,90 @@
+{
+  "id": "ubiquiti-g6-pro-dome",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Pro Dome",
+  "aliases": [
+    "UVC-G6-Pro-Dome"
+  ],
+  "type": "dome",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.9-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 15W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "dimensions_mm": "163.8 (diameter) x 108.8",
+  "weight_g": 1200,
+  "operating_temp_c": "-20 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "4K, 30 FPS max",
+    "2.36x optical zoom",
+    "adaptive IR illumination up to 40m",
+    "face recognition",
+    "license plate recognition",
+    "AI smart detections person/vehicle/animal",
+    "HDR",
+    "microSD card slot",
+    "IK10 vandal resistance",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "built-in mic"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-dome"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-pro-turret.json
+++ b/cameras/ubiquiti/g6-pro-turret.json
@@ -1,0 +1,84 @@
+{
+  "id": "ubiquiti-g6-pro-turret",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Pro Turret",
+  "aliases": [
+    "UVC-G6-Pro-Turret"
+  ],
+  "type": "turret",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.2\" 8MP",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "5.85-13.8",
+    "aperture": "F1.5-F2.9",
+    "varifocal": true
+  },
+  "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 40
+  },
+  "power": {
+    "method": "PoE+; 15W max"
+  },
+  "storage": {
+    "onboard": true,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "117.2 (diameter) x 116.5",
+  "weight_g": 1200,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "Face Recognition",
+    "License Plate Recognition",
+    "Smart Detections (people/vehicles/animals)",
+    "2.36x optical zoom",
+    "two-way audio",
+    "MicroSD card slot"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-turret"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/cameras/ubiquiti/g6-turret.json
+++ b/cameras/ubiquiti/g6-turret.json
@@ -1,0 +1,85 @@
+{
+  "id": "ubiquiti-g6-turret",
+  "brand": "Ubiquiti",
+  "model": "UniFi Protect G6 Turret",
+  "aliases": [
+    "UVC-G6-Turret"
+  ],
+  "type": "turret",
+  "connectivity": [
+    "ethernet"
+  ],
+  "resolution": {
+    "megapixels": 8,
+    "max_width": 3864,
+    "max_height": 2160,
+    "label": "4K UHD"
+  },
+  "sensor": "1/1.8\" 8MP",
+  "lens": {
+    "count": 1,
+    "varifocal": false
+  },
+  "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+  "night_vision": {
+    "type": "ir",
+    "range_m": 30
+  },
+  "power": {
+    "method": "PoE; 12.5W max"
+  },
+  "storage": {
+    "onboard": false,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK04",
+  "dimensions_mm": "100 (diameter) x 95",
+  "weight_g": 550,
+  "operating_temp_c": "-30 to 50",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "features": [
+    "4K, 30 FPS max",
+    "adaptive IR illumination up to 30m",
+    "face recognition",
+    "license plate recognition",
+    "AI smart detections person/vehicle/animal",
+    "HDR",
+    "NDAA compliant",
+    "UniFi Protect ecosystem",
+    "built-in mic"
+  ],
+  "sources": [
+    "https://techspecs.ui.com/unifi/physical-security/uvc-g6-turret"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "configs": {
+    "frigate": {
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
+      "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+    },
+    "home_assistant": {
+      "integration": "unifiprotect",
+      "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+    },
+    "blue_iris": {
+      "profile": "Generic/RTSP",
+      "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+    }
+  },
+  "last_verified": "2026-08-03"
+}

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -965,10 +965,10 @@ dahua-ipc-hdw3867t-zs-il,Dahua,IPC-HDW3867T-ZS-IL,turret,4K,8,"1/2.7"" CMOS",,hy
 dahua-ipc-hdw5259t-ze-il,Dahua,IPC-HDW5259T-ZE-IL,turret,1080p,2,"1/2.7"" CMOS",110-32h,hybrid,IP67,,false,
 dahua-ipc-hdw5259tm-ase-il,Dahua,IPC-HDW5259TM-ASE-IL,turret,1080p,2,"1/2.7"" CMOS",108.4h,hybrid,IP67,,false,
 dahua-ipc-hdw5442t-ze,Dahua,IPC-HDW5442T-ZE,turret,4MP,4,"1/1.8"" CMOS",110-30h,ir,IP67,IK10,false,2023
-dahua-ipc-hdw5442tm-ase,Dahua,IPC-HDW5442TM-ASE,turret,4MP,4,"1/1.8"" Progressive Scan CMOS",,ir,IP67,,false,
+dahua-ipc-hdw5442tm-ase,Dahua,IPC-HDW5442TM-ASE,turret,4MP,4,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hdw5449h-ase-d2,Dahua,IPC-HDW5449H-ASE-D2,dual-lens,4MP,4,"1/1.8"" CMOS",,hybrid,IP67,IK10,true,2024
 dahua-ipc-hdw5842t-ze,Dahua,IPC-HDW5842T-ZE,turret,4K UHD,8,"1/1.8"" CMOS",,ir,IP67,IK10,false,
-dahua-ipc-hdw5842tm-ase,Dahua,IPC-HDW5842TM-ASE,turret,4K,8,"1/1.8"" CMOS",,ir,IP67,,false,
+dahua-ipc-hdw5842tm-ase,Dahua,IPC-HDW5842TM-ASE,turret,4K,8,"1/1.8"" CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hf71242f-z-x,Dahua,IPC-HF71242F-Z-X,box,12MP UHD,12,"1/1.7"" Progressive Scan CMOS",,none,IP42,,false,2024
 dahua-ipc-hfw1230ds-saw,Dahua,IPC-HFW1230DS-SAW,bullet,1080p,2,"1/2.8"" CMOS",100h,ir,IP67,,false,
 dahua-ipc-hfw1239s1-led-s6,Dahua,IPC-HFW1239S1-LED-S6,bullet,1080p HD,2,,107h,color,IP67,,false,2024
@@ -983,7 +983,7 @@ dahua-ipc-hfw1830s-s6,Dahua,IPC-HFW1830S-S6,bullet,4K UHD,8,,107h,ir,IP67,,false
 dahua-ipc-hfw21249t-as-il,Dahua,IPC-HFW21249T-AS-IL,bullet,12MP,12,"1/2.5"" CMOS",112,hybrid,IP67,IK10,true,
 dahua-ipc-hfw21249t-s-il,Dahua,IPC-HFW21249T-S-IL,bullet,12MP,12,"1/2.5"" CMOS",112 (2.8mm) / 95 (3.6mm),hybrid,IP67,,false,
 dahua-ipc-hfw2241s-s,Dahua,IPC-HFW2241S-S,bullet,1080p HD,2,,106h,ir,IP67,,false,2022
-dahua-ipc-hfw2241t-as,Dahua,IPC-HFW2241T-AS,bullet,1080p,2,"1/2.8"" CMOS",88,ir,IP67,,false,
+dahua-ipc-hfw2241t-as,Dahua,IPC-HFW2241T-AS,bullet,1080p,2,"1/2.8"" CMOS",88,ir,IP67,IK10,false,
 dahua-ipc-hfw2241t-zas,Dahua,IPC-HFW2241T-ZAS,bullet,1080p,2,"1/2.8"" CMOS",H: 108°-30°,ir,IP67,IK10,false,
 dahua-ipc-hfw2241t-zs,Dahua,IPC-HFW2241T-ZS,bullet,1080p,2,"1/2.8"" CMOS",108-30,ir,IP67,IK10,false,
 dahua-ipc-hfw2249m-s-b-pro,Dahua,IPC-HFW2249M-S-B-PRO,bullet,1080p,2,"1/2.9"" CMOS",81,color,IP67,,false,
@@ -997,9 +997,9 @@ dahua-ipc-hfw2249tl-s-pv,Dahua,IPC-HFW2249TL-S-PV,bullet,1080p,2,"1/2.8"" CMOS",
 dahua-ipc-hfw2431t-as-s2,Dahua,IPC-HFW2431T-AS-S2,bullet,4MP,4,"1/3"" CMOS",,ir,IP67,IK10,false,2022
 dahua-ipc-hfw2439s-sa-led-b,Dahua,IPC-HFW2439S-SA-LED-B,bullet,4MP,4,,107h,color,IP67,,false,2023
 dahua-ipc-hfw2441s-s,Dahua,IPC-HFW2441S-S,bullet,4MP,4,,106h,ir,IP67,,false,2022
-dahua-ipc-hfw2441t-as,Dahua,IPC-HFW2441T-AS,bullet,4MP,4,"1/2.9"" CMOS",84,ir,IP67,,false,
-dahua-ipc-hfw2441t-zas,Dahua,IPC-HFW2441T-ZAS,bullet,4MP,4,"1/2.9"" CMOS",104-29,ir,IP67,,false,
-dahua-ipc-hfw2441t-zs,Dahua,IPC-HFW2441T-ZS,bullet,4MP,4,"1/2.9"" CMOS",104-29,ir,IP67,,false,
+dahua-ipc-hfw2441t-as,Dahua,IPC-HFW2441T-AS,bullet,4MP,4,"1/2.9"" CMOS",84,ir,IP67,IK10,false,
+dahua-ipc-hfw2441t-zas,Dahua,IPC-HFW2441T-ZAS,bullet,4MP,4,"1/2.9"" CMOS",104-29,ir,IP67,IK10,false,
+dahua-ipc-hfw2441t-zs,Dahua,IPC-HFW2441T-ZS,bullet,4MP,4,"1/2.9"" CMOS",104-29,ir,IP67,IK10,false,
 dahua-ipc-hfw2449dg-4g-zas-pv-pro,Dahua,IPC-HFW2449DG-4G-ZAS-PV-PRO,bullet,4MP,4,"1/1.8"" CMOS",46-107,hybrid,IP67,IK10,true,
 dahua-ipc-hfw2449m-s-b-pro,Dahua,IPC-HFW2449M-S-B-PRO,bullet,4MP,4,"1/1.8"" CMOS",89,color,IP67,,false,
 dahua-ipc-hfw2449s-s-il,Dahua,IPC-HFW2449S-S-IL,bullet,4MP,4,"1/2.7"" CMOS",,hybrid,IP67,,false,

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1010,7 +1010,7 @@ dahua-ipc-hfw2449tl-s-prox,Dahua,IPC-HFW2449TL-S-PROX,bullet,4MP,4,"1/1.8"" CMOS
 dahua-ipc-hfw2449tl-s-pv,Dahua,IPC-HFW2449TL-S-PV,bullet,4MP,4,"1/2.9"" CMOS",101.6,hybrid,IP67,,true,
 dahua-ipc-hfw2541s-s,Dahua,IPC-HFW2541S-S,bullet,5MP,5,"1/2.7"" CMOS",111 (2.8mm) / 92 (3.6mm),ir,IP67,,false,
 dahua-ipc-hfw2541t-as,Dahua,IPC-HFW2541T-AS,bullet,5MP,5,"1/2.7"" CMOS",92,ir,IP67,IK10,false,
-dahua-ipc-hfw2541t-zas,Dahua,IPC-HFW2541T-ZAS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,,false,
+dahua-ipc-hfw2541t-zas,Dahua,IPC-HFW2541T-ZAS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,IK10,false,
 dahua-ipc-hfw2541t-zs,Dahua,IPC-HFW2541T-ZS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,,false,
 dahua-ipc-hfw2549tl-s-pv,Dahua,IPC-HFW2549TL-S-PV,bullet,5MP,5,"1/2.7"" CMOS",111.0,hybrid,IP67,,true,
 dahua-ipc-hfw2649m-s-b-pro,Dahua,IPC-HFW2649M-S-B-PRO,bullet,6MP,6,"1/1.8"" CMOS",78,color,IP67,,false,
@@ -1055,13 +1055,13 @@ dahua-ipc-hfw3866tp-zas,Dahua,IPC-HFW3866TP-ZAS,bullet,4K,8,"1/2.8"" CMOS",,ir,I
 dahua-ipc-hfw3867e-as-il,Dahua,IPC-HFW3867E-AS-IL,bullet,4K,8,"1/2.7"" CMOS",110,hybrid,IP67,,false,
 dahua-ipc-hfw3867t-zas-il,Dahua,IPC-HFW3867T-ZAS-IL,bullet,4K,8,"1/2.7"" CMOS",,hybrid,IP67,,false,
 dahua-ipc-hfw5442e-ze,Dahua,IPC-HFW5442E-ZE,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,
-dahua-ipc-hfw5442e-ze-s3,Dahua,IPC-HFW5442E-ZE-S3,bullet,4MP,4,,110-30h,ir,IP67,,false,2023
+dahua-ipc-hfw5442e-ze-s3,Dahua,IPC-HFW5442E-ZE-S3,bullet,4MP,4,,110-30h,ir,IP67,IK10,false,2023
 dahua-ipc-hfw5842e-ze,Dahua,IPC-HFW5842E-ZE,bullet,4K UHD,8,"1/1.8"" CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hfw5842h-z4he,Dahua,IPC-HFW5842H-Z4HE,bullet,4K UHD,8,"1/1.8"" CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hfw5849t1-ase-led,Dahua,IPC-HFW5849T1-ASE-LED,bullet,4K UHD,8,"1/1.2"" CMOS",113 (2.8mm),color,IP67,IK10,true,2023
 dahua-ipc-hfw71242h-z,Dahua,IPC-HFW71242H-Z,bullet,12MP,12,"1/1.7"" CMOS",,ir,IP67,IK10,true,
-dahua-ipc-hfw7442h-z4-x,Dahua,IPC-HFW7442H-Z4-X,bullet,4MP,4,,83-15h,ir,IP67,,false,2022
-dahua-ipc-hfw7842h-z-x,Dahua,IPC-HFW7842H-Z-X,bullet,4K UHD,8,,106-30h,ir,IP67,,false,2022
+dahua-ipc-hfw7442h-z4-x,Dahua,IPC-HFW7442H-Z4-X,bullet,4MP,4,,83-15h,ir,IP67,IK10,false,2022
+dahua-ipc-hfw7842h-z-x,Dahua,IPC-HFW7842H-Z-X,bullet,4K UHD,8,,106-30h,ir,IP67,IK10,false,2022
 dahua-ipc-hfw7842h-z4-x,Dahua,IPC-HFW7842H-Z4-X,bullet,4K UHD,8,"1/1.8"" CMOS",42-15,ir,IP67,IK10,false,
 dahua-ipc-pdbw5831-b360,Dahua,IPC-PDBW5831-B360,panoramic,4x2MP 360deg,8,"4x 1/2.8"" CMOS",360,ir,IP67,IK10,false,
 dahua-ipc-pdw2849-a180-s-pv,Dahua,IPC-PDW2849-A180-S-PV,panoramic,8MP,8,"1/2.7"" CMOS",180,hybrid,IP67,,true,
@@ -1076,7 +1076,7 @@ dahua-ipc-pfw81642-a180,Dahua,IPC-PFW81642-A180,panoramic,16MP,16,"4 x 1/1.8"" C
 dahua-ipc-pfw83242-a180-s2,Dahua,IPC-PFW83242-A180-S2,panoramic,32MP,32,"1/1.8"" CMOS",180,ir,IP67,IK10,false,
 dahua-ipc-pfw8802-a180,Dahua,IPC-PFW8802-A180,panoramic,8MP 180deg,8,"4x 1/1.9"" Progressive Scan CMOS",180,ir,IP67,IK10,false,
 dahua-ipc-pts2249b-e2-s-pv-pro,Dahua,IPC-PTS2249B-E2-S-PV-PRO,ptz,1080p,2,"1/2.9"" CMOS",81,color,IP66,,true,
-dahua-itc237-pw1b-irz-lr,Dahua,ITC237-PW1B-IRZ-LR,bullet,2MP LPR,2,"1/2.8"" CMOS",,ir,IP67,,false,2023
+dahua-itc237-pw1b-irz-lr,Dahua,ITC237-PW1B-IRZ-LR,bullet,2MP LPR,2,"1/2.8"" CMOS",,ir,IP67,IK10,false,2023
 dahua-mptz1100-2030ra,Dahua,MPTZ1100-2030RA,ptz,1080p,2.42,"1/2.8"" CMOS",2.77-67.8,ir,IP66,,true,
 dahua-ptz19245u-irb-n,Dahua,PTZ19245U-IRB-N,ptz,1080p,2,"1/2.8"" STARVIS CMOS",1.8-70.3 (H),ir,IP68,,true,
 dahua-ptz1a225-hnr-gb,Dahua,PTZ1A225-HNR-GB,ptz,1080p,2,"1/2.8"" CMOS",,ir,IP67,,false,

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -1011,7 +1011,7 @@ dahua-ipc-hfw2449tl-s-pv,Dahua,IPC-HFW2449TL-S-PV,bullet,4MP,4,"1/2.9"" CMOS",10
 dahua-ipc-hfw2541s-s,Dahua,IPC-HFW2541S-S,bullet,5MP,5,"1/2.7"" CMOS",111 (2.8mm) / 92 (3.6mm),ir,IP67,,false,
 dahua-ipc-hfw2541t-as,Dahua,IPC-HFW2541T-AS,bullet,5MP,5,"1/2.7"" CMOS",92,ir,IP67,IK10,false,
 dahua-ipc-hfw2541t-zas,Dahua,IPC-HFW2541T-ZAS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,IK10,false,
-dahua-ipc-hfw2541t-zs,Dahua,IPC-HFW2541T-ZS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,,false,
+dahua-ipc-hfw2541t-zs,Dahua,IPC-HFW2541T-ZS,bullet,5MP,5,"1/2.7"" CMOS",113-31,ir,IP67,IK10,false,
 dahua-ipc-hfw2549tl-s-pv,Dahua,IPC-HFW2549TL-S-PV,bullet,5MP,5,"1/2.7"" CMOS",111.0,hybrid,IP67,,true,
 dahua-ipc-hfw2649m-s-b-pro,Dahua,IPC-HFW2649M-S-B-PRO,bullet,6MP,6,"1/1.8"" CMOS",78,color,IP67,,false,
 dahua-ipc-hfw2649s-s-il,Dahua,IPC-HFW2649S-S-IL,bullet,6MP,6,"1/2.7"" CMOS",112,hybrid,IP67,,false,
@@ -1020,11 +1020,11 @@ dahua-ipc-hfw2649t-zas-il,Dahua,IPC-HFW2649T-ZAS-IL,bullet,6MP,6,"1/2.7"" CMOS",
 dahua-ipc-hfw2649tl-s-pro,Dahua,IPC-HFW2649TL-S-PRO,bullet,6MP,6,"1/1.8"" CMOS",92,color,IP67,,false,
 dahua-ipc-hfw2831sp-s-s2,Dahua,IPC-HFW2831SP-S-S2,bullet,4K,8,"1/2.7"" CMOS",105,ir,IP67,IK10,false,
 dahua-ipc-hfw2831t-as-s2-latam,Dahua,IPC-HFW2831T-AS-S2 (LATAM),bullet,4K UHD,8,"1/2.7"" CMOS",113 horizontal (2.8mm),ir,IP67,IK10,false,2022
-dahua-ipc-hfw2831t-zas-s2,Dahua,IPC-HFW2831T-ZAS-S2,bullet,4K UHD,8,"1/2.7"" CMOS",,ir,IP67,,false,
+dahua-ipc-hfw2831t-zas-s2,Dahua,IPC-HFW2831T-ZAS-S2,bullet,4K UHD,8,"1/2.7"" CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hfw2831tp-zs,Dahua,IPC-HFW2831TP-ZS,bullet,4K/8MP,8,"1/2.7"" CMOS",,ir,IP67,,false,
 dahua-ipc-hfw2841s-s,Dahua,IPC-HFW2841S-S,bullet,4K,8,"1/2.7"" CMOS",106,ir,IP67,,false,
 dahua-ipc-hfw2841t-as,Dahua,IPC-HFW2841T-AS,bullet,4K,8,"1/2.7"" CMOS",88,ir,IP67,IK10,true,
-dahua-ipc-hfw2841t-zas-s2,Dahua,IPC-HFW2841T-ZAS-S2,bullet,4K UHD,8,,110-30h,ir,IP67,,false,2023
+dahua-ipc-hfw2841t-zas-s2,Dahua,IPC-HFW2841T-ZAS-S2,bullet,4K UHD,8,,110-30h,ir,IP67,IK10,false,2023
 dahua-ipc-hfw2841t-zs,Dahua,IPC-HFW2841T-ZS,bullet,4K,8,"1/2.7"" CMOS",31-113,ir,IP67,IK10,false,
 dahua-ipc-hfw2849m-s-b-pro,Dahua,IPC-HFW2849M-S-B-PRO,bullet,4K,8,"1/1.8"" CMOS",93 (3.6mm) / 57 (6mm),color,IP67,,false,
 dahua-ipc-hfw2849s-s-il,Dahua,IPC-HFW2849S-S-IL,bullet,4K UHD,8,"1/2.7"" CMOS",,hybrid,IP67,,false,
@@ -1042,8 +1042,8 @@ dahua-ipc-hfw3549t1-as-pv,Dahua,IPC-HFW3549T1-AS-PV,bullet,5MP,5,"1/2.7"" CMOS",
 dahua-ipc-hfw3649t1-as-pv-s2,Dahua,IPC-HFW3649T1-AS-PV-S2,bullet,6MP,6,"1/2.7"" CMOS",,hybrid,IP67,,true,2024
 dahua-ipc-hfw3667e-as-il,Dahua,IPC-HFW3667E-AS-IL,bullet,6MP,6,"1/2.7"" CMOS",110,hybrid,IP67,,false,
 dahua-ipc-hfw3667t-zas-il,Dahua,IPC-HFW3667T-ZAS-IL,bullet,6MP,6,"1/2.7"" CMOS",114-32,hybrid,IP67,,false,
-dahua-ipc-hfw3841t-zas-s2,Dahua,IPC-HFW3841T-ZAS-S2,bullet,4K UHD,8,,106-30h,ir,IP67,,false,2023
-dahua-ipc-hfw3841tp-zas,Dahua,IPC-HFW3841TP-ZAS,bullet,4K/8MP,8,"1/2.8"" CMOS",113-31,ir,IP67,,false,
+dahua-ipc-hfw3841t-zas-s2,Dahua,IPC-HFW3841T-ZAS-S2,bullet,4K UHD,8,,106-30h,ir,IP67,IK10,false,2023
+dahua-ipc-hfw3841tp-zas,Dahua,IPC-HFW3841TP-ZAS,bullet,4K/8MP,8,"1/2.8"" CMOS",113-31,ir,IP67,IK10,false,
 dahua-ipc-hfw3849e-as-il,Dahua,IPC-HFW3849E-AS-IL,bullet,4K UHD,8,"1/2.7"" CMOS",,hybrid,IP67,,false,
 dahua-ipc-hfw3849e-s-il,Dahua,IPC-HFW3849E-S-IL,bullet,4K UHD,8,"1/2.7"" CMOS",,hybrid,IP67,,false,
 dahua-ipc-hfw3849t1-as-pv,Dahua,IPC-HFW3849T1-AS-PV,bullet,4K UHD,8,"1/2.8"" CMOS",,hybrid,IP67,,true,
@@ -1051,7 +1051,7 @@ dahua-ipc-hfw3849t1-as-pv-pro,Dahua,IPC-HFW3849T1-AS-PV-PRO,bullet,4K UHD,8,"1/1
 dahua-ipc-hfw3849t1-zas-pv,Dahua,IPC-HFW3849T1-ZAS-PV,bullet,4K UHD,8,"1/2.8"" CMOS",,hybrid,IP67,,true,
 dahua-ipc-hfw3849t1-zas-pv-pro,Dahua,IPC-HFW3849T1-ZAS-PV-PRO,bullet,4K,8,"1/2.8"" CMOS",112-48h,hybrid,IP67,,true,
 dahua-ipc-hfw3866ep-as,Dahua,IPC-HFW3866EP-AS,bullet,4K,8,"1/2.8"" CMOS",,ir,IP67,,true,
-dahua-ipc-hfw3866tp-zas,Dahua,IPC-HFW3866TP-ZAS,bullet,4K,8,"1/2.8"" CMOS",,ir,IP67,,false,
+dahua-ipc-hfw3866tp-zas,Dahua,IPC-HFW3866TP-ZAS,bullet,4K,8,"1/2.8"" CMOS",,ir,IP67,IK10,false,
 dahua-ipc-hfw3867e-as-il,Dahua,IPC-HFW3867E-AS-IL,bullet,4K,8,"1/2.7"" CMOS",110,hybrid,IP67,,false,
 dahua-ipc-hfw3867t-zas-il,Dahua,IPC-HFW3867T-ZAS-IL,bullet,4K,8,"1/2.7"" CMOS",,hybrid,IP67,,false,
 dahua-ipc-hfw5442e-ze,Dahua,IPC-HFW5442E-ZE,bullet,4MP,4,"1/1.8"" Progressive Scan CMOS",,ir,IP67,IK10,false,

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -2524,9 +2524,16 @@ ubiquiti-ai-360,Ubiquiti,UniFi Protect AI 360,fisheye,"2K (1:1, fisheye)",4,5MP 
 ubiquiti-ai-bullet,Ubiquiti,UniFi Protect AI Bullet,bullet,2K,4,,84.7 horizontal / 46.2 vertical / 99 diagonal,ir,IP65,IK04,false,2024
 ubiquiti-ai-dome,Ubiquiti,UniFi Protect AI Dome,dome,4K UHD,8,"1/1.8"" 8MP CMOS",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IP66,,false,2024
 ubiquiti-ai-dslr,Ubiquiti,UniFi Protect AI DSLR,box,4K UHD,8,"Four Thirds (4/3"") 10MP CMOS",52 horizontal / 39 vertical / 65 diagonal (17mm lens); 21.6 horizontal / 16.2 vertical / 27 diagonal (45mm lens),,,,true,2024
+ubiquiti-ai-lpr,Ubiquiti,UniFi Protect AI LPR,bullet,4K,8,"1/1.8"" 8MP",109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (tele),ir,IP66,IK04,false,
+ubiquiti-ai-ms-2,Ubiquiti,UniFi Protect AI MS-2,panoramic,Dual 4K (2x 8MP),16,"Dual 1/2.8"" 8MP",108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele),ir,IP66,IK10,false,
+ubiquiti-ai-ms-4,Ubiquiti,UniFi Protect AI MS-4,panoramic,4K UHD per sensor (32MP total),32,"1/2.8"" 8MP (x4)",108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele),ir,IP66,IK10,,
 ubiquiti-ai-pro,Ubiquiti,UniFi Protect AI Pro,bullet,4K UHD,8,"1/1.8"" 8MP CMOS",109.9 horizontal / 59.9 vertical / 127.7 diagonal (wide); 34.9 horizontal / 19.7 vertical / 40 diagonal (zoom),ir,IP65,,true,2024
 ubiquiti-ai-pro-white,Ubiquiti,UniFi Protect AI Pro White,bullet,4K UHD,8,"1/1.8"" 8MP CMOS",109.9 horizontal / 59.9 vertical / 127.7 diagonal (wide); 34.9 horizontal / 19.7 vertical / 40 diagonal (zoom),ir,IP65,,true,2024
+ubiquiti-ai-ptz,Ubiquiti,UniFi Protect AI PTZ,ptz,4K UHD,8,"1/1.8"" 8MP",59.8 horizontal / 44.4 vertical / 70 diagonal (wide); 3 horizontal / 2.24 vertical / 3.76 diagonal (zoom),ir,IP66,,,
+ubiquiti-ai-ptz-precision,Ubiquiti,UniFi Protect AI PTZ Precision,ptz,4K UHD,8,"1/1.8"" 8MP",59 horizontal / 34.1 vertical / 67.1 diagonal (wide); 1.98 horizontal / 1.12 vertical / 2.27 diagonal (zoom),ir,IP66,,,
 ubiquiti-ai-theta-pro,Ubiquiti,UniFi Protect AI Theta Pro,panoramic,4MP (1:1),4,"1/1.8"" 8MP CMOS",180 horizontal / 180 vertical / 180 diagonal,,,,true,2024
+ubiquiti-ai-turret,Ubiquiti,UniFi Protect AI Turret,turret,4K UHD,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IP66,IK08,true,
+ubiquiti-doorbell-lite,Ubiquiti,UniFi Protect Doorbell Lite,doorbell,5MP,5,"1/2.7"" 5MP",95.8 horizontal / 131.2 vertical / 175.9 diagonal,ir,IPX5,,true,
 ubiquiti-g3-bullet,Ubiquiti,UniFi Protect G3 Bullet,bullet,1080p HD,2,"1/3"" 4MP HDR",85 horizontal / 44.8 vertical / 98.1 diagonal (before lens correction); 72 horizontal / 42.9 vertical / 80.4 diagonal (after lens correction),ir,,,false,2018
 ubiquiti-g3-flex,Ubiquiti,UniFi Protect G3 Flex,dome,1080p HD,2,"1/3"" 2MP HDR",87 horizontal / 47 vertical / 104 diagonal (lens correction off); 80 horizontal / 46 vertical / 92 diagonal (lens correction on),ir,IPX4,,false,2019
 ubiquiti-g3-instant,Ubiquiti,UniFi Protect G3 Instant,dome,1080p HD,2,2MP CMOS,111.3 horizontal / 58.9 vertical / 133.6 diagonal,ir,,,true,2021
@@ -2543,8 +2550,22 @@ ubiquiti-g5-dome,Ubiquiti,UniFi Protect G5 Dome,dome,2K/4MP,4,5MP CMOS,102.4 hor
 ubiquiti-g5-dome-ultra,Ubiquiti,UniFi Protect G5 Dome Ultra,dome,2K,4,"1/2.4"" CMOS",102.4 horizontal / 54.9 vertical / 120.6 diagonal,ir,,IK06,,2024
 ubiquiti-g5-flex,Ubiquiti,UniFi Protect G5 Flex,dome,2K,4,5MP CMOS,102.4 horizontal / 54.9 vertical / 120.6 diagonal,ir,IPX4,IK04,false,2024
 ubiquiti-g5-pro,Ubiquiti,UniFi Protect G5 Pro,bullet,4K UHD,8,"1/2"" 8MP",109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (zoom),ir,IP65,IK04,false,2024
+ubiquiti-g5-ptz,Ubiquiti,UniFi Protect G5 PTZ,ptz,4MP,4,"1/2.7"" 5MP CMOS",99.7 horizontal / 51.9 vertical / 121 diagonal (wide); 45.5 horizontal / 25.4 vertical / 52.4 diagonal (zoom),ir,IP66,IK04,false,
 ubiquiti-g5-turret-ultra,Ubiquiti,UniFi Protect G5 Turret Ultra,turret,2K/4MP,4,"1/2.4"" CMOS",102.4 horizontal / 54.9 vertical / 120.6 diagonal,ir,IP66,IK04,false,2024
+ubiquiti-g6-180,Ubiquiti,UniFi Protect G6 180,panoramic,Dual 4K (3.5:1),16,"Dual 1/1.8"" 8MP",180 horizontal / 56.7 vertical,ir,IP66,IK04,true,
+ubiquiti-g6-bullet,Ubiquiti,UniFi Protect G6 Bullet,bullet,4K,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IP66,IK04,false,
+ubiquiti-g6-dome,Ubiquiti,UniFi Protect G6 Dome,dome,4K UHD,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IP66,IK10,false,
+ubiquiti-g6-edge-bullet,Ubiquiti,UniFi Protect G6 Edge Bullet,bullet,4K,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK04,true,
+ubiquiti-g6-edge-dome,Ubiquiti,UniFi Protect G6 Edge Dome,dome,4K UHD,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK10,false,
+ubiquiti-g6-edge-turret,Ubiquiti,UniFi Protect G6 Edge Turret,turret,4K UHD,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK04,true,
+ubiquiti-g6-ins,Ubiquiti,UniFi Protect G6 Instant,dome,4K UHD,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IPX5,IK04,true,
+ubiquiti-g6-mini-dome,Ubiquiti,UniFi Protect G6 Mini Dome,dome,4K UHD,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,,IK08,true,
+ubiquiti-g6-pro-360,Ubiquiti,UniFi Protect G6 Pro 360,fisheye,12MP (1:1),12,"1/1.6"" 12MP",180 horizontal / 180 vertical / 180 diagonal,ir,IP66,IK10,true,
+ubiquiti-g6-pro-bullet,Ubiquiti,UniFi Protect G6 Pro Bullet,bullet,4K,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK04,true,
+ubiquiti-g6-pro-dome,Ubiquiti,UniFi Protect G6 Pro Dome,dome,4K UHD,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK10,false,
+ubiquiti-g6-pro-turret,Ubiquiti,UniFi Protect G6 Pro Turret,turret,4K,8,"1/1.2"" 8MP",113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele),ir,IP66,IK04,true,
 ubiquiti-g6-ptz,Ubiquiti,UniFi Protect G6 PTZ,ptz,4K UHD,8,"1/1.8"" 8MP CMOS (wide channel); 1/1.8"" 8MP CMOS (tele channel)",109.9 horizontal / 56.7 vertical / 134.1 diagonal (wide); 26.6 horizontal / 15.1 vertical / 30.4 diagonal (tele),ir,IP66,IK04,true,2024
+ubiquiti-g6-turret,Ubiquiti,UniFi Protect G6 Turret,turret,4K UHD,8,"1/1.8"" 8MP",109.9 horizontal / 56.7 vertical / 134.1 diagonal,ir,IP66,IK04,false,
 uniarch-ipc-b122-apf28,Uniarch,IPC-B122-APF28,bullet,1080p/2MP,2,CMOS,Horizontal 106.7,ir,IP67,,false,
 uniarch-ipc-b122-apf28k,Uniarch,IPC-B122-APF28K,bullet,1080p/2MP,2,"1/2.9"" CMOS","Horizontal 101.1, Vertical 55.0, Diagonal 111.0",ir,IP67,,false,
 uniarch-ipc-b124-apf28k,Uniarch,IPC-B124-APF28K,bullet,4MP,4,"1/3.0"" CMOS","Horizontal 97.0, Vertical 52.2, Diagonal 107.5",ir,IP67,,false,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -240599,6 +240599,261 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-ai-lpr",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI LPR",
+    "aliases": [
+      "UVC-AI-LPR"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.1-12.3",
+      "aperture": "F1.53-F3.3",
+      "varifocal": true
+    },
+    "field_of_view_deg": "109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 15
+    },
+    "power": {
+      "method": "PoE+; 25.5W max, 42.5-57V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "130 x 151.4 x 302.9",
+    "weight_g": 3300,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "3x optical zoom",
+      "IR optimized with LPR filter",
+      "MicroSD card slot",
+      "IK04 tamper resistance",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-lpr"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ms-2",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI MS-2",
+    "aliases": [
+      "UVC-AI-MS-2"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 16,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "Dual 4K (2x 8MP)"
+    },
+    "sensor": "Dual 1/2.8\" 8MP",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "3.18-7.42",
+      "aperture": "F1.8-F2.8",
+      "varifocal": true
+    },
+    "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 25W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "218 x 132 x 93.5",
+    "weight_g": 1300,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "dual-sensor multi-sensor, 2x 8MP 4K, 30 FPS max",
+      "2.33x optical zoom",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK10 impact resistance",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-2"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ms-4",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI MS-4",
+    "aliases": [
+      "UVC-AI-MS-4"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 32,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD per sensor (32MP total)"
+    },
+    "sensor": "1/2.8\" 8MP (x4)",
+    "lens": {
+      "count": 4,
+      "focal_length_mm": "3.18-7.42",
+      "aperture": "F1.8-F2.8",
+      "varifocal": true
+    },
+    "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE++; 34.6W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "255 (diameter) x 105",
+    "weight_g": 2400,
+    "operating_temp_c": "-20 to 50",
+    "features": [
+      "four 8MP sensors, 32MP total, 24 FPS max",
+      "2.33x optical zoom per sensor",
+      "adaptive IR illumination up to 20m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "2x microSD card slots + M.2 2280 SATA SSD",
+      "IK10 vandal resistance",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-4"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
     "id": "ubiquiti-ai-pro",
     "brand": "Ubiquiti",
     "model": "UniFi Protect AI Pro",
@@ -240776,6 +241031,165 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-ai-ptz",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI PTZ",
+    "aliases": [
+      "UVC-AI-PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6.36-138.5",
+      "aperture": "F1.5-F3.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "59.8 horizontal / 44.4 vertical / 70 diagonal (wide); 3 horizontal / 2.24 vertical / 3.76 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE++; 51W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "207 x 223.7 x 341.3",
+    "weight_g": 3800,
+    "operating_temp_c": "-40 to 50",
+    "features": [
+      "22x optical zoom",
+      "pan-tilt-zoom (360 endless pan / 120 tilt)",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "microSD storage",
+      "NDAA compliant",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ptz-precision",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI PTZ Precision",
+    "aliases": [
+      "UVC-AI-PTZ-Precision"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6.91-214.64",
+      "aperture": "F1.36-F4.6",
+      "varifocal": true
+    },
+    "field_of_view_deg": "59 horizontal / 34.1 vertical / 67.1 diagonal (wide); 1.98 horizontal / 1.12 vertical / 2.27 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE++; 51W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "241 (diameter) x 349",
+    "weight_g": 5500,
+    "operating_temp_c": "-40 to 50",
+    "features": [
+      "31x optical zoom",
+      "pan-tilt-zoom (360 pan / 120 tilt)",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "microSD storage",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz-precision"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
     "id": "ubiquiti-ai-theta-pro",
     "brand": "Ubiquiti",
     "model": "UniFi Protect AI Theta Pro",
@@ -240854,6 +241268,168 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-ai-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI Turret",
+    "aliases": [
+      "UVC-AI-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 20W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "dimensions_mm": "118 (diameter) x 111",
+    "weight_g": 990,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "adaptive IR up to 40m",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK08 tamper resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-doorbell-lite",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect Doorbell Lite",
+    "aliases": [
+      "UVC-Doorbell-Lite"
+    ],
+    "type": "doorbell",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 1920,
+      "max_height": 2560,
+      "label": "5MP"
+    },
+    "sensor": "1/2.7\" 5MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "95.8 horizontal / 131.2 vertical / 175.9 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 5
+    },
+    "power": {
+      "method": "PoE; 8W max"
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IPX5",
+    "dimensions_mm": "137 x 40 x 26.4",
+    "weight_g": 142,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "3:4 vertical aspect ratio for head-to-toe view",
+      "24 FPS max",
+      "Smart Detections (person/vehicle/animal)",
+      "two-way audio",
+      "NDAA compliant",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-doorbell-lite"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -242211,6 +242787,87 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-g5-ptz",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G5 PTZ",
+    "aliases": [
+      "UVC-G5-PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2688,
+      "max_height": 1512,
+      "label": "4MP"
+    },
+    "sensor": "1/2.7\" 5MP CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.42-6.85",
+      "aperture": "F1.85-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "99.7 horizontal / 51.9 vertical / 121 diagonal (wide); 45.5 horizontal / 25.4 vertical / 52.4 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 14W max"
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "90 (diameter) x 152.5",
+    "weight_g": 580,
+    "operating_temp_c": "-30 to 45",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "2x optical zoom",
+      "pan-tilt-zoom",
+      "30 FPS max",
+      "built-in IR & white LED illumination",
+      "Smart Detections (person/vehicle/animal)",
+      "IK04 tamper resistance",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g5-ptz"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03",
+    "added": "2026-06-06"
+  },
+  {
     "id": "ubiquiti-g5-turret-ultra",
     "brand": "Ubiquiti",
     "model": "UniFi Protect G5 Turret Ultra",
@@ -242293,6 +242950,1027 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-g6-180",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 180",
+    "aliases": [
+      "UVC-G6-180"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 16,
+      "max_width": 7680,
+      "max_height": 2160,
+      "label": "Dual 4K (3.5:1)"
+    },
+    "sensor": "Dual 1/1.8\" 8MP",
+    "lens": {
+      "count": 2,
+      "varifocal": false
+    },
+    "field_of_view_deg": "180 horizontal / 56.7 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "136 x 64 x 92",
+    "weight_g": 839,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "16MP dual-lens 180-degree panoramic, 20 FPS max",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-180"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Bullet",
+    "aliases": [
+      "UVC-G6-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 9.9W max, 37-57V DC"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "82 (diameter) x 88.8 (without mount); 82 (diameter) x 153 (with mount)",
+    "weight_g": 587,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "HDR",
+      "built-in mic",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Dome",
+    "aliases": [
+      "UVC-G6-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 9.25W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "144.7 (diameter) x 96.3",
+    "weight_g": 820,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "adaptive IR illumination up to 30m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "IK10 vandal resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Bullet",
+    "aliases": [
+      "UVC-G6-Edge-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 60
+    },
+    "power": {
+      "method": "PoE+; 25W max, 42.5-57V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "107 (diameter) x 113 (without mount); 107 (diameter) x 212 (with wall mount)",
+    "weight_g": 780,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "HDR",
+      "two-way audio",
+      "MicroSD card slot"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Dome",
+    "aliases": [
+      "UVC-G6-Edge-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "163.8 (diameter) x 108.8",
+    "weight_g": 1200,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR up to 40m",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "IK10 impact resistance",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Turret",
+    "aliases": [
+      "UVC-G6-Edge-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.85-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 25W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "117.2 (diameter) x 116.5",
+    "weight_g": 1200,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR illumination up to 40m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "microSD card slot",
+      "two-way audio",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-ins",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Instant",
+    "aliases": [
+      "UVC-G6-Ins"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet",
+      "wifi"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 6
+    },
+    "power": {
+      "method": "5V/2A USB power adapter (included) or PoE-to-USB-C adapter (not included); 7W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IPX5",
+    "ik_rating": "IK04",
+    "dimensions_mm": "81.7 x 50.1 x 57.2",
+    "weight_g": 180,
+    "operating_temp_c": "-20 to 40",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "compact indoor camera with WiFi and Bluetooth",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "HDR",
+      "two-way audio",
+      "microSD storage",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-ins"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-mini-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Mini Dome",
+    "aliases": [
+      "UVC-G6-Mini-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE; 9W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ik_rating": "IK08",
+    "dimensions_mm": "100.8 (diameter) x 56",
+    "weight_g": 254,
+    "operating_temp_c": "-20 to 40",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "IK08 tamper resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-mini-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-360",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro 360",
+    "aliases": [
+      "UVC-G6-Pro-360"
+    ],
+    "type": "fisheye",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 3504,
+      "max_height": 3504,
+      "label": "12MP (1:1)"
+    },
+    "sensor": "1/1.6\" 12MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "180 horizontal / 180 vertical / 180 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 15
+    },
+    "power": {
+      "method": "PoE+; 13.5W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "147 (diameter) x 65.5",
+    "weight_g": 610,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "12MP fisheye 360-degree, 24 FPS max",
+      "Smart IR with 4 controllable zones",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK10 impact resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-360"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Bullet",
+    "aliases": [
+      "UVC-G6-Pro-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "85.8 (diameter) x 106.2 (without mount); 85.8 (diameter) x 210 (with wall mount)",
+    "weight_g": 755,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "optional Vision Enhancer extends IR range from 40m up to 60m",
+      "two-way audio",
+      "MicroSD card slot",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Dome",
+    "aliases": [
+      "UVC-G6-Pro-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "163.8 (diameter) x 108.8",
+    "weight_g": 1200,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR illumination up to 40m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "microSD card slot",
+      "IK10 vandal resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Turret",
+    "aliases": [
+      "UVC-G6-Pro-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.85-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "117.2 (diameter) x 116.5",
+    "weight_g": 1200,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "two-way audio",
+      "MicroSD card slot"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -242383,6 +244061,91 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-g6-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Turret",
+    "aliases": [
+      "UVC-G6-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3864,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 12.5W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "100 (diameter) x 95",
+    "weight_g": 550,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "adaptive IR illumination up to 30m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "uniarch-ipc-b122-apf28",

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98602,6 +98602,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
     "audio": {
       "microphone": true,
@@ -98647,7 +98648,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {
@@ -102965,6 +102966,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103009,7 +103011,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -103445,6 +103447,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103488,7 +103491,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -103523,6 +103526,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103567,7 +103571,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -105116,6 +105120,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -105158,7 +105163,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -94164,6 +94164,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -94207,7 +94208,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -94474,9 +94475,10 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -95763,6 +95765,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "operating_temp_c": "-40 to +60",
     "audio": {
       "microphone": true,
@@ -95783,7 +95786,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97208,6 +97211,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97232,7 +97236,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97322,6 +97326,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97343,7 +97348,7 @@
     "sources": [
       "https://www.dahuasecurity.com/products/network-products/Network-Cameras/WizSense-2-Series/IR/IPC-HFW2441T-ZAS"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97430,6 +97435,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97477,7 +97483,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -98714,6 +98714,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -98759,7 +98760,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {
@@ -99615,6 +99616,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -99656,7 +99658,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -99998,6 +100000,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -100039,7 +100042,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -101800,6 +101803,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -101842,7 +101846,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -101929,10 +101933,11 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "113-31",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -102635,9 +102640,10 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/2.8\" CMOS",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -240681,7 +240687,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ms-2",
@@ -240768,7 +240775,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ms-4",
@@ -240851,7 +240859,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-pro",
@@ -241108,7 +241117,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ptz-precision",
@@ -241187,7 +241197,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-theta-pro",
@@ -241353,7 +241364,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-doorbell-lite",
@@ -241429,7 +241441,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -243033,7 +243046,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-bullet",
@@ -243114,7 +243128,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-dome",
@@ -243199,7 +243214,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-bullet",
@@ -243284,7 +243300,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-dome",
@@ -243371,7 +243388,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-turret",
@@ -243458,7 +243476,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ins",
@@ -243543,7 +243562,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-mini-dome",
@@ -243626,7 +243646,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-360",
@@ -243710,7 +243731,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-bullet",
@@ -243796,7 +243818,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-dome",
@@ -243886,7 +243909,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-turret",
@@ -243970,7 +243994,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -244145,7 +244170,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "uniarch-ipc-b122-apf28",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -240599,6 +240599,261 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-ai-lpr",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI LPR",
+    "aliases": [
+      "UVC-AI-LPR"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.1-12.3",
+      "aperture": "F1.53-F3.3",
+      "varifocal": true
+    },
+    "field_of_view_deg": "109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 15
+    },
+    "power": {
+      "method": "PoE+; 25.5W max, 42.5-57V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "130 x 151.4 x 302.9",
+    "weight_g": 3300,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "3x optical zoom",
+      "IR optimized with LPR filter",
+      "MicroSD card slot",
+      "IK04 tamper resistance",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-lpr"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ms-2",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI MS-2",
+    "aliases": [
+      "UVC-AI-MS-2"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 16,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "Dual 4K (2x 8MP)"
+    },
+    "sensor": "Dual 1/2.8\" 8MP",
+    "lens": {
+      "count": 2,
+      "focal_length_mm": "3.18-7.42",
+      "aperture": "F1.8-F2.8",
+      "varifocal": true
+    },
+    "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 25W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "218 x 132 x 93.5",
+    "weight_g": 1300,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "dual-sensor multi-sensor, 2x 8MP 4K, 30 FPS max",
+      "2.33x optical zoom",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK10 impact resistance",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-2"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ms-4",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI MS-4",
+    "aliases": [
+      "UVC-AI-MS-4"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 32,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD per sensor (32MP total)"
+    },
+    "sensor": "1/2.8\" 8MP (x4)",
+    "lens": {
+      "count": 4,
+      "focal_length_mm": "3.18-7.42",
+      "aperture": "F1.8-F2.8",
+      "varifocal": true
+    },
+    "field_of_view_deg": "108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE++; 34.6W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "255 (diameter) x 105",
+    "weight_g": 2400,
+    "operating_temp_c": "-20 to 50",
+    "features": [
+      "four 8MP sensors, 32MP total, 24 FPS max",
+      "2.33x optical zoom per sensor",
+      "adaptive IR illumination up to 20m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "2x microSD card slots + M.2 2280 SATA SSD",
+      "IK10 vandal resistance",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-4"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
     "id": "ubiquiti-ai-pro",
     "brand": "Ubiquiti",
     "model": "UniFi Protect AI Pro",
@@ -240776,6 +241031,165 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-ai-ptz",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI PTZ",
+    "aliases": [
+      "UVC-AI-PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6.36-138.5",
+      "aperture": "F1.5-F3.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "59.8 horizontal / 44.4 vertical / 70 diagonal (wide); 3 horizontal / 2.24 vertical / 3.76 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE++; 51W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "207 x 223.7 x 341.3",
+    "weight_g": 3800,
+    "operating_temp_c": "-40 to 50",
+    "features": [
+      "22x optical zoom",
+      "pan-tilt-zoom (360 endless pan / 120 tilt)",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "microSD storage",
+      "NDAA compliant",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-ai-ptz-precision",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI PTZ Precision",
+    "aliases": [
+      "UVC-AI-PTZ-Precision"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "6.91-214.64",
+      "aperture": "F1.36-F4.6",
+      "varifocal": true
+    },
+    "field_of_view_deg": "59 horizontal / 34.1 vertical / 67.1 diagonal (wide); 1.98 horizontal / 1.12 vertical / 2.27 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 100
+    },
+    "power": {
+      "method": "PoE++; 51W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "dimensions_mm": "241 (diameter) x 349",
+    "weight_g": 5500,
+    "operating_temp_c": "-40 to 50",
+    "features": [
+      "31x optical zoom",
+      "pan-tilt-zoom (360 pan / 120 tilt)",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "microSD storage",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz-precision"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
     "id": "ubiquiti-ai-theta-pro",
     "brand": "Ubiquiti",
     "model": "UniFi Protect AI Theta Pro",
@@ -240854,6 +241268,168 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-ai-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect AI Turret",
+    "aliases": [
+      "UVC-AI-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 20W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK08",
+    "dimensions_mm": "118 (diameter) x 111",
+    "weight_g": 990,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "adaptive IR up to 40m",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK08 tamper resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-ai-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-doorbell-lite",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect Doorbell Lite",
+    "aliases": [
+      "UVC-Doorbell-Lite"
+    ],
+    "type": "doorbell",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 1920,
+      "max_height": 2560,
+      "label": "5MP"
+    },
+    "sensor": "1/2.7\" 5MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "95.8 horizontal / 131.2 vertical / 175.9 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 5
+    },
+    "power": {
+      "method": "PoE; 8W max"
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IPX5",
+    "dimensions_mm": "137 x 40 x 26.4",
+    "weight_g": 142,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "3:4 vertical aspect ratio for head-to-toe view",
+      "24 FPS max",
+      "Smart Detections (person/vehicle/animal)",
+      "two-way audio",
+      "NDAA compliant",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-doorbell-lite"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -242211,6 +242787,87 @@
     "added": "2026-06-11"
   },
   {
+    "id": "ubiquiti-g5-ptz",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G5 PTZ",
+    "aliases": [
+      "UVC-G5-PTZ"
+    ],
+    "type": "ptz",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 4,
+      "max_width": 2688,
+      "max_height": 1512,
+      "label": "4MP"
+    },
+    "sensor": "1/2.7\" 5MP CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "3.42-6.85",
+      "aperture": "F1.85-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "99.7 horizontal / 51.9 vertical / 121 diagonal (wide); 45.5 horizontal / 25.4 vertical / 52.4 diagonal (zoom)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 14W max"
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "90 (diameter) x 152.5",
+    "weight_g": 580,
+    "operating_temp_c": "-30 to 45",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "2x optical zoom",
+      "pan-tilt-zoom",
+      "30 FPS max",
+      "built-in IR & white LED illumination",
+      "Smart Detections (person/vehicle/animal)",
+      "IK04 tamper resistance",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g5-ptz"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03",
+    "added": "2026-06-06"
+  },
+  {
     "id": "ubiquiti-g5-turret-ultra",
     "brand": "Ubiquiti",
     "model": "UniFi Protect G5 Turret Ultra",
@@ -242293,6 +242950,1027 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-g6-180",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 180",
+    "aliases": [
+      "UVC-G6-180"
+    ],
+    "type": "panoramic",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 16,
+      "max_width": 7680,
+      "max_height": 2160,
+      "label": "Dual 4K (3.5:1)"
+    },
+    "sensor": "Dual 1/1.8\" 8MP",
+    "lens": {
+      "count": 2,
+      "varifocal": false
+    },
+    "field_of_view_deg": "180 horizontal / 56.7 vertical",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "136 x 64 x 92",
+    "weight_g": 839,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "16MP dual-lens 180-degree panoramic, 20 FPS max",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-180"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Bullet",
+    "aliases": [
+      "UVC-G6-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 9.9W max, 37-57V DC"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "82 (diameter) x 88.8 (without mount); 82 (diameter) x 153 (with mount)",
+    "weight_g": 587,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "HDR",
+      "built-in mic",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Dome",
+    "aliases": [
+      "UVC-G6-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 9.25W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "144.7 (diameter) x 96.3",
+    "weight_g": 820,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "adaptive IR illumination up to 30m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "IK10 vandal resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Bullet",
+    "aliases": [
+      "UVC-G6-Edge-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 60
+    },
+    "power": {
+      "method": "PoE+; 25W max, 42.5-57V DC"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "107 (diameter) x 113 (without mount); 107 (diameter) x 212 (with wall mount)",
+    "weight_g": 780,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "HDR",
+      "two-way audio",
+      "MicroSD card slot"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Dome",
+    "aliases": [
+      "UVC-G6-Edge-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "163.8 (diameter) x 108.8",
+    "weight_g": 1200,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR up to 40m",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "IK10 impact resistance",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-edge-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Edge Turret",
+    "aliases": [
+      "UVC-G6-Edge-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.85-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 25W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "117.2 (diameter) x 116.5",
+    "weight_g": 1200,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR illumination up to 40m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "microSD card slot",
+      "two-way audio",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-ins",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Instant",
+    "aliases": [
+      "UVC-G6-Ins"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet",
+      "wifi"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 6
+    },
+    "power": {
+      "method": "5V/2A USB power adapter (included) or PoE-to-USB-C adapter (not included); 7W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IPX5",
+    "ik_rating": "IK04",
+    "dimensions_mm": "81.7 x 50.1 x 57.2",
+    "weight_g": 180,
+    "operating_temp_c": "-20 to 40",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "compact indoor camera with WiFi and Bluetooth",
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (person/vehicle/animal)",
+      "HDR",
+      "two-way audio",
+      "microSD storage",
+      "UniFi Protect ecosystem"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-ins"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-mini-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Mini Dome",
+    "aliases": [
+      "UVC-G6-Mini-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 20
+    },
+    "power": {
+      "method": "PoE; 9W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ik_rating": "IK08",
+    "dimensions_mm": "100.8 (diameter) x 56",
+    "weight_g": 254,
+    "operating_temp_c": "-20 to 40",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "4K UHD, 30 FPS max",
+      "Face Recognition",
+      "License Plate Recognition",
+      "AI event detection person/vehicle/animal",
+      "IK08 tamper resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-mini-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-360",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro 360",
+    "aliases": [
+      "UVC-G6-Pro-360"
+    ],
+    "type": "fisheye",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 12,
+      "max_width": 3504,
+      "max_height": 3504,
+      "label": "12MP (1:1)"
+    },
+    "sensor": "1/1.6\" 12MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "180 horizontal / 180 vertical / 180 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 15
+    },
+    "power": {
+      "method": "PoE+; 13.5W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "147 (diameter) x 65.5",
+    "weight_g": 610,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "12MP fisheye 360-degree, 24 FPS max",
+      "Smart IR with 4 controllable zones",
+      "AI event detection person/vehicle/animal",
+      "MicroSD card slot",
+      "IK10 impact resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "two-way audio"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-360"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-bullet",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Bullet",
+    "aliases": [
+      "UVC-G6-Pro-Bullet"
+    ],
+    "type": "bullet",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "85.8 (diameter) x 106.2 (without mount); 85.8 (diameter) x 210 (with wall mount)",
+    "weight_g": 755,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "optional Vision Enhancer extends IR range from 40m up to 60m",
+      "two-way audio",
+      "MicroSD card slot",
+      "NDAA compliant"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-bullet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-dome",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Dome",
+    "aliases": [
+      "UVC-G6-Pro-Dome"
+    ],
+    "type": "dome",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.9-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "dimensions_mm": "163.8 (diameter) x 108.8",
+    "weight_g": 1200,
+    "operating_temp_c": "-20 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "2.36x optical zoom",
+      "adaptive IR illumination up to 40m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "microSD card slot",
+      "IK10 vandal resistance",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-dome"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
+  },
+  {
+    "id": "ubiquiti-g6-pro-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Pro Turret",
+    "aliases": [
+      "UVC-G6-Pro-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.2\" 8MP",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "5.85-13.8",
+      "aperture": "F1.5-F2.9",
+      "varifocal": true
+    },
+    "field_of_view_deg": "113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 40
+    },
+    "power": {
+      "method": "PoE+; 15W max"
+    },
+    "storage": {
+      "onboard": true,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "117.2 (diameter) x 116.5",
+    "weight_g": 1200,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "Face Recognition",
+      "License Plate Recognition",
+      "Smart Detections (people/vehicles/animals)",
+      "2.36x optical zoom",
+      "two-way audio",
+      "MicroSD card slot"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -242383,6 +244061,91 @@
     },
     "last_verified": "2026-07-06",
     "added": "2026-06-06"
+  },
+  {
+    "id": "ubiquiti-g6-turret",
+    "brand": "Ubiquiti",
+    "model": "UniFi Protect G6 Turret",
+    "aliases": [
+      "UVC-G6-Turret"
+    ],
+    "type": "turret",
+    "connectivity": [
+      "ethernet"
+    ],
+    "resolution": {
+      "megapixels": 8,
+      "max_width": 3864,
+      "max_height": 2160,
+      "label": "4K UHD"
+    },
+    "sensor": "1/1.8\" 8MP",
+    "lens": {
+      "count": 1,
+      "varifocal": false
+    },
+    "field_of_view_deg": "109.9 horizontal / 56.7 vertical / 134.1 diagonal",
+    "night_vision": {
+      "type": "ir",
+      "range_m": 30
+    },
+    "power": {
+      "method": "PoE; 12.5W max"
+    },
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK04",
+    "dimensions_mm": "100 (diameter) x 95",
+    "weight_g": 550,
+    "operating_temp_c": "-30 to 50",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "features": [
+      "4K, 30 FPS max",
+      "adaptive IR illumination up to 30m",
+      "face recognition",
+      "license plate recognition",
+      "AI smart detections person/vehicle/animal",
+      "HDR",
+      "NDAA compliant",
+      "UniFi Protect ecosystem",
+      "built-in mic"
+    ],
+    "sources": [
+      "https://techspecs.ui.com/unifi/physical-security/uvc-g6-turret"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "configs": {
+      "frigate": {
+        "detect": {
+          "width": 1280,
+          "height": 720,
+          "fps": 5
+        },
+        "rtsp_url_template": "rtsps://{ip}:7441/{camera_id}?enableSrtp"
+      },
+      "home_assistant": {
+        "integration": "unifiprotect",
+        "notes": "Native UniFi Protect integration. Requires UniFi Protect console."
+      },
+      "blue_iris": {
+        "profile": "Generic/RTSP",
+        "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
+      }
+    },
+    "last_verified": "2026-08-03"
   },
   {
     "id": "uniarch-ipc-b122-apf28",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98602,6 +98602,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "operating_temp_c": "-30 to 60",
     "audio": {
       "microphone": true,
@@ -98647,7 +98648,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {
@@ -102965,6 +102966,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103009,7 +103011,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -103445,6 +103447,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103488,7 +103491,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -103523,6 +103526,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -103567,7 +103571,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -105116,6 +105120,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -105158,7 +105163,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -94164,6 +94164,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -94207,7 +94208,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -94474,9 +94475,10 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/1.8\" CMOS",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -95763,6 +95765,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "operating_temp_c": "-40 to +60",
     "audio": {
       "microphone": true,
@@ -95783,7 +95786,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97208,6 +97211,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97232,7 +97236,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97322,6 +97326,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97343,7 +97348,7 @@
     "sources": [
       "https://www.dahuasecurity.com/products/network-products/Network-Cameras/WizSense-2-Series/IR/IPC-HFW2441T-ZAS"
     ],
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "configs": {
       "frigate": {
         "detect": {
@@ -97430,6 +97435,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -97477,7 +97483,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -98714,6 +98714,7 @@
       "onvif"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -98759,7 +98760,7 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-27",
+    "last_verified": "2026-08-03",
     "added": "2026-07-27"
   },
   {
@@ -99615,6 +99616,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": false,
       "speaker": false,
@@ -99656,7 +99658,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -99998,6 +100000,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -100039,7 +100042,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -101800,6 +101803,7 @@
       "rtsp"
     ],
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "audio": {
       "microphone": true,
       "speaker": false,
@@ -101842,7 +101846,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-07-04",
+    "last_verified": "2026-08-03",
     "added": "2026-06-06"
   },
   {
@@ -101929,10 +101933,11 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/2.8\" CMOS",
     "field_of_view_deg": "113-31",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -102635,9 +102640,10 @@
         "notes": "Select the 'Dahua' profile."
       }
     },
-    "last_verified": "2026-07-22",
+    "last_verified": "2026-08-03",
     "sensor": "1/2.8\" CMOS",
     "ip_rating": "IP67",
+    "ik_rating": "IK10",
     "added": "2026-07-06"
   },
   {
@@ -240681,7 +240687,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ms-2",
@@ -240768,7 +240775,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ms-4",
@@ -240851,7 +240859,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-pro",
@@ -241108,7 +241117,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-ptz-precision",
@@ -241187,7 +241197,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-ai-theta-pro",
@@ -241353,7 +241364,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-doorbell-lite",
@@ -241429,7 +241441,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g3-bullet",
@@ -243033,7 +243046,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-bullet",
@@ -243114,7 +243128,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-dome",
@@ -243199,7 +243214,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-bullet",
@@ -243284,7 +243300,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-dome",
@@ -243371,7 +243388,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-edge-turret",
@@ -243458,7 +243476,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ins",
@@ -243543,7 +243562,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-mini-dome",
@@ -243626,7 +243646,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-360",
@@ -243710,7 +243731,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-bullet",
@@ -243796,7 +243818,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-dome",
@@ -243886,7 +243909,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-pro-turret",
@@ -243970,7 +243994,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "ubiquiti-g6-ptz",
@@ -244145,7 +244170,8 @@
         "notes": "Use Generic/RTSP profile with RTSPS URL from UniFi Protect. Requires Protect RTSP stream enabled per camera."
       }
     },
-    "last_verified": "2026-08-03"
+    "last_verified": "2026-08-03",
+    "added": "2026-08-03"
   },
   {
     "id": "uniarch-ipc-b122-apf28",

--- a/docs/cameras/dahua/ipc-hdw5442tm-ase.md
+++ b/docs/cameras/dahua/ipc-hdw5442tm-ase.md
@@ -16,6 +16,7 @@
 | Storage | microSD ≤ 512GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 
 ## Features

--- a/docs/cameras/dahua/ipc-hdw5842tm-ase.md
+++ b/docs/cameras/dahua/ipc-hdw5842tm-ase.md
@@ -14,6 +14,7 @@
 | Storage | microSD ≤ 1024GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 
 ## Features

--- a/docs/cameras/dahua/ipc-hfw2241t-as.md
+++ b/docs/cameras/dahua/ipc-hfw2241t-as.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -40 to +60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2441t-as.md
+++ b/docs/cameras/dahua/ipc-hfw2441t-as.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -40 to 60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2441t-zas.md
+++ b/docs/cameras/dahua/ipc-hfw2441t-zas.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -30 to 60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2441t-zs.md
+++ b/docs/cameras/dahua/ipc-hfw2441t-zs.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -30 to 60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2541t-zas.md
+++ b/docs/cameras/dahua/ipc-hfw2541t-zas.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -30 to 60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2541t-zs.md
+++ b/docs/cameras/dahua/ipc-hfw2541t-zs.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | rtsp, onvif |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Operating temp | -30 to 60°C |
 

--- a/docs/cameras/dahua/ipc-hfw2831t-zas-s2.md
+++ b/docs/cameras/dahua/ipc-hfw2831t-zas-s2.md
@@ -16,6 +16,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 
 ## Features

--- a/docs/cameras/dahua/ipc-hfw2841t-zas-s2.md
+++ b/docs/cameras/dahua/ipc-hfw2841t-zas-s2.md
@@ -13,6 +13,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/dahua/ipc-hfw3841t-zas-s2.md
+++ b/docs/cameras/dahua/ipc-hfw3841t-zas-s2.md
@@ -13,6 +13,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/dahua/ipc-hfw3841tp-zas.md
+++ b/docs/cameras/dahua/ipc-hfw3841tp-zas.md
@@ -15,6 +15,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 
 ## Features

--- a/docs/cameras/dahua/ipc-hfw3866tp-zas.md
+++ b/docs/cameras/dahua/ipc-hfw3866tp-zas.md
@@ -14,6 +14,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 
 ## Features

--- a/docs/cameras/dahua/ipc-hfw5442e-ze-s3.md
+++ b/docs/cameras/dahua/ipc-hfw5442e-ze-s3.md
@@ -13,6 +13,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/dahua/ipc-hfw7442h-z4-x.md
+++ b/docs/cameras/dahua/ipc-hfw7442h-z4-x.md
@@ -13,6 +13,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2022 |
 

--- a/docs/cameras/dahua/ipc-hfw7842h-z-x.md
+++ b/docs/cameras/dahua/ipc-hfw7842h-z-x.md
@@ -13,6 +13,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2022 |
 

--- a/docs/cameras/dahua/itc237-pw1b-irz-lr.md
+++ b/docs/cameras/dahua/itc237-pw1b-irz-lr.md
@@ -16,6 +16,7 @@
 | Storage | microSD ≤ 256GB, NVR |
 | Protocols | onvif, rtsp |
 | IP rating | IP67 |
+| IK rating | IK10 |
 | Two-way audio | No |
 | Released | 2023 |
 

--- a/docs/cameras/ubiquiti/ai-lpr.md
+++ b/docs/cameras/ubiquiti/ai-lpr.md
@@ -1,0 +1,39 @@
+# Ubiquiti UniFi Protect AI LPR
+
+*Also known as: UVC-AI-LPR*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI LPR |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× 4.1-12.3mm F1.53-F3.3 |
+| Field of view | 109.9 horizontal / 60 vertical / 127.7 diagonal (wide); 35 horizontal / 19.8 vertical / 40 diagonal (tele)° |
+| Night vision | ir (15m) |
+| Power | PoE+; 25.5W max, 42.5-57V DC |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- License Plate Recognition
+- Smart Detections (people/vehicles/animals)
+- 3x optical zoom
+- IR optimized with LPR filter
+- MicroSD card slot
+- IK04 tamper resistance
+- NDAA compliant
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-lpr
+
+---
+*Auto-generated from ubiquiti-ai-lpr.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/ai-ms-2.md
+++ b/docs/cameras/ubiquiti/ai-ms-2.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect AI MS-2
+
+*Also known as: UVC-AI-MS-2*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI MS-2 |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | Dual 4K (2x 8MP) (16MP, 3840×2160) |
+| Sensor | Dual 1/2.8" 8MP |
+| Lens | 2× 3.18-7.42mm F1.8-F2.8 |
+| Field of view | 108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)° |
+| Night vision | ir (20m) |
+| Power | PoE+; 25W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- dual-sensor multi-sensor, 2x 8MP 4K, 30 FPS max
+- 2.33x optical zoom
+- Face Recognition
+- License Plate Recognition
+- AI event detection person/vehicle/animal
+- MicroSD card slot
+- IK10 impact resistance
+- UniFi Protect ecosystem
+- built-in mic
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-2
+
+---
+*Auto-generated from ubiquiti-ai-ms-2.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/ai-ms-4.md
+++ b/docs/cameras/ubiquiti/ai-ms-4.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect AI MS-4
+
+*Also known as: UVC-AI-MS-4*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI MS-4 |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | 4K UHD per sensor (32MP total) (32MP, 3840×2160) |
+| Sensor | 1/2.8" 8MP (x4) |
+| Lens | 4× 3.18-7.42mm F1.8-F2.8 |
+| Field of view | 108.8 horizontal / 57.6 vertical / 130.8 diagonal (wide); 42.8 horizontal / 24.1 vertical / 49.1 diagonal (tele)° |
+| Night vision | ir (20m) |
+| Power | PoE++; 34.6W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- four 8MP sensors, 32MP total, 24 FPS max
+- 2.33x optical zoom per sensor
+- adaptive IR illumination up to 20m
+- face recognition
+- license plate recognition
+- AI smart detections person/vehicle/animal
+- HDR
+- 2x microSD card slots + M.2 2280 SATA SSD
+- IK10 vandal resistance
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-ms-4
+
+---
+*Auto-generated from ubiquiti-ai-ms-4.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/ai-ptz-precision.md
+++ b/docs/cameras/ubiquiti/ai-ptz-precision.md
@@ -1,0 +1,37 @@
+# Ubiquiti UniFi Protect AI PTZ Precision
+
+*Also known as: UVC-AI-PTZ-Precision*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI PTZ Precision |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× 6.91-214.64mm F1.36-F4.6 |
+| Field of view | 59 horizontal / 34.1 vertical / 67.1 diagonal (wide); 1.98 horizontal / 1.12 vertical / 2.27 diagonal (zoom)° |
+| Night vision | ir (100m) |
+| Power | PoE++; 51W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| Operating temp | -40 to 50°C |
+
+## Features
+
+- 31x optical zoom
+- pan-tilt-zoom (360 pan / 120 tilt)
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (person/vehicle/animal)
+- microSD storage
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz-precision
+
+---
+*Auto-generated from ubiquiti-ai-ptz-precision.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/ai-ptz.md
+++ b/docs/cameras/ubiquiti/ai-ptz.md
@@ -1,0 +1,38 @@
+# Ubiquiti UniFi Protect AI PTZ
+
+*Also known as: UVC-AI-PTZ*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI PTZ |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× 6.36-138.5mm F1.5-F3.4 |
+| Field of view | 59.8 horizontal / 44.4 vertical / 70 diagonal (wide); 3 horizontal / 2.24 vertical / 3.76 diagonal (zoom)° |
+| Night vision | ir (100m) |
+| Power | PoE++; 51W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| Operating temp | -40 to 50°C |
+
+## Features
+
+- 22x optical zoom
+- pan-tilt-zoom (360 endless pan / 120 tilt)
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (person/vehicle/animal)
+- microSD storage
+- NDAA compliant
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-ptz
+
+---
+*Auto-generated from ubiquiti-ai-ptz.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/ai-turret.md
+++ b/docs/cameras/ubiquiti/ai-turret.md
@@ -1,0 +1,42 @@
+# Ubiquiti UniFi Protect AI Turret
+
+*Also known as: UVC-AI-Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect AI Turret |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (40m) |
+| Power | PoE+; 20W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK08 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- 4K UHD, 30 FPS max
+- adaptive IR up to 40m
+- Face Recognition
+- License Plate Recognition
+- AI event detection person/vehicle/animal
+- MicroSD card slot
+- IK08 tamper resistance
+- NDAA compliant
+- UniFi Protect ecosystem
+- two-way audio
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-ai-turret
+
+---
+*Auto-generated from ubiquiti-ai-turret.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/doorbell-lite.md
+++ b/docs/cameras/ubiquiti/doorbell-lite.md
@@ -1,0 +1,36 @@
+# Ubiquiti UniFi Protect Doorbell Lite
+
+*Also known as: UVC-Doorbell-Lite*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect Doorbell Lite |
+| Type | doorbell |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 1920×2560) |
+| Sensor | 1/2.7" 5MP |
+| Lens | 1× |
+| Field of view | 95.8 horizontal / 131.2 vertical / 175.9 diagonal° |
+| Night vision | ir (5m) |
+| Power | PoE; 8W max |
+| Protocols | rtsp |
+| IP rating | IPX5 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- 3:4 vertical aspect ratio for head-to-toe view
+- 24 FPS max
+- Smart Detections (person/vehicle/animal)
+- two-way audio
+- NDAA compliant
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-doorbell-lite
+
+---
+*Auto-generated from ubiquiti-doorbell-lite.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g5-ptz.md
+++ b/docs/cameras/ubiquiti/g5-ptz.md
@@ -1,0 +1,38 @@
+# Ubiquiti UniFi Protect G5 PTZ
+
+*Also known as: UVC-G5-PTZ*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G5 PTZ |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4MP (4MP, 2688×1512) |
+| Sensor | 1/2.7" 5MP CMOS |
+| Lens | 1× 3.42-6.85mm F1.85-F2.4 |
+| Field of view | 99.7 horizontal / 51.9 vertical / 121 diagonal (wide); 45.5 horizontal / 25.4 vertical / 52.4 diagonal (zoom)° |
+| Night vision | ir (20m) |
+| Power | PoE+; 14W max |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | No |
+| Operating temp | -30 to 45°C |
+
+## Features
+
+- 2x optical zoom
+- pan-tilt-zoom
+- 30 FPS max
+- built-in IR & white LED illumination
+- Smart Detections (person/vehicle/animal)
+- IK04 tamper resistance
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g5-ptz
+
+---
+*Auto-generated from ubiquiti-g5-ptz.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-180.md
+++ b/docs/cameras/ubiquiti/g6-180.md
@@ -1,0 +1,40 @@
+# Ubiquiti UniFi Protect G6 180
+
+*Also known as: UVC-G6-180*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 180 |
+| Type | panoramic |
+| Connectivity | ethernet |
+| Resolution | Dual 4K (3.5:1) (16MP, 7680×2160) |
+| Sensor | Dual 1/1.8" 8MP |
+| Lens | 2× |
+| Field of view | 180 horizontal / 56.7 vertical° |
+| Night vision | ir (20m) |
+| Power | PoE+; 15W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- 16MP dual-lens 180-degree panoramic, 20 FPS max
+- Face Recognition
+- License Plate Recognition
+- AI event detection person/vehicle/animal
+- MicroSD card slot
+- NDAA compliant
+- UniFi Protect ecosystem
+- two-way audio
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-180
+
+---
+*Auto-generated from ubiquiti-g6-180.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-bullet.md
+++ b/docs/cameras/ubiquiti/g6-bullet.md
@@ -1,0 +1,38 @@
+# Ubiquiti UniFi Protect G6 Bullet
+
+*Also known as: UVC-G6-Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Bullet |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (30m) |
+| Power | PoE; 9.9W max, 37-57V DC |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (people/vehicles/animals)
+- HDR
+- built-in mic
+- NDAA compliant
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-bullet
+
+---
+*Auto-generated from ubiquiti-g6-bullet.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-dome.md
+++ b/docs/cameras/ubiquiti/g6-dome.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect G6 Dome
+
+*Also known as: UVC-G6-Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Dome |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (30m) |
+| Power | PoE; 9.25W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- 4K, 30 FPS max
+- adaptive IR illumination up to 30m
+- face recognition
+- license plate recognition
+- AI smart detections person/vehicle/animal
+- IK10 vandal resistance
+- NDAA compliant
+- UniFi Protect ecosystem
+- built-in mic
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-dome
+
+---
+*Auto-generated from ubiquiti-g6-dome.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-edge-bullet.md
+++ b/docs/cameras/ubiquiti/g6-edge-bullet.md
@@ -1,0 +1,39 @@
+# Ubiquiti UniFi Protect G6 Edge Bullet
+
+*Also known as: UVC-G6-Edge-Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Edge Bullet |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.9-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (60m) |
+| Power | PoE+; 25W max, 42.5-57V DC |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (people/vehicles/animals)
+- 2.36x optical zoom
+- HDR
+- two-way audio
+- MicroSD card slot
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-bullet
+
+---
+*Auto-generated from ubiquiti-g6-edge-bullet.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-edge-dome.md
+++ b/docs/cameras/ubiquiti/g6-edge-dome.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect G6 Edge Dome
+
+*Also known as: UVC-G6-Edge-Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Edge Dome |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.9-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (40m) |
+| Power | PoE+; 15W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- 4K UHD, 30 FPS max
+- 2.36x optical zoom
+- adaptive IR up to 40m
+- Face Recognition
+- License Plate Recognition
+- AI event detection person/vehicle/animal
+- IK10 impact resistance
+- UniFi Protect ecosystem
+- built-in mic
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-dome
+
+---
+*Auto-generated from ubiquiti-g6-edge-dome.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-edge-turret.md
+++ b/docs/cameras/ubiquiti/g6-edge-turret.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect G6 Edge Turret
+
+*Also known as: UVC-G6-Edge-Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Edge Turret |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.85-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (40m) |
+| Power | PoE+; 25W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- 4K, 30 FPS max
+- 2.36x optical zoom
+- adaptive IR illumination up to 40m
+- face recognition
+- license plate recognition
+- AI smart detections person/vehicle/animal
+- microSD card slot
+- two-way audio
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-edge-turret
+
+---
+*Auto-generated from ubiquiti-g6-edge-turret.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-ins.md
+++ b/docs/cameras/ubiquiti/g6-ins.md
@@ -1,0 +1,40 @@
+# Ubiquiti UniFi Protect G6 Instant
+
+*Also known as: UVC-G6-Ins*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Instant |
+| Type | dome |
+| Connectivity | ethernet, wifi |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (6m) |
+| Power | 5V/2A USB power adapter (included) or PoE-to-USB-C adapter (not included); 7W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IPX5 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 40°C |
+
+## Features
+
+- compact indoor camera with WiFi and Bluetooth
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (person/vehicle/animal)
+- HDR
+- two-way audio
+- microSD storage
+- UniFi Protect ecosystem
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-ins
+
+---
+*Auto-generated from ubiquiti-g6-ins.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-mini-dome.md
+++ b/docs/cameras/ubiquiti/g6-mini-dome.md
@@ -1,0 +1,39 @@
+# Ubiquiti UniFi Protect G6 Mini Dome
+
+*Also known as: UVC-G6-Mini-Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Mini Dome |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (20m) |
+| Power | PoE; 9W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IK rating | IK08 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 40°C |
+
+## Features
+
+- 4K UHD, 30 FPS max
+- Face Recognition
+- License Plate Recognition
+- AI event detection person/vehicle/animal
+- IK08 tamper resistance
+- NDAA compliant
+- UniFi Protect ecosystem
+- two-way audio
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-mini-dome
+
+---
+*Auto-generated from ubiquiti-g6-mini-dome.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-pro-360.md
+++ b/docs/cameras/ubiquiti/g6-pro-360.md
@@ -1,0 +1,40 @@
+# Ubiquiti UniFi Protect G6 Pro 360
+
+*Also known as: UVC-G6-Pro-360*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Pro 360 |
+| Type | fisheye |
+| Connectivity | ethernet |
+| Resolution | 12MP (1:1) (12MP, 3504×3504) |
+| Sensor | 1/1.6" 12MP |
+| Lens | 1× |
+| Field of view | 180 horizontal / 180 vertical / 180 diagonal° |
+| Night vision | ir (15m) |
+| Power | PoE+; 13.5W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- 12MP fisheye 360-degree, 24 FPS max
+- Smart IR with 4 controllable zones
+- AI event detection person/vehicle/animal
+- MicroSD card slot
+- IK10 impact resistance
+- NDAA compliant
+- UniFi Protect ecosystem
+- two-way audio
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-360
+
+---
+*Auto-generated from ubiquiti-g6-pro-360.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-pro-bullet.md
+++ b/docs/cameras/ubiquiti/g6-pro-bullet.md
@@ -1,0 +1,40 @@
+# Ubiquiti UniFi Protect G6 Pro Bullet
+
+*Also known as: UVC-G6-Pro-Bullet*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Pro Bullet |
+| Type | bullet |
+| Connectivity | ethernet |
+| Resolution | 4K (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.9-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (40m) |
+| Power | PoE+; 15W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (people/vehicles/animals)
+- 2.36x optical zoom
+- optional Vision Enhancer extends IR range from 40m up to 60m
+- two-way audio
+- MicroSD card slot
+- NDAA compliant
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-bullet
+
+---
+*Auto-generated from ubiquiti-g6-pro-bullet.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-pro-dome.md
+++ b/docs/cameras/ubiquiti/g6-pro-dome.md
@@ -1,0 +1,44 @@
+# Ubiquiti UniFi Protect G6 Pro Dome
+
+*Also known as: UVC-G6-Pro-Dome*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Pro Dome |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.9-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (40m) |
+| Power | PoE+; 15W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+| Operating temp | -20 to 50°C |
+
+## Features
+
+- 4K, 30 FPS max
+- 2.36x optical zoom
+- adaptive IR illumination up to 40m
+- face recognition
+- license plate recognition
+- AI smart detections person/vehicle/animal
+- HDR
+- microSD card slot
+- IK10 vandal resistance
+- NDAA compliant
+- UniFi Protect ecosystem
+- built-in mic
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-dome
+
+---
+*Auto-generated from ubiquiti-g6-pro-dome.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-pro-turret.md
+++ b/docs/cameras/ubiquiti/g6-pro-turret.md
@@ -1,0 +1,38 @@
+# Ubiquiti UniFi Protect G6 Pro Turret
+
+*Also known as: UVC-G6-Pro-Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Pro Turret |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K (8MP, 3840×2160) |
+| Sensor | 1/1.2" 8MP |
+| Lens | 1× 5.85-13.8mm F1.5-F2.9 |
+| Field of view | 113.8 horizontal / 61.9 vertical / 134 diagonal (wide); 45.5 horizontal / 25.8 vertical / 52 diagonal (tele)° |
+| Night vision | ir (40m) |
+| Power | PoE+; 15W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | Yes |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- Face Recognition
+- License Plate Recognition
+- Smart Detections (people/vehicles/animals)
+- 2.36x optical zoom
+- two-way audio
+- MicroSD card slot
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-pro-turret
+
+---
+*Auto-generated from ubiquiti-g6-pro-turret.json — do not edit by hand.*

--- a/docs/cameras/ubiquiti/g6-turret.md
+++ b/docs/cameras/ubiquiti/g6-turret.md
@@ -1,0 +1,41 @@
+# Ubiquiti UniFi Protect G6 Turret
+
+*Also known as: UVC-G6-Turret*
+
+| Field | Spec |
+|-------|------|
+| Brand | Ubiquiti |
+| Model | UniFi Protect G6 Turret |
+| Type | turret |
+| Connectivity | ethernet |
+| Resolution | 4K UHD (8MP, 3864×2160) |
+| Sensor | 1/1.8" 8MP |
+| Lens | 1× |
+| Field of view | 109.9 horizontal / 56.7 vertical / 134.1 diagonal° |
+| Night vision | ir (30m) |
+| Power | PoE; 12.5W max |
+| Storage | NVR |
+| Protocols | rtsp |
+| IP rating | IP66 |
+| IK rating | IK04 |
+| Two-way audio | No |
+| Operating temp | -30 to 50°C |
+
+## Features
+
+- 4K, 30 FPS max
+- adaptive IR illumination up to 30m
+- face recognition
+- license plate recognition
+- AI smart detections person/vehicle/animal
+- HDR
+- NDAA compliant
+- UniFi Protect ecosystem
+- built-in mic
+
+## Sources
+
+- https://techspecs.ui.com/unifi/physical-security/uvc-g6-turret
+
+---
+*Auto-generated from ubiquiti-g6-turret.json — do not edit by hand.*


### PR DESCRIPTION
## Dahua `ik_rating` backfill (#162) + UniFi Protect catalog expansion (#181)

Two pieces of work on one branch (as requested):

### 1. Dahua `ik_rating` (#162) — 112 → 129 (+17)
Datasheet-verified IK10 for the **17 vandal-rated Dahua models** found across the full 223-camera missing-IK set: WizMind HFW5442/7442/7842 bullets + HDW5442/5842TM-ASE eyeballs, ITC237 traffic cam, and the WizSense **`-AS/-ZAS/-ZS` varifocal bullets** (HFW22/24/2541/2831/2841/3841T-ZAS/-ZS, HFW3841TP-ZAS, HFW3866TP-ZAS) — IK10 per the established "IK10 (optional) → IK10" dataset convention.

**Key finding:** every other camera checked (HDW eyeballs, fixed-lens HFW bullets, SD/SDT/SD8 PTZ speed domes, PDW/PFW panoramic, X-Spans, analog HAC) is **IP-only with no IK** — confirmed against official datasheets and correctly left absent. Agents repeatedly caught and rejected false third-party "IK10" marketing claims against the official spec. **Dahua reserves IK ratings for its HDBW vandal domes (already covered) plus these select WizMind/WizSense-varifocal/traffic models — the lane is now saturated for Dahua.**

### 2. UniFi Protect catalog (#181) — Ubiquiti 25 → 46 (+21)
The current UniFi Protect lineup from techspecs.ui.com: the full **G6 series** (Bullet/Pro/Edge/Turret/Dome/Mini/180-panoramic/Pro-360-fisheye/Instant), new **AI models** (AI PTZ, PTZ Precision, LPR, Turret, MS-2 & MS-4 multi-sensor), G5/G6 PTZ, Doorbell Lite. Skipped `up-chime-us`/`uacc-chime-poe` (chime accessories, not cameras) and models already present.

Camera count 2,776 → **2,797**. CI: build clean, 0 drift, schema-valid, no resolution mismatches.
