### PR TITLE
docs: required schema shape for strix/verified/ files

### DIFF
--- a/strix/README.md
+++ b/strix/README.md
@@ -25,3 +25,50 @@ verification gate.
 - These are consolidated into **`data/rtsp-patterns.json`** — the CC0 brand-level
   RTSP layer both projects can pull from. Regenerate after editing `verified/`:
   `node scripts/build-rtsp-patterns.js` (or the equivalent consolidation step).
+
+## ⚠ Required schema for `verified/<brand_id>.json`
+
+**Every file must follow this exact shape — do not invent new field names.**
+The web frontend reads these fields directly; a wrong key silently breaks pages.
+
+```json
+{
+  "brand": "Brand Display Name",
+  "brand_id": "brand-id",
+  "status": "verified",
+  "default_port": 554,
+  "templates": [
+    {
+      "stream": "main",
+      "path": "/the/rtsp/path",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "https://official-doc-url — description",
+      "strix_lead": "manual:brand-id"
+    },
+    {
+      "stream": "sub",
+      "path": "/the/sub/path",
+      "codec": "H.264|H.265",
+      "verified": true,
+      "source": "https://official-doc-url — description",
+      "strix_lead": "manual:brand-id"
+    }
+  ],
+  "notes": "Optional free-text notes.",
+  "verified_on": "YYYY-MM-DD"
+}
+```
+
+**Rules:**
+- `brand` — human display name (e.g. `"Hikvision"`, `"TP-Link VIGI"`). **Required.**
+- `brand_id` — kebab-case, matches the filename (e.g. `"hikvision"`).
+- `default_port` — integer, usually `554`. **Not** `port`.
+- `templates[].stream` — `"main"` / `"sub"` / `"third"`. **Not** `label` or `subtype`.
+- `templates[].path` — just the URL path starting with `/` (e.g. `"/Streaming/Channels/101"`). **Not** a full URL with credentials.
+- `templates[].source` — the official doc URL. Per-template (not top-level).
+- `templates[].strix_lead` — `"manual:<brand-id>"` when hand-verified from docs.
+- `templates[].verified` — always `true` for confirmed paths.
+
+For unverified brands use `"status": "unverified"` and `"templates": []`.
+`codec` is optional but fill it when the doc specifies.


### PR DESCRIPTION
Documents the canonical JSON schema that all future `strix/verified/<brand>.json` files must follow. Waves 3–5 used a different shape (`label`/`url`/`subtype`/`port`) which broke the web frontend and required a normalizer patch — this prevents recurrence.