### PR TITLE
docs: refresh README stats (build-managed) + changelog the CI tooling (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [1.58.1] — 2026-08-07
 
+### Added — data-quality CI (#229, #235)
+- **Consistency-lint PR gate** (`scripts/lint-data.js`, `npm run lint`) — cross-field invariants a JSON Schema can't express (environment↔IP weatherproofing, `ip_rating` shape, `weight_g` sanity, ISO `last_verified`, canonical formatting, FOV normalisation), wired into the `build` workflow so PRs fail on violations.
+- **Auto coverage report** (`scripts/coverage-report.js` → `COVERAGE.md` + README badges), regenerated on every push to `main`.
+- **Wayback source archiving** (`scripts/archive-sources.js` + `archive-sources.yml`) — preserves each camera's `sources[]` against manufacturer link-rot.
+- **Monthly `last_verified` staleness sweep** (`scripts/check-staleness.js` + `check-staleness.yml`), companion to the weekly dead-link sweep (#222).
+- All documented in [`docs/ci.md`](docs/ci.md).
+
 ### Changed
 - **Canonicalised JSON formatting across the dataset (#230).** Reformatted 109 camera files to canonical 2-space indent + trailing newline via `npm run lint -- --fix`. No spec values changed (the generated `data/` aggregate is byte-identical) — purely whitespace, to keep future diffs clean.
 - **Normalised `field_of_view_deg` (#231).** Stripped the `°` symbol from 62 values (Bosch/Dahua/Luma/Tapo/VIGI), preserving descriptive wording (thermal, tele/wide, per-focal).

--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | Total cameras | **2,884** |
 | Brands | **74** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
-| PoE wired | 1,669 |
-| WiFi | 544 |
-| Battery / wire-free | 190 |
-| 4K / 8MP+ | 639 |
-| 4–5MP | 885 |
-| 1080p–2MP | 588 |
-| With integration configs (Frigate / Home Assistant) | 1,912 |
-| With color-lux rating (`night_vision.min_lux_color`) | 516 |
+| PoE wired | 2,105 |
+| WiFi | 596 |
+| Battery / wire-free | 203 |
+| 4K / 8MP+ | 797 |
+| 4–5MP | 1,204 |
+| 1080p–2MP | 882 |
+| With integration configs (Frigate / Home Assistant) | 2,409 |
+| With color-lux rating (`night_vision.min_lux_color`) | 1,353 |
 
 ### All 74 brands
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -352,6 +352,31 @@ function updateReadme(cameras) {
     .replace(/(inspect )[\d,]+( cameras across )\d+( brands)/, `$1${total}$2${brandCount}$3`)
     .replace(/(page through all )[\d,]+( cameras)/, `$1${total}$2`);
 
+  // "By the numbers" stat rows — computed from the dataset so they never drift
+  // (previously hand-written and went stale, e.g. the color-lux count).
+  const n = (f) => cameras.filter(f).length.toLocaleString("en-US");
+  const psHas = (k) => (x) => x.power_source && x.power_source.includes(k);
+  const mpOf = (x) => (x.resolution && x.resolution.megapixels) || 0;
+  const stats = {
+    poe: n((x) => psHas("poe")(x)),
+    wifi: n((x) => x.connectivity && x.connectivity.includes("wifi")),
+    batt: n((x) => psHas("battery")(x)),
+    uhd: n((x) => mpOf(x) >= 8),
+    mid: n((x) => mpOf(x) >= 4 && mpOf(x) < 8),
+    fhd: n((x) => mpOf(x) > 0 && mpOf(x) < 4),
+    cfg: n((x) => x.configs && (x.configs.frigate || x.configs.home_assistant)),
+    clux: n((x) => x.night_vision && x.night_vision.min_lux_color != null),
+  };
+  readme = readme
+    .replace(/(\| PoE wired \| )[\d,]+( \|)/, `$1${stats.poe}$2`)
+    .replace(/(\| WiFi \| )[\d,]+( \|)/, `$1${stats.wifi}$2`)
+    .replace(/(\| Battery \/ wire-free \| )[\d,]+( \|)/, `$1${stats.batt}$2`)
+    .replace(/(\| 4K \/ 8MP\+ \| )[\d,]+( \|)/, `$1${stats.uhd}$2`)
+    .replace(/(\| 4–5MP \| )[\d,]+( \|)/, `$1${stats.mid}$2`)
+    .replace(/(\| 1080p–2MP \| )[\d,]+( \|)/, `$1${stats.fhd}$2`)
+    .replace(/(\| With integration configs \(Frigate \/ Home Assistant\) \| )[\d,]+( \|)/, `$1${stats.cfg}$2`)
+    .replace(/(\| With color-lux rating \(`night_vision\.min_lux_color`\) \| )[\d,]+( \|)/, `$1${stats.clux}$2`);
+
   // "All brands" table (between brands-table markers): auto-refresh the Cameras
   // column and re-sort by count, but PRESERVE the hand-written display name and
   // Segment text (parsed back from the current table, keyed by brand field).


### PR DESCRIPTION
Two doc gaps fixed:

1. **README 'By the numbers' was stale** — never refreshed through the backfills (color-lux said **516**, actually **1,353**; configs 1,912 → 2,409, etc.). Now **build-managed** in `build.js` (like the brand/camera counts) so it can't drift again.
2. **The CI tooling (#229) had no CHANGELOG entry** — it merged at 1.58.0 without one. Added an *Added — data-quality CI* section under 1.58.1 (lint gate, coverage report, Wayback archiver, staleness sweep).

Build 0-drift, lint green.