### PR TITLE
fix: canonicalize gsc3620.json (CI lint gate)

### DIFF
--- a/cameras/grandstream/gsc3620.json
+++ b/cameras/grandstream/gsc3620.json
@@ -86,11 +86,21 @@
   ],
   "configs": {
     "frigate": {
-      "detect": { "width": 1280, "height": 720, "fps": 5 },
+      "detect": {
+        "width": 1280,
+        "height": 720,
+        "fps": 5
+      },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/0",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/4"
     },
-    "home_assistant": { "integration": "onvif", "notes": "Use ONVIF integration." },
-    "blue_iris": { "profile": "ONVIF", "notes": "Select 'ONVIF' profile. ONVIF Profile S supported." }
+    "home_assistant": {
+      "integration": "onvif",
+      "notes": "Use ONVIF integration."
+    },
+    "blue_iris": {
+      "profile": "ONVIF",
+      "notes": "Select 'ONVIF' profile. ONVIF Profile S supported."
+    }
   }
 }


### PR DESCRIPTION
The GSC3620 build agent wrote `cameras/grandstream/gsc3620.json` in non-canonical form, which the `npm run build` AJV gate didn't catch but the CI **Lint data consistency** step (E5 canonical 2-space JSON) does. Reformatted via `npm run lint -- --fix` — content unchanged, aggregate unaffected. Both `build` and `lint` now green locally.