### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: ch-bas


### PR DESCRIPTION
Adds `.github/FUNDING.yml` (`github: ch-bas`) so GitHub shows the **Sponsor** button on this repo, linked to the ch-bas Sponsors profile (Sponsors listing is live).

No code/data change.