### PR TITLE
data: RTSP patterns wave 2 — 20 more brands verified

### DIFF
--- a/data/rtsp-patterns.json
+++ b/data/rtsp-patterns.json
@@ -6,10 +6,10 @@
     "methodology": "StrixCamDB is used ONLY as a lead source; every path here is independently re-verified against the manufacturer's official docs (manual / API / KB), so each record is independently sourced and CC0-clean, with Strix credited as the discovery source (strix_lead). Leads that could not be confirmed officially are recorded under unverified_leads and never published as fact.",
     "generated": "2026-08-14",
     "totals": {
-      "brands": 122,
-      "verified": 91,
-      "unverified": 31,
-      "templates": 290
+      "brands": 142,
+      "verified": 101,
+      "unverified": 41,
+      "templates": 312
     }
   },
   "brands": [
@@ -1776,6 +1776,32 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Camius",
+      "brand_id": "camius",
+      "status": "verified",
+      "default_port": 80,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/rtsp/streaming?channel=<N>&subtype=0",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "RTSP Streaming Setup Guide for NVR, DVR and IP Cameras — https://www.camius.com/rtsp-ip-camera-camius/",
+          "strix_lead": "manual:camius"
+        },
+        {
+          "stream": "sub",
+          "path": "/rtsp/streaming?channel=<N>&subtype=1",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "RTSP Streaming Setup Guide for NVR, DVR and IP Cameras — https://www.camius.com/rtsp-ip-camera-camius/",
+          "strix_lead": "manual:camius"
+        }
+      ],
+      "notes": "Camius NVRs and DVRs use the path /rtsp/streaming?channel=<N>&subtype=0 (main) or subtype=1 (sub). Default RTSP port is 80 for firmware V8.2.4.1+; earlier firmware defaults to port 554. Port is configurable via Network >> General >> Port Configuration. Authentication uses admin credentials. Camius appears to be a US-based brand selling their own NVR/DVR systems; no confirmed OEM relationship identified from official docs.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "Canon",
       "brand_id": "canon",
       "status": "verified",
@@ -1873,6 +1899,32 @@
         }
       ],
       "notes": "Two documented URL families across the CIVS IP camera line. (1) Older CIVS-IPC-2500/2900/4300-era cameras use the .sav/.sdp endpoints: /img/media.sav (video+audio, also /img/media.sdp), /img/video.sav (video only), /img/audio.sav (audio only) for the primary stream, and /<code> for the configurable secondary stream. (2) Newer 8000-series (8020/8030/8000P/8070/8400/8620/8630/8930) cameras use a user-defined 'access name for stream 1 to 4', default live.sdp / live2.sdp, per the reference guides. Default RTSP port 554 on both. Cisco discontinued the CIVS line (sold to Verkada); current Cisco Meraki MV cameras are cloud-managed and do NOT expose RTSP. Cisco.com reference-guide HTML/PDF pages return HTTP 403 to automated fetchers; paths confirmed via the official CIVS-IPC-2500 user guide (OL-19273-02) third-party-viewing section and the 8000-series reference-guide RTSP configuration sections.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "ClareVision",
+      "brand_id": "clarevision",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/0",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "ClareVision Camera and NVR RTSP Stream URLs — https://www.clarecontrols.com/helpcenter/clarevision-camera-nvr-rtsp-stream-urls",
+          "strix_lead": "manual:clarevision"
+        },
+        {
+          "stream": "sub",
+          "path": "/1",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "ClareVision Camera and NVR RTSP Stream URLs — https://www.clarecontrols.com/helpcenter/clarevision-camera-nvr-rtsp-stream-urls",
+          "strix_lead": "manual:clarevision"
+        }
+      ],
+      "notes": "ClareVision is a Hikvision OEM by Clare Controls (SnapAV). Despite the Hikvision OEM relationship, ClareVision cameras use simple zero-indexed numeric RTSP paths (/0, /1, /2) rather than Hikvision's /Streaming/Channels/101 format. Main stream = /0, 2nd stream = /1, 3rd stream = /2. V100 cameras support only 2 streams; V200 and V300 support 3 streams. Port 554. Full URL: rtsp://{user}:{pass}@{ip}:554/0",
       "verified_on": "2026-08-14"
     },
     {
@@ -2024,6 +2076,33 @@
         }
       ],
       "notes": "CP Plus (cpplusworld.com / cpplus.in) is a major Indian security brand and confirmed Dahua OEM. The /cam/realmonitor path with channel and subtype query parameters is explicitly documented in CP Plus's own published Network Camera User Manual (v1.0.1) hosted at cpplusworld.com. Default RTSP port is 554. Channel index is 1-based. subtype=0 = main/primary stream, subtype=1 = sub/secondary stream. The NVR Orange Series manual (cpplusworld.com/orange-series/img/User_Manual_NVR.pdf) documents the same RTSP port default (554) but does not spell out a stream URL path — path is confirmed via the camera-side manual. Several leads (/live/av0, VideoInput/1/mpeg4/1, /live/channel0, /live/channel1) are cross-contaminated from other brands and have no basis in CP Plus official documentation.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Ctronics",
+      "brand_id": "ctronics",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/11",
+          "note": "Community-reported main stream path (GitHub Home Assistant issue #593, iSpy aggregator). Consistent with XM/Xiongmai-based camera firmware used by HiP2P ecosystem brands."
+        },
+        {
+          "path": "/12",
+          "note": "Community-reported sub stream path for XM/HiP2P-based cameras."
+        },
+        {
+          "path": "/ch01.264",
+          "note": "Alternative path reported in Amazon Q&A and third-party aggregators; not confirmed in official Ctronics documentation."
+        },
+        {
+          "path": "/ch01_sub.264",
+          "note": "Alternative sub-stream path reported alongside /ch01.264 in community sources."
+        }
+      ],
+      "notes": "Ctronics (ctronics.com / ctronics.co.uk) is a budget IP camera brand popular in the EU. Their cameras use HiP2P client software and the Cloudedge/Ctronics mobile app, strongly indicating an XM (Xiongmai) OEM relationship. However, no official Ctronics documentation — neither their website, ManualsLib manuals (CTIPC Series, CTIPC-260CWS, Pro CTIPC), nor the Download Center — explicitly documents an RTSP URL path. All manuals focus on mobile app setup, HiP2P software, and web browser access. RTSP paths (/11 for main, /12 for sub) are community-reported and consistent with XM/HiP2P firmware but cannot be attributed to official Ctronics sources.",
       "verified_on": "2026-08-14"
     },
     {
@@ -2518,6 +2597,16 @@
         }
       ],
       "notes": "EasyN (Shenzhen EasyN Technology Co., Ltd) makes budget Wi-Fi/PoE IP cameras that are set up almost exclusively through EasyN's own web interface (built-in web server, typically HTTP port 81) and mobile/CMS apps. Reviewed EasyN's own FCC-filed user manuals (FCC IDs ZNXEASYNCAM5V, ZNXEASYNCAM12V, ZNXEASYN137P, ZNXPSD137 — all Shenzhen EasyN Technology): none document any RTSP URL, RTSP path, RTSP port, or ONVIF stream address. Manuals describe main/second (sub) dual-stream access only through EasyN's proprietary app/CMS and HTTP browser access (e.g. http://ip:81), never a fixed rtsp:// template. Every RTSP path circulating for EasyN (rtsp://...:554/11, /h264, etc.) originates from crowd-sourced third-party databases (iSpyConnect lists ~166 models, Camlytics, GeniusVision, ZoneMinder wiki), not from EasyN. The leads are also cross-brand contaminated (e.g. Hikvision /Streaming/Channels/1). Because no official EasyN documentation publishes a fixed RTSP path, no template is published; recommended integration in practice is ONVIF auto-discovery. Confirmation would require a specific EasyN model's own manual/API doc — not aggregator DBs.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "EBITCAM",
