### PR TITLE
chore: regenerate aggregate — restore 'added' dates on Amcrest + i-PRO

### DIFF
--- a/data/cameras.json
+++ b/data/cameras.json
@@ -41923,7 +41923,8 @@
     },
     "ptz": {
       "autotracking": true
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip4m-1041w",
@@ -42251,7 +42252,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses the Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip5m-b1186ew",
@@ -42460,7 +42462,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile (Amcrest uses the Dahua protocol). Also works via ONVIF/RTSP."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip5m-t1179e",
@@ -42936,7 +42939,8 @@
         "profile": "Dahua",
         "notes": "Add as a Dahua-protocol camera (Amcrest is Dahua OEM); the 'Amcrest' make also works where available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-2496e",
@@ -43143,7 +43147,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-2693ew",
@@ -43554,7 +43559,8 @@
         "profile": "Dahua",
         "notes": "Add as a Dahua-protocol camera (Amcrest is Dahua OEM); PTZ supported over the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-fct2999ew-ai",
@@ -43670,7 +43676,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-t2599ew",
@@ -43874,7 +43881,8 @@
         "profile": "Dahua",
         "notes": "Add using the Dahua profile (Amcrest is Dahua OEM); RTSP main subtype=0, sub subtype=1."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-vt2779ew",
@@ -43983,7 +43991,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses the Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-vt2879ew-ai",
@@ -199995,7 +200004,8 @@
         "notes": "Use ONVIF profile. i-PRO is the successor to Panasonic security cameras (also selectable as 'Panasonic')."
       }
     },
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s15700-v2ln",
@@ -200122,7 +200132,8 @@
       "https://i-pro.com/products_and_solutions/sites/default/files/2024-01/WV-S15700-V2LN%20_%20i-PRO%20Global_R4_240123.pdf",
       "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s15700-v2ln"
     ],
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s2236l",
@@ -200356,7 +200367,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s25500-v3l",
@@ -200490,7 +200502,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s25700-v2l",
@@ -200623,7 +200636,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s6532ln",
@@ -200765,7 +200779,8 @@
         "notes": "Use ONVIF profile. i-PRO is the successor to Panasonic security cameras (also selectable as 'Panasonic')."
       }
     },
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -201007,7 +201022,8 @@
         "notes": "Add via ONVIF (or Panasonic profile - i-PRO is the successor to Panasonic security cameras). Configure each of the 4 sensor channels as a separate camera."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-u2532la",
@@ -201138,7 +201154,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x22300-v3l",
@@ -201264,7 +201281,8 @@
         "profile": "ONVIF",
         "notes": "Use the ONVIF profile (or i-PRO/Panasonic); RTSP path /Src/MediaInput/stream_1."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x2251l",
@@ -201489,7 +201507,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras. Successor model: WV-S25700-V2LN."
       }
     },
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x86531-z2",
@@ -201630,7 +201649,8 @@
         "notes": "Use the generic ONVIF profile; add the 4 fixed sensor channels and the PTZ channel individually. Camera exposes 2 IP addresses."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "idis-dc-d4516wrx",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -41923,7 +41923,8 @@
     },
     "ptz": {
       "autotracking": true
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip4m-1041w",
@@ -42251,7 +42252,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses the Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip5m-b1186ew",
@@ -42460,7 +42462,8 @@
         "profile": "Dahua",
         "notes": "Select the 'Dahua' profile (Amcrest uses the Dahua protocol). Also works via ONVIF/RTSP."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip5m-t1179e",
@@ -42936,7 +42939,8 @@
         "profile": "Dahua",
         "notes": "Add as a Dahua-protocol camera (Amcrest is Dahua OEM); the 'Amcrest' make also works where available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-2496e",
@@ -43143,7 +43147,8 @@
     },
     "environment": [
       "outdoor"
-    ]
+    ],
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-2693ew",
@@ -43554,7 +43559,8 @@
         "profile": "Dahua",
         "notes": "Add as a Dahua-protocol camera (Amcrest is Dahua OEM); PTZ supported over the Dahua protocol."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-fct2999ew-ai",
@@ -43670,7 +43676,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-t2599ew",
@@ -43874,7 +43881,8 @@
         "profile": "Dahua",
         "notes": "Add using the Dahua profile (Amcrest is Dahua OEM); RTSP main subtype=0, sub subtype=1."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-vt2779ew",
@@ -43983,7 +43991,8 @@
         "profile": "Dahua",
         "notes": "Select 'Dahua' profile. Amcrest uses the Dahua protocol. Also works with 'Amcrest' profile if available."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "amcrest-ip8m-vt2879ew-ai",
@@ -199995,7 +200004,8 @@
         "notes": "Use ONVIF profile. i-PRO is the successor to Panasonic security cameras (also selectable as 'Panasonic')."
       }
     },
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s15700-v2ln",
@@ -200122,7 +200132,8 @@
       "https://i-pro.com/products_and_solutions/sites/default/files/2024-01/WV-S15700-V2LN%20_%20i-PRO%20Global_R4_240123.pdf",
       "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s15700-v2ln"
     ],
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s2236l",
@@ -200356,7 +200367,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s25500-v3l",
@@ -200490,7 +200502,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s25700-v2l",
@@ -200623,7 +200636,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s6532ln",
@@ -200765,7 +200779,8 @@
         "notes": "Use ONVIF profile. i-PRO is the successor to Panasonic security cameras (also selectable as 'Panasonic')."
       }
     },
-    "last_verified": "2026-08-13"
+    "last_verified": "2026-08-13",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -201007,7 +201022,8 @@
         "notes": "Add via ONVIF (or Panasonic profile - i-PRO is the successor to Panasonic security cameras). Configure each of the 4 sensor channels as a separate camera."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-u2532la",
@@ -201138,7 +201154,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x22300-v3l",
@@ -201264,7 +201281,8 @@
         "profile": "ONVIF",
         "notes": "Use the ONVIF profile (or i-PRO/Panasonic); RTSP path /Src/MediaInput/stream_1."
       }
-    }
+    },
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x2251l",
@@ -201489,7 +201507,8 @@
         "notes": "Use the ONVIF profile. i-PRO is the successor to Panasonic security cameras. Successor model: WV-S25700-V2LN."
       }
     },
-    "status": "discontinued"
+    "status": "discontinued",
+    "added": "2026-08-13"
   },
   {
     "id": "i-pro-wv-x86531-z2",
@@ -201630,7 +201649,8 @@
         "notes": "Use the generic ONVIF profile; add the 4 fixed sensor channels and the PTZ channel individually. Camera exposes 2 IP addresses."
       }
     },
-    "status": "available"
+    "status": "available",
+    "added": "2026-08-13"
   },
   {
     "id": "idis-dc-d4516wrx",


### PR DESCRIPTION
The stacked #252→#253→#254 merges left the generated aggregate (`data/cameras.json`, `docs/cameras.json`) without git-derived `added` provenance dates on the 20 newly-merged Amcrest + i-PRO cameras — a build-timing side-effect of the merge sequence — so they didn't appear in the RSS feed / "recently added" page. This rebuilds the aggregate from source: all **2,930** records now carry `added`. No source camera data changed.