### PR TITLE
docs: fix stale '72 brands' in README intro (build-managed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCTV Camera Database
 
-An open, structured database of 2,884 CCTV / IP camera models and their technical specifications, covering 72 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,884 CCTV / IP camera models and their technical specifications, covering 74 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
 [![cameras](https://img.shields.io/badge/cameras-2%2C884-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-74-green)](cameras/)

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -348,6 +348,7 @@ function updateReadme(cameras) {
     .replace(/### All \d+ brands/, `### All ${brandCount} brands`)
     // Prose counts that would otherwise drift (intro line, demo-GIF alt, pagination).
     .replace(/(database of )[\d,]+( CCTV \/ IP camera models)/, `$1${total}$2`)
+    .replace(/(covering )\d+( brands across)/, `$1${brandCount}$2`)
     .replace(/(inspect )[\d,]+( cameras across )\d+( brands)/, `$1${total}$2${brandCount}$3`)
     .replace(/(page through all )[\d,]+( cameras)/, `$1${total}$2`);
 


### PR DESCRIPTION
The README intro said '72 brands' while the badge/table/heading said 74. `build.js` auto-patches most prose counts but missed `covering N brands` — added that replacement so it's build-managed and stays in sync. Now all four brand-count mentions read 74.