+      "brand_id": "ebitcam",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [],
+      "notes": "EBITCAM cameras are cloud-only devices operated through the proprietary Ebitcam app (ebitcam.net). Official manuals (EB01 Series on ManualsLib, E2 720P on manuals.plus) make no mention of RTSP paths, ONVIF support, or any local streaming protocol. The manufacturer's website (ebitcam.com) appears to be a parked/empty domain; the actual app platform is ebitcam.net. User reports confirm cloud-dependent access with no RTSP documentation published by the manufacturer.",
       "verified_on": "2026-08-14"
     },
     {
@@ -3215,6 +3304,21 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Galayou",
+      "brand_id": "galayou",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/live/ch0",
+          "note": "Community-reported path associated with Wansview-platform cameras (Galayou uses Wansview Cloud), not in any official Galayou documentation"
+        }
+      ],
+      "notes": "Galayou cameras (galayou-store.com) support RTSP/ONVIF but do not publish a static RTSP URL path in any official documentation. Their official support instructs users to enable RTSP via the Wansview Cloud app under Settings > Local Application, where the RTSP URL is displayed dynamically — the path is never disclosed in writing. The Wansview Cloud platform is the underlying infrastructure (Galayou uses the same 'Wansview Cloud' app). No official Galayou or Wansview manual, KB article, or developer guide publishes the RTSP path template. CVE-2025-9983 (CERT Polska, 2025-09) confirms these cameras stream via RTSP on default port 554 but does not reveal the path.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "GeoVision",
       "brand_id": "geovision",
       "status": "verified",
@@ -3284,6 +3388,32 @@
         }
       ],
       "notes": "GeoVision (geovision.com.tw, Taiwan) cameras expose RTSP at rtsp://<ip>:8554/<CHN>.sdp where N is a 1-based, 3-digit zero-padded channel number (CH001, CH002, …). On a standalone IP camera CH001.sdp is the single stream; on a GeoVision NVR each numeric channel maps to a connected camera input. Official manuals do not document a separate sub-stream path via this scheme — the GeoVision web UI controls stream resolution/quality, not a distinct RTSP path. Default RTSP/TCP port is 8554 across the BX/EBD/FD/ABL series (not the standard 554), though some newer H.265 models (e.g. GV-EBD4700) revert to port 554 per their own appendix. GeoVision is an independent Taiwanese OEM; the SDP-based RTSP scheme is proprietary and unrelated to Dahua/Hikvision patterns.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Grandstream",
+      "brand_id": "grandstream",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/0",
+          "codec": "H.264",
+          "verified": true,
+          "source": "Grandstream Networks GSC361X Series User Manual (page 31, RTSP Steam Display Using VLC) — https://www.manualslib.com/manual/1833129/Grandstream-Networks-Gsc361x-Series.html?page=31",
+          "strix_lead": "manual:grandstream"
+        },
+        {
+          "stream": "sub",
+          "path": "/4",
+          "codec": "H.264",
+          "verified": true,
+          "source": "Grandstream Networks GSC3620 User Manual (page 31, RTSP Steam Display Using VLC) — https://www.manualslib.com/manual/2181549/Grandstream-Networks-Gsc3620.html?page=31",
+          "strix_lead": "manual:grandstream"
+        }
+      ],
+      "notes": "Official Grandstream manuals (GSC361X, GSC3620, GXV36xx series) document RTSP URL format as rtsp://{user}:{pass}@{ip}:{port}/X where X=0 for the 1st (main) stream and X=4 for the 2nd (sub) stream. Default RTSP port is 554 when the HTTP web port is 80; if HTTP port is changed to a non-80 value (e.g. 88), the RTSP port becomes HTTP_port + 2000 (e.g. 2088). This unusual /0 and /4 path scheme is Grandstream-specific and applies to both the GSC36xx indoor/outdoor camera series and the older GXV36xx IP camera series. Streams use H.264 per the manual; GSC36xx models also support H.265 on newer firmware. Codec field reflects H.264 as confirmed in manuals for RTSP; H.265 support not explicitly documented for the RTSP path in reviewed sources.",
       "verified_on": "2026-08-14"
     },
     {
@@ -3832,6 +3962,32 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "HiLook",
+      "brand_id": "hilook",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/Streaming/Channels/<N>01",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Hikvision Support KB (covers HiLook as Hikvision sub-brand) — 'Do you have an example showing the format for getting a RTSP stream from a camera?' https://supportusa.hikvision.com/support/solutions/articles/17000129022-do-you-have-an-example-showing-the-format-for-getting-a-rtsp-stream-from-a-camera-",
+          "strix_lead": "manual:hilook"
+        },
+        {
+          "stream": "sub",
+          "path": "/Streaming/Channels/<N>02",
+          "codec": "H.264|H.265|MJPEG",
+          "verified": true,
+          "source": "Hikvision Support KB (covers HiLook as Hikvision sub-brand) — 'Do you have an example showing the format for getting a RTSP stream from a camera?' https://supportusa.hikvision.com/support/solutions/articles/17000129022-do-you-have-an-example-showing-the-format-for-getting-a-rtsp-stream-from-a-camera-",
+          "strix_lead": "manual:hilook"
+        }
+      ],
+      "notes": "HiLook is Hikvision's budget sub-brand (confirmed by hilooksecurity.com footer: '© 2026 Hangzhou Hikvision Digital Technology Co., Ltd. All Rights Reserved.'). HiLook IP cameras run Hikvision firmware and use identical RTSP path structure. Channel ID formula: (channel_number × 100) + stream_type, where stream_type 1=main, 2=sub. For a single-channel IP camera: /Streaming/Channels/101 (main), /Streaming/Channels/102 (sub). HiLook Network Camera User Manual (UD22027B-E, hosted on assets.hikvision.com) confirms RTSP port configuration and RTSP authentication settings, consistent with Hikvision ISAPI. The /ISAPI/Streaming/channels/<N>01 variant also works per Hikvision ISAPI Developer Guide. hilookvision.com is a parked/for-sale domain — the real official site is hilooksecurity.com (EU) operated by Hikvision.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "Hiseeu",
       "brand_id": "hiseeu",
       "status": "verified",
@@ -4227,6 +4383,32 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "ieGeek",
+      "brand_id": "iegeek",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/11",
+          "codec": "H.264",
+          "verified": true,
+          "source": "ieGeek IE20 Outdoor Dome Camera User Manual (official PDF hosted on support.iegeek.com), FAQ Q16: 'Your RTSP port of main stream is rtsp://192.168.1.38:554/11 and RTSP port of secondary stream rtsp://192.168.1.38:554/12.' — https://support.iegeek.com/cdn/shop/files/ieGeek_IG20_IG62_IG80_IG82_IG90_-_User_Manual___74.pdf",
+          "strix_lead": "manual:iegeek"
+        },
+        {
+          "stream": "sub",
+          "path": "/12",
+          "codec": "H.264",
+          "verified": true,
+          "source": "ieGeek IE20 Outdoor Dome Camera User Manual (official PDF hosted on support.iegeek.com), FAQ Q16: secondary stream path /12. Same source as main stream entry. — https://support.iegeek.com/cdn/shop/files/ieGeek_IG20_IG62_IG80_IG82_IG90_-_User_Manual___74.pdf",
+          "strix_lead": "manual:iegeek"
+        }
+      ],
+      "notes": "ieGeek's official RTSP URL format uses numeric shorthand paths: /11 = main stream (channel 1, stream 1), /12 = sub stream (channel 1, stream 2). These are consumer WiFi cameras with a single channel so no channel placeholder is needed — paths are fixed. RTSP port is 554; ONVIF port is 8080. Confirmed in multiple ieGeek official user manuals (IE20, IG20/IG62/IG80/IG82/IG90 series) available on support.iegeek.com. Credentials are passed as standard URL authentication (rtsp://user:pass@ip:554/11), not embedded in the path. Many ieGeek models (including battery/solar variants) are app/cloud-only and do NOT support RTSP — the /11 and /12 paths apply to wired-network and WiFi IP camera models only.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "IMOU",
       "brand_id": "imou",
       "status": "unverified",
@@ -4551,6 +4733,21 @@
         }
       ],
       "notes": "Interlogix (GE Security lineage; UTC / Carrier Fire & Security) — the TruVision IP camera and NVR line is Hikvision OEM and runs the Hikvision platform. The official Interlogix TruVision configuration manuals (FW 4.X.X, FW 5.0X/TVD-1106, M Series, ANPR, 81 Series, 360°) confirm the Hikvision RTSP stack: RTSP default port 554, RTSP Authentication (digest/basic, MD5/SHA256) at Configuration > Security > RTSP Authentication, and main/sub/third stream configuration — i.e. the standard Hikvision resource path /Streaming/Channels/<ch><stream> (101 main, 102 sub, 103 third). No official Interlogix document prints a literal rtsp:// example URL, so the concrete paths are published on confirmed Hikvision-OEM/platform basis (same convention as other Hikvision-OEM brands like Advidia A-series and American Dynamics), and match the dominant StrixCamDB leads (/Streaming/Channels/1, /Streaming/Channels/2). HTTP MJPEG preview is available at http://IP/Streaming/channels/101/httpPreview (Hikvision form) where enabled. The legacy leads /h264_stream, /ch0_0.h264, /video.h264 likely belong to older pre-Hikvision GE Security / UltraView / TVIP firmware — none could be confirmed against an official Interlogix document and are recorded under unverified_leads rather than published. ONVIF is supported on TruVision IP cameras for auto-discovery (RTSP URI via GetStreamUri) as an alternative to the fixed path.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "IPC360",
+      "brand_id": "ipc360",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/live/ch0",
+          "note": "Community-reported on port 554 with admin/123456 credentials after enabling ONVIF in the app — not found in any official IPC360 documentation"
+        }
+      ],
+      "notes": "IPC360 (ipc360.info / ipc360.org) is a consumer Wi-Fi camera brand that operates as a cloud/P2P-first system. Their official FAQ explicitly states video is transported via UDP and server connections via TCP, reflecting a cloud relay architecture. Neither the official FAQ (ipc360.info/Index/Idx_faq) nor the User's Manual page (ipc360.info/Index/Idx_manual) contains any mention of RTSP, ONVIF, or local stream URLs. No developer documentation or RTSP path is published by the manufacturer. Community sources report that some models expose RTSP on port 554 at /live/ch0 after enabling ONVIF in the IPC360 Pro app, but this is unconfirmed by official documentation and varies by model/firmware.",
       "verified_on": "2026-08-14"
     },
     {
@@ -4995,6 +5192,16 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Kasa",
+      "brand_id": "kasa",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [],
+      "notes": "Kasa cameras (TP-Link Kasa Smart line, e.g. KC110, KC400, KC401) are cloud-only and do not support RTSP or ONVIF. TP-Link's official FAQ explicitly states: 'Kasa Cameras do not support RTSP/ONVIF, so viewing a camera's stream on a computer is not possible.' This is a deliberate architectural decision with no planned RTSP support. Live viewing is restricted to the Kasa mobile app; remote access relies on TP-Link's cloud. TP-Link's RTSP-capable product line is Tapo (see tapo.json), not Kasa. Source: https://www.tp-link.com/us/support/faq/1959/",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "LaView",
       "brand_id": "laview",
       "status": "unverified",
@@ -5314,6 +5521,66 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Loryta",
+      "brand_id": "loryta",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/cam/realmonitor?channel=<N>&subtype=0",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Dahua Wiki — RTSP via VLC (Loryta is a Dahua OEM; identical RTSP path) — https://dahuawiki.com/Remote_Access/RTSP_via_VLC",
+          "strix_lead": "manual:loryta"
+        },
+        {
+          "stream": "sub",
+          "path": "/cam/realmonitor?channel=<N>&subtype=1",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Dahua Wiki — RTSP via VLC (Loryta is a Dahua OEM; identical RTSP path) — https://dahuawiki.com/Remote_Access/RTSP_via_VLC",
+          "strix_lead": "manual:loryta"
+        }
+      ],
+      "notes": "Loryta is a Dahua OEM brand sold by EmpireTech (empiretech01.com). Camera model numbers (e.g. IPC-T2431T-AS, IPC-T5241H-AS-PV) are Dahua SKUs. The loryta.com domain does not resolve; the EmpireTech store (empiretech01.com) is the official retail channel. RTSP paths are identical to Dahua: /cam/realmonitor?channel=<N>&subtype=0 (main) and subtype=1 (sub). Default port 554. Credentials use the camera's configured username/password (default admin/admin).",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Luma",
+      "brand_id": "luma",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/Streaming/channels/1",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "CGI commands for Luma IP Cameras (Technical Bulletin v170310-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI%20commands%20for%20IPCs.pdf",
+          "strix_lead": "manual:luma"
+        },
+        {
+          "stream": "sub",
+          "path": "/Streaming/channels/2",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "CGI commands for Luma IP Cameras (Technical Bulletin v170310-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI%20commands%20for%20IPCs.pdf",
+          "strix_lead": "manual:luma"
+        },
+        {
+          "stream": "third",
+          "path": "/Streaming/channels/3",
+          "codec": "H.264",
+          "verified": true,
+          "source": "CGI Commands for Luma X10 Series IP Cameras (Technical Bulletin v180306-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI_commands_for_x10_IPCs.pdf",
+          "strix_lead": "manual:luma"
+        }
+      ],
+      "notes": "Luma is a Hikvision OEM sold by SnapAV (now Snap One). RTSP path is the standard Hikvision ISAPI /Streaming/channels/<N> form: 1=main, 2=sub, 3=third (X10 series only; third stream must be enabled in System Settings > Hardware Settings). Default RTSP port is 554. Authentication is required (RTSP authentication defaults to Basic). The sub-stream example in the original bulletin (rtsp://admin:pw123@192.186.1.11:10554/Streaming/channels/2) shows direct camera access on a non-default port, confirming the path applies to standalone cameras not just NVR relay.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "Merit LILIN",
       "brand_id": "merit-lilin",
       "status": "verified",
@@ -5351,6 +5618,55 @@
         }
       ],
       "notes": "LILIN standalone IP cameras use a codec+resolution path token: /rtsph264<res> for H.264 and /rtspjpeg<res> for MJPEG, where <res> is the encoder's resolution (leads seen: 4k, 1080p, 1024p, 720p, 480p, 960h, 3m, 5m, sxga, cif; plus bare /rtsph264 and /rtspjpeg). Confirmed directly by LILIN's own support KB for the 4K variant (rtsph2644k). Default RTSP port is 554; LILIN also allows RTSP over HTTP on port 80 (e.g. rtsp://user:pass@ip:80/rtsph264480p). Auth is inline user:pass@. Each encoder/stream has its own URL, listed in the camera web GUI (Setup > Video/Audio). NOTE: a separate/newer LILIN IP-camera line (E-Series, per meritlilin.com UserManual_ESeries_IPC-EN.pdf) instead uses /av0_0 (main) and /av0_1 (sub) on port 554 — a distinct scheme not covered by these templates; and LILIN DVR/NVR use /rtspstream?channel=<ch>&stream=<n>. Templates here cover the classic rtsph264<res>/rtspjpeg<res> IP-camera scheme matching the leads.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Merkury Innovations",
+      "brand_id": "merkury",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/cam/realtime",
+          "note": "Community-reported path for Tuya-based cameras, not in any official Merkury/Geeni documentation"
+        }
+      ],
+      "notes": "Merkury Innovations cameras (sold under the Geeni brand at mygeeni.com) are Tuya-based cloud-only devices. The official Geeni support site (support.mygeeni.com) states cameras only work via the Geeni app and voice assistants — no RTSP, ONVIF, or local streaming is mentioned in any official documentation. No developer guide, product manual, or support article from merkuryinnovations.com or mygeeni.com references RTSP streams or local access. Community projects (github.com/guino/Merkury720, github.com/guino/Merkury1080P) document rooting/custom-firmware workarounds, but these are not official. Status is unverified because the manufacturer publishes no RTSP path.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Milesight",
+      "brand_id": "milesight",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/main",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Milesight RTSP Stream Support Article — https://support.milesight.com/support/solutions/articles/69000859092-rtsp-stream-of-milesight-network-camera-nvr-vms",
+          "strix_lead": "manual:milesight"
+        },
+        {
+          "stream": "sub",
+          "path": "/sub",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Milesight RTSP Stream Support Article — https://support.milesight.com/support/solutions/articles/69000859092-rtsp-stream-of-milesight-network-camera-nvr-vms",
+          "strix_lead": "manual:milesight"
+        },
+        {
+          "stream": "third",
+          "path": "/third",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "Milesight IPC Fisheye User Manual RTSP page — https://www.milesight.com/support/download/document-center/ipc-series/fisheye/en/user-manual/rtsp.html",
+          "strix_lead": "manual:milesight"
+        }
+      ],
+      "notes": "Milesight is an independent IP camera brand (milesight.com). Official docs confirm default RTSP port 554. Standard single-sensor cameras use /main (primary), /sub (secondary), /third (tertiary). Fisheye cameras extend to /fourth and /fifth for additional dewarped views. Dual-sensor cameras use channel-prefixed paths: /channel1/main, /channel1/sub, /channel2/main. Multi-directional cameras use /sensor1/main through /sensor4/main, plus /bundle/main for the stitched view. Authentication is embedded in the URL as rtsp://{user}:{pass}@{ip}:554/main. RTSP port is configurable (valid range 1–65535).",
       "verified_on": "2026-08-14"
     },
     {
@@ -5808,6 +6124,25 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Provision-ISR",
+      "brand_id": "provision-isr",
+      "status": "unverified",
+      "default_port": 554,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/udp/av0_0",
+          "note": "Community-reported main stream path (e.g. CamioCam/rtsp repo); not found in any official Provision-ISR document"
+        },
+        {
+          "path": "/udp/av0_1",
+          "note": "Community-reported sub stream path; not found in any official Provision-ISR document"
+        }
+      ],
+      "notes": "Provision-ISR (provision-isr.com) is an Israeli surveillance brand. All official IP camera user manuals (multiple models: DAI-390IP04, DI-340IP536, I3-250IP536, Z4-25IPE, I2-320IPSN, EC-001, DAI250IP5VF, and others) confirm RTSP support on port 554 and state 'each of the streams have a unique RTSP address — input the desired address into your RTSP player.' However, the actual RTSP path is only shown as a UI screenshot in the camera's web interface and is never printed as a text string in any official manual PDF or support page. No official Provision-ISR documentation (manuals, knowledge-sharing articles, developer guides) explicitly publishes the RTSP URL path. The /udp/av0_0 path referenced by third-party aggregators (iSpy, CamioCam) is community-sourced only. Cameras support ONVIF, which may allow stream-URL autodiscovery.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "Q-See",
       "brand_id": "q-see",
       "status": "verified",
@@ -5973,6 +6308,16 @@
         }
       ],
       "notes": "Channel number is 2-digit zero-padded (e.g. 01, 02). For standalone cameras the channel is always 01. For multi-channel NVR/Home Hub systems, channels start at 01 (1-based). Codec is determined by camera model and firmware, not by path; the official documented path prefix is /Preview_{channel}_{stream} without a codec prefix. Port 8554 paths (e1/mainStream etc.) appear in community sources and may be a distinct firmware family; they are not confirmed by Reolink's official RTSP KB article. RTSP and ONVIF are disabled by default on Reolink cameras and must be enabled in the camera settings.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Resideo",
+      "brand_id": "resideo",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [],
+      "notes": "Resideo cameras (Honeywell Home IPCAM series, Lyric C1/C2, First Alert VX series) are cloud-only devices designed exclusively for the Total Connect 2.0 platform. All video access is routed through Resideo's AlarmNet cloud infrastructure and their mobile/web app. No RTSP stream URL or path is published in any official Resideo documentation, product manuals, or developer resources. The IPCAM-WOC2, IPCAM-WIC2, VX3, VX5, and Lyric C1/C2 user manuals contain no RTSP configuration. Official product pages confirm clip viewing is 'Via TC2 (app & website)' only. The ProSeries API (proseriesapi.resideo.com) covers video download via MAC address but not RTSP endpoints.",
       "verified_on": "2026-08-14"
     },
     {
@@ -7400,6 +7745,33 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "Tiandy",
+      "brand_id": "tiandy",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/cam/realmonitor?channel=<N>&subtype=0",
+          "note": "Widely reported by third-party aggregators (iSpy, security.world, visioforge) as Tiandy main-stream path matching Dahua format. No official Tiandy document confirms this path — all sources trace back to community observation. visioforge.com explicitly admits 'it's an observed pattern rather than a formally cited standard.'"
+        },
+        {
+          "path": "/cam/realmonitor?channel=<N>&subtype=1",
+          "note": "Sub-stream variant of the Dahua-style path. Same caveat — community-reported only, no official Tiandy doc."
+        },
+        {
+          "path": "/<N>/1",
+          "note": "Format documented in the Tiandy NVR official user manual (section 4.4.2.1, e.g. rtsp://admin:pass@ip:554/1/1) but in the context of adding third-party RTSP cameras to the NVR, not as the Tiandy camera's own RTSP output path. Firmware reverse-engineering (github.com/zb3/tiandy-research, 2020) independently found the IPC native path to be /S (stream type only, e.g. /1 for main) while NVR path is /C/S — neither confirmed from official docs."
+        },
+        {
+          "path": "/live/ch0",
+          "note": "Reported for older Tiandy models by community sources. No official documentation found."
+        }
+      ],
+      "notes": "Tiandy Technologies (tiandy.com / en.tiandy.com) is a Chinese manufacturer founded in 1994, ranked among the top 10 global surveillance brands. Despite checking the official download portal (en.tiandy.com/download.html), multiple official distributor-hosted PDF manuals (tiandy.sk, g4cctv.com, pliki.genway.pl — all image-based scanned PDFs with no extractable RTSP text), the official NVR user manual (anabon.com), the ManualsLib catalog, and the Korean regional Tiandy PDF, no official Tiandy document was found that explicitly publishes the RTSP stream URL path for their IP cameras. A 2020 firmware security research report (github.com/zb3/tiandy-research) explicitly states 'Tiandy's official documentation does not provide instructions for accessing streams via [RTSP] protocols.' The /cam/realmonitor?channel=<N>&subtype=0 path circulates heavily in community databases but is attributed to Dahua-compatibility observation, not an official Tiandy source. Tiandy cameras do support RTSP (port 554) and ONVIF Profile S/T per product spec sheets, but the actual RTSP path is not published in accessible official documentation. Re-verify if Tiandy publishes a developer guide or SDK documentation via their partner portal (partner.tiandy.com, requires login).",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "TP-Link",
       "brand_id": "tp-link",
       "status": "verified",
@@ -8161,6 +8533,32 @@
       "verified_on": "2026-08-14"
     },
     {
+      "brand": "VIGI",
+      "brand_id": "vigi",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/stream1",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "How to View VIGI Camera on PC Through RTSP Stream — https://www.tp-link.com/us/support/faq/3718/",
+          "strix_lead": "manual:vigi"
+        },
+        {
+          "stream": "sub",
+          "path": "/stream2",
+          "codec": "H.264|H.265",
+          "verified": true,
+          "source": "How to View VIGI Camera on PC Through RTSP Stream — https://www.tp-link.com/us/support/faq/3718/",
+          "strix_lead": "manual:vigi"
+        }
+      ],
+      "notes": "TP-Link VIGI is a separate business-grade camera line (distinct from the consumer Tapo/Kasa line). Official TP-Link FAQ 3718 and 4201 document RTSP paths /stream1 (main/high quality) and /stream2 (sub/low quality) on port 554. Credentials (camera account username/password set via VIGI app) are prompted separately by the connecting client, not embedded in the URL path. Some clients may require the explicit port: rtsp://{ip}:554/stream1. VIGI cameras support H.264, H.264+, H.265, H.265+ on main stream; H.264/H.265 on sub stream. ONVIF is also supported for full device control via third-party NVR/NAS.",
+      "verified_on": "2026-08-14"
+    },
+    {
       "brand": "Vivotek",
       "brand_id": "vivotek",
       "status": "verified",
@@ -8385,6 +8783,32 @@
         }
       ],
       "notes": "Wanscam (Shenzhen Wanscam Technology Co., Ltd) makes budget WiFi/P2P consumer cameras that are primarily app-driven (their own mobile/PC clients + ONVIF auto-discovery). The only official Wanscam document reviewed — the JW0004 FCC user manual (FCC ID REH-JW0004, user-manual-1884638) — lists 'RTSP Stream Mode' as a feature but publishes NO RTSP URL, path, or port. The commonly cited pattern rtsp://{user}:{pass}@{ip}:10554/11 (main) and /12 (sub), plus the /live/ch0 scheme and port 10554, come exclusively from third-party VMS/aggregator databases (iSpyConnect, Camlytics, GeniusVision), not from Wanscam's own documentation, so they cannot be published as verified. If a specific model's official manual/web-UI later documents a fixed RTSP path, this can be upgraded to verified. wanscam.com is reachable but currently serves an expired TLS certificate, blocking automated fetch of any product-page/app-help docs.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Wisenet",
+      "brand_id": "wisenet",
+      "status": "verified",
+      "default_port": 554,
+      "templates": [
+        {
+          "stream": "main",
+          "path": "/profile2/media.smp",
+          "codec": "H.264/H.265",
+          "verified": true,
+          "source": "Hanwha Vision Support Portal — 'Camera - RTSP URL' (https://support.hanwhavision.com/hc/en-001/articles/47782445700243-Camera-RTSP-URL) and 'What are the RTSP URLs of Hanwha Devices?' (https://support.hanwhavision.com/hc/en-001/articles/47257361792659-What-are-the-RTSP-URLs-of-Hanwha-Devices): format rtsp://<DeviceIP>/profile<no>/media.smp; profile2 is the documented main (H.264/H.265) stream.",
+          "strix_lead": "manual:wisenet"
+        },
+        {
+          "stream": "sub",
+          "path": "/profile3/media.smp",
+          "codec": "H.264/H.265",
+          "verified": true,
+          "source": "Hanwha Vision Support Portal — 'Camera - RTSP URL' (https://support.hanwhavision.com/hc/en-001/articles/47782445700243-Camera-RTSP-URL) and 'RTSP URLs' (https://support.hanwhavision.eu/hc/en-gb/articles/4414178841746-RTSP-URLs): profile3 is the documented sub stream.",
+          "strix_lead": "manual:wisenet"
+        }
+      ],
+      "notes": "Wisenet is Hanwha Vision's consumer-facing brand (wisenetlife.com), formerly Samsung Techwin / Samsung SNH. All Wisenet-branded IP cameras use the same Hanwha Vision platform and RTSP path structure as Hanwha pro cameras. Official RTSP URL format: rtsp://{user}:{pass}@{ip}:{port}/profile<N>/media.smp. Profile numbering: profile1=MJPEG (internal/reserved), profile2=main H.264/H.265 stream, profile3=sub stream. Default RTSP port is 554; configurable in range 1024–65535 (ports 3702 and 49152 not available). The wisenetlife.com consumer site does not publish its own RTSP KB article; the authoritative source is the Hanwha Vision support portal (support.hanwhavision.com) which covers all Wisenet-branded hardware. See also the verified hanwha.json entry which documents the same path format for the pro line.",
       "verified_on": "2026-08-14"
     },
     {
@@ -8990,6 +9414,25 @@
         }
       ],
       "notes": "Two documented URL families per ZOSI's official Help Center RTSP article: WiFi standalone IP cameras use /video1 (main) and /video2 (sub); PoE cameras use /ucast/11 (main) and /ucast/12 (sub). All on port 554, no channel index in the single-camera IPC URLs (credentials optional, prepended as user:pass@ip). Battery-powered ZOSI cameras do NOT support RTSP per ZOSI. Codec assumed H.264 (ZOSI labels streams Clear/Smooth; codec not explicitly stated on the KB page, but ZOSI IPCs are H.264/H.265 — recorded conservatively as H.264). NVR-side channel URLs not covered by this IPC-direct article.",
+      "verified_on": "2026-08-14"
+    },
+    {
+      "brand": "Zxtech",
+      "brand_id": "zxtech",
+      "status": "unverified",
+      "default_port": null,
+      "templates": [],
+      "unverified_leads": [
+        {
+          "path": "/cam/realmonitor?channel=<N>&subtype=0",
+          "note": "Community-reported Dahua-style path (iSpyConnect) — not in official Zxtech/Domar docs"
+        },
+        {
+          "path": "/0",
+          "note": "Community-reported bare path for some models (iSpyConnect mc1181n6 entry) — not in official docs"
+        }
+      ],
+      "notes": "Zxtech is a UK brand distributed exclusively by Domar CCTV (domar.com). Cameras confirm RTSP and ONVIF support in product literature, but neither Zxtech nor Domar publish the specific RTSP stream URL path in any official documentation. The Domar PoE Kits Manual (2025), PoE Camera Quick Start Guide, and Zxtech Tropox manual (ManualsLib) all focus on proprietary P2P app access and ONVIF discovery — no RTSP path is documented. OEM origin is unconfirmed from official sources; community aggregators suggest Dahua-style paths but this is not verified from manufacturer documentation.",
       "verified_on": "2026-08-14"
     }
   ]

--- a/strix/verified/camius.json
+++ b/strix/verified/camius.json
@@ -1,0 +1,26 @@
+{
+  "brand": "Camius",
+  "brand_id": "camius",
+  "status": "verified",
+  "default_port": 80,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/rtsp/streaming?channel=<N>&subtype=0",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "RTSP Streaming Setup Guide for NVR, DVR and IP Cameras — https://www.camius.com/rtsp-ip-camera-camius/",
+      "strix_lead": "manual:camius"
+    },
+    {
+      "stream": "sub",
+      "path": "/rtsp/streaming?channel=<N>&subtype=1",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "RTSP Streaming Setup Guide for NVR, DVR and IP Cameras — https://www.camius.com/rtsp-ip-camera-camius/",
+      "strix_lead": "manual:camius"
+    }
+  ],
+  "notes": "Camius NVRs and DVRs use the path /rtsp/streaming?channel=<N>&subtype=0 (main) or subtype=1 (sub). Default RTSP port is 80 for firmware V8.2.4.1+; earlier firmware defaults to port 554. Port is configurable via Network >> General >> Port Configuration. Authentication uses admin credentials. Camius appears to be a US-based brand selling their own NVR/DVR systems; no confirmed OEM relationship identified from official docs.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/clarevision.json
+++ b/strix/verified/clarevision.json
@@ -1,0 +1,26 @@
+{
+  "brand": "ClareVision",
+  "brand_id": "clarevision",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/0",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "ClareVision Camera and NVR RTSP Stream URLs — https://www.clarecontrols.com/helpcenter/clarevision-camera-nvr-rtsp-stream-urls",
+      "strix_lead": "manual:clarevision"
+    },
+    {
+      "stream": "sub",
+      "path": "/1",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "ClareVision Camera and NVR RTSP Stream URLs — https://www.clarecontrols.com/helpcenter/clarevision-camera-nvr-rtsp-stream-urls",
+      "strix_lead": "manual:clarevision"
+    }
+  ],
+  "notes": "ClareVision is a Hikvision OEM by Clare Controls (SnapAV). Despite the Hikvision OEM relationship, ClareVision cameras use simple zero-indexed numeric RTSP paths (/0, /1, /2) rather than Hikvision's /Streaming/Channels/101 format. Main stream = /0, 2nd stream = /1, 3rd stream = /2. V100 cameras support only 2 streams; V200 and V300 support 3 streams. Port 554. Full URL: rtsp://{user}:{pass}@{ip}:554/0",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/ctronics.json
+++ b/strix/verified/ctronics.json
@@ -1,0 +1,27 @@
+{
+  "brand": "Ctronics",
+  "brand_id": "ctronics",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    {
+      "path": "/11",
+      "note": "Community-reported main stream path (GitHub Home Assistant issue #593, iSpy aggregator). Consistent with XM/Xiongmai-based camera firmware used by HiP2P ecosystem brands."
+    },
+    {
+      "path": "/12",
+      "note": "Community-reported sub stream path for XM/HiP2P-based cameras."
+    },
+    {
+      "path": "/ch01.264",
+      "note": "Alternative path reported in Amazon Q&A and third-party aggregators; not confirmed in official Ctronics documentation."
+    },
+    {
+      "path": "/ch01_sub.264",
+      "note": "Alternative sub-stream path reported alongside /ch01.264 in community sources."
+    }
+  ],
+  "notes": "Ctronics (ctronics.com / ctronics.co.uk) is a budget IP camera brand popular in the EU. Their cameras use HiP2P client software and the Cloudedge/Ctronics mobile app, strongly indicating an XM (Xiongmai) OEM relationship. However, no official Ctronics documentation — neither their website, ManualsLib manuals (CTIPC Series, CTIPC-260CWS, Pro CTIPC), nor the Download Center — explicitly documents an RTSP URL path. All manuals focus on mobile app setup, HiP2P software, and web browser access. RTSP paths (/11 for main, /12 for sub) are community-reported and consistent with XM/HiP2P firmware but cannot be attributed to official Ctronics sources.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/ebitcam.json
+++ b/strix/verified/ebitcam.json
@@ -1,0 +1,10 @@
+{
+  "brand": "EBITCAM",
+  "brand_id": "ebitcam",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [],
+  "notes": "EBITCAM cameras are cloud-only devices operated through the proprietary Ebitcam app (ebitcam.net). Official manuals (EB01 Series on ManualsLib, E2 720P on manuals.plus) make no mention of RTSP paths, ONVIF support, or any local streaming protocol. The manufacturer's website (ebitcam.com) appears to be a parked/empty domain; the actual app platform is ebitcam.net. User reports confirm cloud-dependent access with no RTSP documentation published by the manufacturer.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/galayou.json
+++ b/strix/verified/galayou.json
@@ -1,0 +1,12 @@
+{
+  "brand": "Galayou",
+  "brand_id": "galayou",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    { "path": "/live/ch0", "note": "Community-reported path associated with Wansview-platform cameras (Galayou uses Wansview Cloud), not in any official Galayou documentation" }
+  ],
+  "notes": "Galayou cameras (galayou-store.com) support RTSP/ONVIF but do not publish a static RTSP URL path in any official documentation. Their official support instructs users to enable RTSP via the Wansview Cloud app under Settings > Local Application, where the RTSP URL is displayed dynamically — the path is never disclosed in writing. The Wansview Cloud platform is the underlying infrastructure (Galayou uses the same 'Wansview Cloud' app). No official Galayou or Wansview manual, KB article, or developer guide publishes the RTSP path template. CVE-2025-9983 (CERT Polska, 2025-09) confirms these cameras stream via RTSP on default port 554 but does not reveal the path.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/grandstream.json
+++ b/strix/verified/grandstream.json
@@ -1,0 +1,26 @@
+{
+  "brand": "Grandstream",
+  "brand_id": "grandstream",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/0",
+      "codec": "H.264",
+      "verified": true,
+      "source": "Grandstream Networks GSC361X Series User Manual (page 31, RTSP Steam Display Using VLC) — https://www.manualslib.com/manual/1833129/Grandstream-Networks-Gsc361x-Series.html?page=31",
+      "strix_lead": "manual:grandstream"
+    },
+    {
+      "stream": "sub",
+      "path": "/4",
+      "codec": "H.264",
+      "verified": true,
+      "source": "Grandstream Networks GSC3620 User Manual (page 31, RTSP Steam Display Using VLC) — https://www.manualslib.com/manual/2181549/Grandstream-Networks-Gsc3620.html?page=31",
+      "strix_lead": "manual:grandstream"
+    }
+  ],
+  "notes": "Official Grandstream manuals (GSC361X, GSC3620, GXV36xx series) document RTSP URL format as rtsp://{user}:{pass}@{ip}:{port}/X where X=0 for the 1st (main) stream and X=4 for the 2nd (sub) stream. Default RTSP port is 554 when the HTTP web port is 80; if HTTP port is changed to a non-80 value (e.g. 88), the RTSP port becomes HTTP_port + 2000 (e.g. 2088). This unusual /0 and /4 path scheme is Grandstream-specific and applies to both the GSC36xx indoor/outdoor camera series and the older GXV36xx IP camera series. Streams use H.264 per the manual; GSC36xx models also support H.265 on newer firmware. Codec field reflects H.264 as confirmed in manuals for RTSP; H.265 support not explicitly documented for the RTSP path in reviewed sources.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/hilook.json
+++ b/strix/verified/hilook.json
@@ -1,0 +1,26 @@
+{
+  "brand": "HiLook",
+  "brand_id": "hilook",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/Streaming/Channels/<N>01",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Hikvision Support KB (covers HiLook as Hikvision sub-brand) — 'Do you have an example showing the format for getting a RTSP stream from a camera?' https://supportusa.hikvision.com/support/solutions/articles/17000129022-do-you-have-an-example-showing-the-format-for-getting-a-rtsp-stream-from-a-camera-",
+      "strix_lead": "manual:hilook"
+    },
+    {
+      "stream": "sub",
+      "path": "/Streaming/Channels/<N>02",
+      "codec": "H.264|H.265|MJPEG",
+      "verified": true,
+      "source": "Hikvision Support KB (covers HiLook as Hikvision sub-brand) — 'Do you have an example showing the format for getting a RTSP stream from a camera?' https://supportusa.hikvision.com/support/solutions/articles/17000129022-do-you-have-an-example-showing-the-format-for-getting-a-rtsp-stream-from-a-camera-",
+      "strix_lead": "manual:hilook"
+    }
+  ],
+  "notes": "HiLook is Hikvision's budget sub-brand (confirmed by hilooksecurity.com footer: '© 2026 Hangzhou Hikvision Digital Technology Co., Ltd. All Rights Reserved.'). HiLook IP cameras run Hikvision firmware and use identical RTSP path structure. Channel ID formula: (channel_number × 100) + stream_type, where stream_type 1=main, 2=sub. For a single-channel IP camera: /Streaming/Channels/101 (main), /Streaming/Channels/102 (sub). HiLook Network Camera User Manual (UD22027B-E, hosted on assets.hikvision.com) confirms RTSP port configuration and RTSP authentication settings, consistent with Hikvision ISAPI. The /ISAPI/Streaming/channels/<N>01 variant also works per Hikvision ISAPI Developer Guide. hilookvision.com is a parked/for-sale domain — the real official site is hilooksecurity.com (EU) operated by Hikvision.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/iegeek.json
+++ b/strix/verified/iegeek.json
@@ -1,0 +1,26 @@
+{
+  "brand": "ieGeek",
+  "brand_id": "iegeek",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/11",
+      "codec": "H.264",
+      "verified": true,
+      "source": "ieGeek IE20 Outdoor Dome Camera User Manual (official PDF hosted on support.iegeek.com), FAQ Q16: 'Your RTSP port of main stream is rtsp://192.168.1.38:554/11 and RTSP port of secondary stream rtsp://192.168.1.38:554/12.' — https://support.iegeek.com/cdn/shop/files/ieGeek_IG20_IG62_IG80_IG82_IG90_-_User_Manual___74.pdf",
+      "strix_lead": "manual:iegeek"
+    },
+    {
+      "stream": "sub",
+      "path": "/12",
+      "codec": "H.264",
+      "verified": true,
+      "source": "ieGeek IE20 Outdoor Dome Camera User Manual (official PDF hosted on support.iegeek.com), FAQ Q16: secondary stream path /12. Same source as main stream entry. — https://support.iegeek.com/cdn/shop/files/ieGeek_IG20_IG62_IG80_IG82_IG90_-_User_Manual___74.pdf",
+      "strix_lead": "manual:iegeek"
+    }
+  ],
+  "notes": "ieGeek's official RTSP URL format uses numeric shorthand paths: /11 = main stream (channel 1, stream 1), /12 = sub stream (channel 1, stream 2). These are consumer WiFi cameras with a single channel so no channel placeholder is needed — paths are fixed. RTSP port is 554; ONVIF port is 8080. Confirmed in multiple ieGeek official user manuals (IE20, IG20/IG62/IG80/IG82/IG90 series) available on support.iegeek.com. Credentials are passed as standard URL authentication (rtsp://user:pass@ip:554/11), not embedded in the path. Many ieGeek models (including battery/solar variants) are app/cloud-only and do NOT support RTSP — the /11 and /12 paths apply to wired-network and WiFi IP camera models only.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/ipc360.json
+++ b/strix/verified/ipc360.json
@@ -1,0 +1,15 @@
+{
+  "brand": "IPC360",
+  "brand_id": "ipc360",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    {
+      "path": "/live/ch0",
+      "note": "Community-reported on port 554 with admin/123456 credentials after enabling ONVIF in the app — not found in any official IPC360 documentation"
+    }
+  ],
+  "notes": "IPC360 (ipc360.info / ipc360.org) is a consumer Wi-Fi camera brand that operates as a cloud/P2P-first system. Their official FAQ explicitly states video is transported via UDP and server connections via TCP, reflecting a cloud relay architecture. Neither the official FAQ (ipc360.info/Index/Idx_faq) nor the User's Manual page (ipc360.info/Index/Idx_manual) contains any mention of RTSP, ONVIF, or local stream URLs. No developer documentation or RTSP path is published by the manufacturer. Community sources report that some models expose RTSP on port 554 at /live/ch0 after enabling ONVIF in the IPC360 Pro app, but this is unconfirmed by official documentation and varies by model/firmware.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/kasa.json
+++ b/strix/verified/kasa.json
@@ -1,0 +1,10 @@
+{
+  "brand": "Kasa",
+  "brand_id": "kasa",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [],
+  "notes": "Kasa cameras (TP-Link Kasa Smart line, e.g. KC110, KC400, KC401) are cloud-only and do not support RTSP or ONVIF. TP-Link's official FAQ explicitly states: 'Kasa Cameras do not support RTSP/ONVIF, so viewing a camera's stream on a computer is not possible.' This is a deliberate architectural decision with no planned RTSP support. Live viewing is restricted to the Kasa mobile app; remote access relies on TP-Link's cloud. TP-Link's RTSP-capable product line is Tapo (see tapo.json), not Kasa. Source: https://www.tp-link.com/us/support/faq/1959/",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/loryta.json
+++ b/strix/verified/loryta.json
@@ -1,0 +1,26 @@
+{
+  "brand": "Loryta",
+  "brand_id": "loryta",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/cam/realmonitor?channel=<N>&subtype=0",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Dahua Wiki — RTSP via VLC (Loryta is a Dahua OEM; identical RTSP path) — https://dahuawiki.com/Remote_Access/RTSP_via_VLC",
+      "strix_lead": "manual:loryta"
+    },
+    {
+      "stream": "sub",
+      "path": "/cam/realmonitor?channel=<N>&subtype=1",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Dahua Wiki — RTSP via VLC (Loryta is a Dahua OEM; identical RTSP path) — https://dahuawiki.com/Remote_Access/RTSP_via_VLC",
+      "strix_lead": "manual:loryta"
+    }
+  ],
+  "notes": "Loryta is a Dahua OEM brand sold by EmpireTech (empiretech01.com). Camera model numbers (e.g. IPC-T2431T-AS, IPC-T5241H-AS-PV) are Dahua SKUs. The loryta.com domain does not resolve; the EmpireTech store (empiretech01.com) is the official retail channel. RTSP paths are identical to Dahua: /cam/realmonitor?channel=<N>&subtype=0 (main) and subtype=1 (sub). Default port 554. Credentials use the camera's configured username/password (default admin/admin).",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/luma.json
+++ b/strix/verified/luma.json
@@ -1,0 +1,34 @@
+{
+  "brand": "Luma",
+  "brand_id": "luma",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/Streaming/channels/1",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "CGI commands for Luma IP Cameras (Technical Bulletin v170310-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI%20commands%20for%20IPCs.pdf",
+      "strix_lead": "manual:luma"
+    },
+    {
+      "stream": "sub",
+      "path": "/Streaming/channels/2",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "CGI commands for Luma IP Cameras (Technical Bulletin v170310-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI%20commands%20for%20IPCs.pdf",
+      "strix_lead": "manual:luma"
+    },
+    {
+      "stream": "third",
+      "path": "/Streaming/channels/3",
+      "codec": "H.264",
+      "verified": true,
+      "source": "CGI Commands for Luma X10 Series IP Cameras (Technical Bulletin v180306-1527) — https://www.snapav.com/wcsstore/ExtendedSitesCatalogAssetStore/attachments/documents/Surveillance/ProtocolsAndDrivers/CGI_commands_for_x10_IPCs.pdf",
+      "strix_lead": "manual:luma"
+    }
+  ],
+  "notes": "Luma is a Hikvision OEM sold by SnapAV (now Snap One). RTSP path is the standard Hikvision ISAPI /Streaming/channels/<N> form: 1=main, 2=sub, 3=third (X10 series only; third stream must be enabled in System Settings > Hardware Settings). Default RTSP port is 554. Authentication is required (RTSP authentication defaults to Basic). The sub-stream example in the original bulletin (rtsp://admin:pw123@192.186.1.11:10554/Streaming/channels/2) shows direct camera access on a non-default port, confirming the path applies to standalone cameras not just NVR relay.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/merkury.json
+++ b/strix/verified/merkury.json
@@ -1,0 +1,15 @@
+{
+  "brand": "Merkury Innovations",
+  "brand_id": "merkury",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    {
+      "path": "/cam/realtime",
+      "note": "Community-reported path for Tuya-based cameras, not in any official Merkury/Geeni documentation"
+    }
+  ],
+  "notes": "Merkury Innovations cameras (sold under the Geeni brand at mygeeni.com) are Tuya-based cloud-only devices. The official Geeni support site (support.mygeeni.com) states cameras only work via the Geeni app and voice assistants — no RTSP, ONVIF, or local streaming is mentioned in any official documentation. No developer guide, product manual, or support article from merkuryinnovations.com or mygeeni.com references RTSP streams or local access. Community projects (github.com/guino/Merkury720, github.com/guino/Merkury1080P) document rooting/custom-firmware workarounds, but these are not official. Status is unverified because the manufacturer publishes no RTSP path.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/milesight.json
+++ b/strix/verified/milesight.json
@@ -1,0 +1,34 @@
+{
+  "brand": "Milesight",
+  "brand_id": "milesight",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/main",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Milesight RTSP Stream Support Article — https://support.milesight.com/support/solutions/articles/69000859092-rtsp-stream-of-milesight-network-camera-nvr-vms",
+      "strix_lead": "manual:milesight"
+    },
+    {
+      "stream": "sub",
+      "path": "/sub",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Milesight RTSP Stream Support Article — https://support.milesight.com/support/solutions/articles/69000859092-rtsp-stream-of-milesight-network-camera-nvr-vms",
+      "strix_lead": "manual:milesight"
+    },
+    {
+      "stream": "third",
+      "path": "/third",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "Milesight IPC Fisheye User Manual RTSP page — https://www.milesight.com/support/download/document-center/ipc-series/fisheye/en/user-manual/rtsp.html",
+      "strix_lead": "manual:milesight"
+    }
+  ],
+  "notes": "Milesight is an independent IP camera brand (milesight.com). Official docs confirm default RTSP port 554. Standard single-sensor cameras use /main (primary), /sub (secondary), /third (tertiary). Fisheye cameras extend to /fourth and /fifth for additional dewarped views. Dual-sensor cameras use channel-prefixed paths: /channel1/main, /channel1/sub, /channel2/main. Multi-directional cameras use /sensor1/main through /sensor4/main, plus /bundle/main for the stitched view. Authentication is embedded in the URL as rtsp://{user}:{pass}@{ip}:554/main. RTSP port is configurable (valid range 1–65535).",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/provision-isr.json
+++ b/strix/verified/provision-isr.json
@@ -1,0 +1,19 @@
+{
+  "brand": "Provision-ISR",
+  "brand_id": "provision-isr",
+  "status": "unverified",
+  "default_port": 554,
+  "templates": [],
+  "unverified_leads": [
+    {
+      "path": "/udp/av0_0",
+      "note": "Community-reported main stream path (e.g. CamioCam/rtsp repo); not found in any official Provision-ISR document"
+    },
+    {
+      "path": "/udp/av0_1",
+      "note": "Community-reported sub stream path; not found in any official Provision-ISR document"
+    }
+  ],
+  "notes": "Provision-ISR (provision-isr.com) is an Israeli surveillance brand. All official IP camera user manuals (multiple models: DAI-390IP04, DI-340IP536, I3-250IP536, Z4-25IPE, I2-320IPSN, EC-001, DAI250IP5VF, and others) confirm RTSP support on port 554 and state 'each of the streams have a unique RTSP address — input the desired address into your RTSP player.' However, the actual RTSP path is only shown as a UI screenshot in the camera's web interface and is never printed as a text string in any official manual PDF or support page. No official Provision-ISR documentation (manuals, knowledge-sharing articles, developer guides) explicitly publishes the RTSP URL path. The /udp/av0_0 path referenced by third-party aggregators (iSpy, CamioCam) is community-sourced only. Cameras support ONVIF, which may allow stream-URL autodiscovery.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/resideo.json
+++ b/strix/verified/resideo.json
@@ -1,0 +1,10 @@
+{
+  "brand": "Resideo",
+  "brand_id": "resideo",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [],
+  "notes": "Resideo cameras (Honeywell Home IPCAM series, Lyric C1/C2, First Alert VX series) are cloud-only devices designed exclusively for the Total Connect 2.0 platform. All video access is routed through Resideo's AlarmNet cloud infrastructure and their mobile/web app. No RTSP stream URL or path is published in any official Resideo documentation, product manuals, or developer resources. The IPCAM-WOC2, IPCAM-WIC2, VX3, VX5, and Lyric C1/C2 user manuals contain no RTSP configuration. Official product pages confirm clip viewing is 'Via TC2 (app & website)' only. The ProSeries API (proseriesapi.resideo.com) covers video download via MAC address but not RTSP endpoints.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/tiandy.json
+++ b/strix/verified/tiandy.json
@@ -1,0 +1,27 @@
+{
+  "brand": "Tiandy",
+  "brand_id": "tiandy",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    {
+      "path": "/cam/realmonitor?channel=<N>&subtype=0",
+      "note": "Widely reported by third-party aggregators (iSpy, security.world, visioforge) as Tiandy main-stream path matching Dahua format. No official Tiandy document confirms this path — all sources trace back to community observation. visioforge.com explicitly admits 'it's an observed pattern rather than a formally cited standard.'"
+    },
+    {
+      "path": "/cam/realmonitor?channel=<N>&subtype=1",
+      "note": "Sub-stream variant of the Dahua-style path. Same caveat — community-reported only, no official Tiandy doc."
+    },
+    {
+      "path": "/<N>/1",
+      "note": "Format documented in the Tiandy NVR official user manual (section 4.4.2.1, e.g. rtsp://admin:pass@ip:554/1/1) but in the context of adding third-party RTSP cameras to the NVR, not as the Tiandy camera's own RTSP output path. Firmware reverse-engineering (github.com/zb3/tiandy-research, 2020) independently found the IPC native path to be /S (stream type only, e.g. /1 for main) while NVR path is /C/S — neither confirmed from official docs."
+    },
+    {
+      "path": "/live/ch0",
+      "note": "Reported for older Tiandy models by community sources. No official documentation found."
+    }
+  ],
+  "notes": "Tiandy Technologies (tiandy.com / en.tiandy.com) is a Chinese manufacturer founded in 1994, ranked among the top 10 global surveillance brands. Despite checking the official download portal (en.tiandy.com/download.html), multiple official distributor-hosted PDF manuals (tiandy.sk, g4cctv.com, pliki.genway.pl — all image-based scanned PDFs with no extractable RTSP text), the official NVR user manual (anabon.com), the ManualsLib catalog, and the Korean regional Tiandy PDF, no official Tiandy document was found that explicitly publishes the RTSP stream URL path for their IP cameras. A 2020 firmware security research report (github.com/zb3/tiandy-research) explicitly states 'Tiandy's official documentation does not provide instructions for accessing streams via [RTSP] protocols.' The /cam/realmonitor?channel=<N>&subtype=0 path circulates heavily in community databases but is attributed to Dahua-compatibility observation, not an official Tiandy source. Tiandy cameras do support RTSP (port 554) and ONVIF Profile S/T per product spec sheets, but the actual RTSP path is not published in accessible official documentation. Re-verify if Tiandy publishes a developer guide or SDK documentation via their partner portal (partner.tiandy.com, requires login).",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/vigi.json
+++ b/strix/verified/vigi.json
@@ -1,0 +1,26 @@
+{
+  "brand": "VIGI",
+  "brand_id": "vigi",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/stream1",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "How to View VIGI Camera on PC Through RTSP Stream — https://www.tp-link.com/us/support/faq/3718/",
+      "strix_lead": "manual:vigi"
+    },
+    {
+      "stream": "sub",
+      "path": "/stream2",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "How to View VIGI Camera on PC Through RTSP Stream — https://www.tp-link.com/us/support/faq/3718/",
+      "strix_lead": "manual:vigi"
+    }
+  ],
+  "notes": "TP-Link VIGI is a separate business-grade camera line (distinct from the consumer Tapo/Kasa line). Official TP-Link FAQ 3718 and 4201 document RTSP paths /stream1 (main/high quality) and /stream2 (sub/low quality) on port 554. Credentials (camera account username/password set via VIGI app) are prompted separately by the connecting client, not embedded in the URL path. Some clients may require the explicit port: rtsp://{ip}:554/stream1. VIGI cameras support H.264, H.264+, H.265, H.265+ on main stream; H.264/H.265 on sub stream. ONVIF is also supported for full device control via third-party NVR/NAS.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/wisenet.json
+++ b/strix/verified/wisenet.json
@@ -1,0 +1,26 @@
+{
+  "brand": "Wisenet",
+  "brand_id": "wisenet",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/profile2/media.smp",
+      "codec": "H.264/H.265",
+      "verified": true,
+      "source": "Hanwha Vision Support Portal — 'Camera - RTSP URL' (https://support.hanwhavision.com/hc/en-001/articles/47782445700243-Camera-RTSP-URL) and 'What are the RTSP URLs of Hanwha Devices?' (https://support.hanwhavision.com/hc/en-001/articles/47257361792659-What-are-the-RTSP-URLs-of-Hanwha-Devices): format rtsp://<DeviceIP>/profile<no>/media.smp; profile2 is the documented main (H.264/H.265) stream.",
+      "strix_lead": "manual:wisenet"
+    },
+    {
+      "stream": "sub",
+      "path": "/profile3/media.smp",
+      "codec": "H.264/H.265",
+      "verified": true,
+      "source": "Hanwha Vision Support Portal — 'Camera - RTSP URL' (https://support.hanwhavision.com/hc/en-001/articles/47782445700243-Camera-RTSP-URL) and 'RTSP URLs' (https://support.hanwhavision.eu/hc/en-gb/articles/4414178841746-RTSP-URLs): profile3 is the documented sub stream.",
+      "strix_lead": "manual:wisenet"
+    }
+  ],
+  "notes": "Wisenet is Hanwha Vision's consumer-facing brand (wisenetlife.com), formerly Samsung Techwin / Samsung SNH. All Wisenet-branded IP cameras use the same Hanwha Vision platform and RTSP path structure as Hanwha pro cameras. Official RTSP URL format: rtsp://{user}:{pass}@{ip}:{port}/profile<N>/media.smp. Profile numbering: profile1=MJPEG (internal/reserved), profile2=main H.264/H.265 stream, profile3=sub stream. Default RTSP port is 554; configurable in range 1024–65535 (ports 3702 and 49152 not available). The wisenetlife.com consumer site does not publish its own RTSP KB article; the authoritative source is the Hanwha Vision support portal (support.hanwhavision.com) which covers all Wisenet-branded hardware. See also the verified hanwha.json entry which documents the same path format for the pro line.",
+  "verified_on": "2026-08-14"
+}

--- a/strix/verified/zxtech.json
+++ b/strix/verified/zxtech.json
@@ -1,0 +1,13 @@
+{
+  "brand": "Zxtech",
+  "brand_id": "zxtech",
+  "status": "unverified",
+  "default_port": null,
+  "templates": [],
+  "unverified_leads": [
+    { "path": "/cam/realmonitor?channel=<N>&subtype=0", "note": "Community-reported Dahua-style path (iSpyConnect) — not in official Zxtech/Domar docs" },
+    { "path": "/0", "note": "Community-reported bare path for some models (iSpyConnect mc1181n6 entry) — not in official docs" }
+  ],
+  "notes": "Zxtech is a UK brand distributed exclusively by Domar CCTV (domar.com). Cameras confirm RTSP and ONVIF support in product literature, but neither Zxtech nor Domar publish the specific RTSP stream URL path in any official documentation. The Domar PoE Kits Manual (2025), PoE Camera Quick Start Guide, and Zxtech Tropox manual (ManualsLib) all focus on proprietary P2P app access and ONVIF discovery — no RTSP path is documented. OEM origin is unconfirmed from official sources; community aggregators suggest Dahua-style paths but this is not verified from manufacturer documentation.",
+  "verified_on": "2026-08-14"
+}


### PR DESCRIPTION
## Summary
Wave 2 of RTSP pattern verification — 20 more camera brands researched against official manufacturer documentation.

## Brands covered
See strix/verified/ for individual brand files. Each entry is either verified (official path confirmed) or honest-unverified (cloud-only or no official RTSP path published).

## Test plan
- [x] Review each strix/verified/<brand>.json for source quality
- [x] Check data/rtsp-patterns.json updated totals look correct
- [x] Spot-check 2-3 verified brands against the cited source URLs