### PR TITLE
data: add i-PRO network cameras (batch 2, 60 models)

### DIFF
--- a/cameras/i-pro/wv-s65340-z2n1.json
+++ b/cameras/i-pro/wv-s65340-z2n1.json
@@ -1,0 +1,97 @@
+{
+  "id": "i-pro-wv-s65340-z2n1",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z2N1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.07,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "AI motion detection",
+    "auto-tracking",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "occupancy detection",
+    "scene change detection",
+    "privacy guard",
+    "21x optical zoom",
+    "256 preset positions",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "ClearSight Coating"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n1"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z4.json
+++ b/cameras/i-pro/wv-s65340-z4.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-s65340-z4",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z4",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.1-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.001,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "power": {
+    "method": "AC 24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI autotracking",
+    "360° endless pan",
+    "Super Dynamic 144dB WDR",
+    "Image stabilizer",
+    "FIPS 140-2 Level 3",
+    "256 preset positions",
+    "Motion detection",
+    "Face/people/vehicle detection",
+    "Privacy guard"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z4g.json
+++ b/cameras/i-pro/wv-s65340-z4g.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-s65340-z4g",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z4G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.1-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.017,
+    "min_lux_color": 0.03
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "AC24V or PoE++ (IEEE 802.3bt)",
+    "consumption_w": 50.84
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI auto-tracking",
+    "Super Dynamic 144dB HDR",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4g"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z4k.json
+++ b/cameras/i-pro/wv-s65340-z4k.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-s65340-z4k",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z4K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.07,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.1-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI auto-tracking",
+    "Privacy guard",
+    "Face detection",
+    "Vehicle detection",
+    "144dB Super Dynamic WDR",
+    "40x optical zoom",
+    "360° endless pan",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "Salt damage resistant (ISO 14993)"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4k"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z4n.json
+++ b/cameras/i-pro/wv-s65340-z4n.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-s65340-z4n",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z4N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.1-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI auto-tracking",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "privacy guard",
+    "Super Dynamic WDR (144dB)",
+    "FIPS 140-2 Level 3 secure element"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z4n1.json
+++ b/cameras/i-pro/wv-s65340-z4n1.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s65340-z4n1",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z4N1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true
+  },
+  "field_of_view_deg": "65 (wide) – 2.1 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "PoE++ / PoE+ / AC24V",
+    "consumption_w": 50.84
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s65501-z1.json
+++ b/cameras/i-pro/wv-s65501-z1.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s65501-z1",
+  "brand": "i-PRO",
+  "model": "WV-S65501-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true
+  },
+  "field_of_view_deg": "6.2-58",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.06,
+    "min_lux_color": 0.08
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+    "consumption_w": 18.9
+  },
+  "power_source": [
+    "dc",
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s65501-z1g.json
+++ b/cameras/i-pro/wv-s65501-z1g.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-s65501-z1g",
+  "brand": "i-PRO",
+  "model": "WV-S65501-Z1G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true
+  },
+  "field_of_view_deg": "58 (wide) - 6.2 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.18,
+    "min_lux_color": 0.32
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE / PoE+ / DC12V",
+    "consumption_w": 18.9
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "10x optical zoom",
+    "motorized zoom",
+    "motorized focus",
+    "PoE+",
+    "two-way audio",
+    "microSD 512GB"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1g"
+  ]
+}

--- a/cameras/i-pro/wv-s66300-z3.json
+++ b/cameras/i-pro/wv-s66300-z3.json
@@ -1,0 +1,78 @@
+{
+  "id": "i-pro-wv-s66300-z3",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3"
+  ]
+}

--- a/cameras/i-pro/wv-s66300-z3l.json
+++ b/cameras/i-pro/wv-s66300-z3l.json
@@ -1,0 +1,80 @@
+{
+  "id": "i-pro-wv-s66300-z3l",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z3L",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.4-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 250,
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 45.9
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3l"
+  ],
+  "release_year": 2023
+}

--- a/cameras/i-pro/wv-s66300-z3ln.json
+++ b/cameras/i-pro/wv-s66300-z3ln.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s66300-z3ln",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z3LN",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.4-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 350,
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3ln"
+  ]
+}

--- a/cameras/i-pro/wv-s66300-z3n.json
+++ b/cameras/i-pro/wv-s66300-z3n.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-s66300-z3n",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z3N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "32x optical zoom",
+    "AI analytics",
+    "motion detection",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "ONVIF Profile G/M/S/T",
+    "FIPS 140-2 Level 3 SecureElement",
+    "360° endless pan",
+    "256 preset positions",
+    "wind resistance up to 40 m/s"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3n"
+  ]
+}

--- a/cameras/i-pro/wv-s66300-z4.json
+++ b/cameras/i-pro/wv-s66300-z4.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s66300-z4",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z4",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "65 (Wide) – 2.0 (Tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI analytics",
+    "image stabilizer",
+    "256 preset positions",
+    "ONVIF Profile G/M/S/T",
+    "FIPS 140-2 Level 3"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s66300-z4l.json
+++ b/cameras/i-pro/wv-s66300-z4l.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-s66300-z4l",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z4L",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.0-65 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 250,
+    "min_lux_color": 0.015
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE 802.3at)"
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI engine",
+    "IR LED",
+    "motorized zoom",
+    "vandal resistant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "release_year": 2023,
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4l"
+  ]
+}

--- a/cameras/i-pro/wv-s66300-z4ln.json
+++ b/cameras/i-pro/wv-s66300-z4ln.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-s66300-z4ln",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z4LN",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.0-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.011,
+    "range_m": 350
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI auto tracking",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3 SecureElement",
+    "Edge AI analytics",
+    "Image stabilization",
+    "360° endless pan",
+    "256 presets",
+    "144dB dynamic range",
+    "Up to 32 privacy zones"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4ln"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s66300-z4n.json
+++ b/cameras/i-pro/wv-s66300-z4n.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-s66300-z4n",
+  "brand": "i-PRO",
+  "model": "WV-S66300-Z4N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true
+  },
+  "field_of_view_deg": "65 (wide) – 2.0 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "motorized zoom",
+    "motorized focus",
+    "60x extra zoom",
+    "PTZ"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4n"
+  ]
+}

--- a/cameras/i-pro/wv-s66600-z3.json
+++ b/cameras/i-pro/wv-s66600-z3.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-s66600-z3",
+  "brand": "i-PRO",
+  "model": "WV-S66600-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.012
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "AI engine",
+    "360° endless pan",
+    "motorized zoom",
+    "low-light"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3"
+  ]
+}

--- a/cameras/i-pro/wv-s66600-z3l.json
+++ b/cameras/i-pro/wv-s66600-z3l.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s66600-z3l",
+  "brand": "i-PRO",
+  "model": "WV-S66600-Z3L",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.13,
+    "range_m": 200
+  },
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3l"
+  ],
+  "features": [
+    "30x optical zoom",
+    "AI engine",
+    "Rapid PTZ",
+    "ONVIF Profile G/M/S/T",
+    "IR illuminator",
+    "PoE++"
+  ]
+}

--- a/cameras/i-pro/wv-s66600-z3ln.json
+++ b/cameras/i-pro/wv-s66600-z3ln.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-s66600-z3ln",
+  "brand": "i-PRO",
+  "model": "WV-S66600-Z3LN",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.13,
+    "range_m": 280
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / DC 54V",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "IR illumination",
+    "AI engine",
+    "edge AI applications",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "High speed PTZ (Pan: 700deg/s, Tilt: 500deg/s)",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s66600-z3n.json
+++ b/cameras/i-pro/wv-s66600-z3n.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-s66600-z3n",
+  "brand": "i-PRO",
+  "model": "WV-S66600-Z3N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "360° endless pan",
+    "AI analytics",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "occupancy detection",
+    "privacy guard",
+    "132dB Super Dynamic WDR",
+    "FIPS 140-2 Level 3 security"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3n"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s66700-z3.json
+++ b/cameras/i-pro/wv-s66700-z3.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s66700-z3",
+  "brand": "i-PRO",
+  "model": "WV-S66700-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "features": [
+    "30x optical zoom",
+    "AI engine",
+    "4K",
+    "motorized zoom",
+    "motorized focus",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3"
+  ]
+}

--- a/cameras/i-pro/wv-s66700-z3l.json
+++ b/cameras/i-pro/wv-s66700-z3l.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-s66700-z3l",
+  "brand": "i-PRO",
+  "model": "WV-S66700-Z3L",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.13,
+    "range_m": 200
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) or DC 54V",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "features": [
+    "Edge AI analytics",
+    "256 preset positions",
+    "30x optical zoom",
+    "motorized zoom/focus",
+    "ONVIF Profile G/M/S/T",
+    "IR LED 200m"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3l"
+  ]
+}

--- a/cameras/i-pro/wv-s66700-z3ln.json
+++ b/cameras/i-pro/wv-s66700-z3ln.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-s66700-z3ln",
+  "brand": "i-PRO",
+  "model": "WV-S66700-Z3LN",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "62-2.5",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 200,
+    "min_lux_color": 0.13
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "IR LEDs",
+    "AI analytics",
+    "motion detection",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "privacy guard",
+    "256 preset positions",
+    "360° endless pan",
+    "super dynamic 132dB WDR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s66700-z3n.json
+++ b/cameras/i-pro/wv-s66700-z3n.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-s66700-z3n",
+  "brand": "i-PRO",
+  "model": "WV-S66700-Z3N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / DC 54V",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "AI auto tracking",
+    "360° endless pan",
+    "FIPS 140-2 Level 3 SecureElement",
+    "Super Dynamic 132dB WDR",
+    "Edge AI analytics"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3n"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66300-z3k.json
+++ b/cameras/i-pro/wv-x66300-z3k.json
@@ -1,0 +1,95 @@
+{
+  "id": "i-pro-wv-x66300-z3k",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z3K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "65 (wide) - 2.4 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "32x optical zoom",
+    "AI auto-tracking",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "occupancy detection",
+    "video motion detection",
+    "edge AI analytics",
+    "FIPS 140-2 level 3",
+    "NDAA compliant",
+    "360° endless pan",
+    "GOP control"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3k"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66300-z3lk.json
+++ b/cameras/i-pro/wv-x66300-z3lk.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-x66300-z3lk",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z3LK",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "65 (wide) to 2.4 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.011,
+    "range_m": 250
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "32x optical zoom",
+    "48x extra zoom",
+    "AI auto tracking",
+    "256 presets",
+    "360° endless pan",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3",
+    "Heavy salt damage resistance",
+    "Face/people/vehicle detection",
+    "Occupancy detection",
+    "Scene change detection"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3lk"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66300-z3ls.json
+++ b/cameras/i-pro/wv-x66300-z3ls.json
@@ -1,0 +1,78 @@
+{
+  "id": "i-pro-wv-x66300-z3ls",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z3LS",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.4-65 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 250,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3ls"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x66300-z3s.json
+++ b/cameras/i-pro/wv-x66300-z3s.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x66300-z3s",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z3S",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-136",
+    "aperture": "F1.6-F4.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.4-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "32x optical zoom",
+    "AI engine",
+    "IP66",
+    "IK10",
+    "salt-resistant (ISO 14993)",
+    "ONVIF Profile G/M/S/T",
+    "PoE++"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3s"
+  ]
+}

--- a/cameras/i-pro/wv-x66300-z4k.json
+++ b/cameras/i-pro/wv-x66300-z4k.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-x66300-z4k",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z4K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.0-65",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "features": [
+    "40x optical zoom",
+    "60x extra zoom",
+    "360° endless pan",
+    "ONVIF Profile G/M/S/T",
+    "Super resolution (2048x1536 via upscaling)"
+  ],
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4k"
+  ]
+}

--- a/cameras/i-pro/wv-x66300-z4lk.json
+++ b/cameras/i-pro/wv-x66300-z4lk.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-x66300-z4lk",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z4LK",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.0-65 (H, 16:9)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011,
+    "range_m": 350
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (54V, 45.9W) or PoE+ (54V, 25.4W)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "IR illumination",
+    "ONVIF Profile G/M/S/T",
+    "MQTT",
+    "microSDXC up to 512GB"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4lk"
+  ]
+}

--- a/cameras/i-pro/wv-x66300-z4ls.json
+++ b/cameras/i-pro/wv-x66300-z4ls.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-x66300-z4ls",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z4LS",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "65 (Wide) – 2.0 (Tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.011,
+    "range_m": 350
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "features": [
+    "40x optical zoom",
+    "IR illumination",
+    "AI analytics",
+    "ONVIF Profile G/M/S/T",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "H.265 SD recording"
+  ],
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4ls"
+  ]
+}

--- a/cameras/i-pro/wv-x66300-z4s.json
+++ b/cameras/i-pro/wv-x66300-z4s.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-x66300-z4s",
+  "brand": "i-PRO",
+  "model": "WV-X66300-Z4S",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true
+  },
+  "field_of_view_deg": "65 (wide) - 2.0 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++/PoE+",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "60x extra zoom",
+    "360° endless pan",
+    "AI analytics",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "AI sound classification",
+    "FIPS 140-2 level 3 encryption",
+    "NDAA compliant",
+    "salt damage resistance",
+    "wind resistance up to 40m/s",
+    "256 preset positions",
+    "Super Dynamic 144dB WDR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4s"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x66600-z3k.json
+++ b/cameras/i-pro/wv-x66600-z3k.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x66600-z3k",
+  "brand": "i-PRO",
+  "model": "WV-X66600-Z3K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI Video Motion Detection",
+    "AI Privacy Guard",
+    "AI Face Detection",
+    "AI People Detection",
+    "AI Vehicle Detection",
+    "AI Occupancy Detection",
+    "30x optical zoom",
+    "360° endless panning",
+    "FIPS 140-2 Level 3 security",
+    "Up to 32 privacy zones"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3k"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x66600-z3lk.json
+++ b/cameras/i-pro/wv-x66600-z3lk.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x66600-z3lk",
+  "brand": "i-PRO",
+  "model": "WV-X66600-Z3LK",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.13,
+    "range_m": 200
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) or DC 54V",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "30x optical zoom",
+    "AI auto-tracking",
+    "Edge AI applications",
+    "360° endless pan",
+    "FIPS 140-2 level 3 security"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3lk"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66600-z3ls.json
+++ b/cameras/i-pro/wv-x66600-z3ls.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-x66600-z3ls",
+  "brand": "i-PRO",
+  "model": "WV-X66600-Z3LS",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 280,
+    "min_lux": 0.006,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "motorized zoom",
+    "motorized focus",
+    "IR LEDs",
+    "PTZ",
+    "PoE++"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3ls"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x66600-z3s.json
+++ b/cameras/i-pro/wv-x66600-z3s.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x66600-z3s",
+  "brand": "i-PRO",
+  "model": "WV-X66600-Z3S",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "62-2.5",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "features": [
+    "30x optical zoom",
+    "AI analytics",
+    "360° pan",
+    "256 presets",
+    "Privacy guard",
+    "Face detection",
+    "People detection",
+    "Vehicle detection",
+    "Motion detection"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3s"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x66700-z3k.json
+++ b/cameras/i-pro/wv-x66700-z3k.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-x66700-z3k",
+  "brand": "i-PRO",
+  "model": "WV-X66700-Z3K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.29,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62-2.5",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) or DC 54V",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "30x optical zoom",
+    "AI auto-tracking",
+    "360° endless pan",
+    "256 preset positions",
+    "Edge AI analytics (up to 3 apps)",
+    "FIPS 140-2 Level 3 security",
+    "NDAA compliant",
+    "Heavy salt damage resistance (ISO 14993)"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3k"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66700-z3lk.json
+++ b/cameras/i-pro/wv-x66700-z3lk.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x66700-z3lk",
+  "brand": "i-PRO",
+  "model": "WV-X66700-Z3LK",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62-2.5 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13,
+    "range_m": 280
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) or DC 54V",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI engine",
+    "30x optical zoom",
+    "heavy salt damage resistance",
+    "IR LED 280m",
+    "autotracking"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3lk"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x66700-z3ls.json
+++ b/cameras/i-pro/wv-x66700-z3ls.json
@@ -1,0 +1,95 @@
+{
+  "id": "i-pro-wv-x66700-z3ls",
+  "brand": "i-PRO",
+  "model": "WV-X66700-Z3LS",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13,
+    "range_m": 200
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt)",
+    "consumption_w": 45.9
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "IR",
+    "PTZ",
+    "30x optical zoom",
+    "AI analytics",
+    "motion detection",
+    "face detection",
+    "vehicle detection",
+    "people detection",
+    "occupancy detection",
+    "scene change detection",
+    "gunshot detection",
+    "privacy guard",
+    "FIPS 140-2 level 3",
+    "salt resistance"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3ls"
+  ]
+}

--- a/cameras/i-pro/wv-x66700-z3s.json
+++ b/cameras/i-pro/wv-x66700-z3s.json
@@ -1,0 +1,80 @@
+{
+  "id": "i-pro-wv-x66700-z3s",
+  "brand": "i-PRO",
+  "model": "WV-X66700-Z3S",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.29,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (WIDE) – 2.5 (TELE)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt) / DC 54V",
+    "consumption_w": 37.8
+  },
+  "power_source": [
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3s"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67300-z4-3.json
+++ b/cameras/i-pro/wv-x67300-z4-3.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-x67300-z4-3",
+  "brand": "i-PRO",
+  "model": "WV-X67300-Z4-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "f/1.6-4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.001,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (802.3bt) or AC 100-240V",
+    "consumption_w": 54
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "360° endless pan",
+    "H.265",
+    "IP68",
+    "IK10",
+    "ONVIF Profile M/S/T",
+    "PoE++"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4-3"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67300-z4l3.json
+++ b/cameras/i-pro/wv-x67300-z4l3.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x67300-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67300-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.011,
+    "range_m": 560
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt Type4 Class 8) or AC 100-240V",
+    "consumption_w": 78.9
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "40x-640x digital zoom",
+    "Built-in wiper",
+    "Auto defroster",
+    "Edge AI (2 apps)",
+    "FIPS 140-2 security",
+    "Auto tracking"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4l3"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67300a-z4-3.json
+++ b/cameras/i-pro/wv-x67300a-z4-3.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-x67300a-z4-3",
+  "brand": "i-PRO",
+  "model": "WV-X67300A-Z4-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.07,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) or AC 100-240V",
+    "consumption_w": 54
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": true,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "AI autotracking",
+    "256 preset positions",
+    "built-in wiper",
+    "auto defroster",
+    "FIPS 140-3 Level 3",
+    "NDAA compliant",
+    "ONVIF Profile S/T/M"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4-3"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67300a-z4l3.json
+++ b/cameras/i-pro/wv-x67300a-z4l3.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-x67300a-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67300A-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.011,
+    "range_m": 560
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "AC 100-240V or PoE++ (802.3bt Class 8 / Class 6)",
+    "consumption_w": 78.9
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "features": [
+    "40x optical zoom",
+    "IR LED",
+    "AI",
+    "PoE++",
+    "MQTT",
+    "HTTPS",
+    "H.265",
+    "rugged"
+  ],
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67301-z4l3.json
+++ b/cameras/i-pro/wv-x67301-z4l3.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-x67301-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67301-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "range_m": 280
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "power": {
+    "method": "PoE++ (Type 4 Class 8 / Type 3 Class 6) or AC 100-240V",
+    "consumption_w": 70.2
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "360° endless pan",
+    "256 preset positions",
+    "built-in wiper",
+    "auto-defroster",
+    "white LED illuminator",
+    "AI sound classification",
+    "Edge AI analytics",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3 SecureElement",
+    "MIL-STD-810-H compliant",
+    "wind resistance up to 75 m/s",
+    "corrosion resistant ISO14993"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "release_year": 2024,
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67301a-z4l3.json
+++ b/cameras/i-pro/wv-x67301a-z4l3.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x67301a-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67301A-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6",
+    "varifocal": true
+  },
+  "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011,
+    "range_m": 280
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (802.3bt Type 4 Class 8, 90W) or AC 100-240V",
+    "consumption_w": 70.2
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "white LED illumination",
+    "280m illumination range",
+    "IP68/IP66",
+    "IK10",
+    "PoE++ Type4"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301a-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67310-z4-1.json
+++ b/cameras/i-pro/wv-x67310-z4-1.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-x67310-z4-1",
+  "brand": "i-PRO",
+  "model": "WV-X67310-Z4-1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt Type 4) or 24V AC/DC",
+    "consumption_w": 54
+  },
+  "power_source": [
+    "poe",
+    "dc",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 1024,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "40x optical zoom",
+    "40x digital zoom",
+    "256 presets",
+    "image stabilizer",
+    "gyro sensor",
+    "built-in wiper",
+    "auto-defroster",
+    "edge AI analytics",
+    "NDAA compliant",
+    "FIPS 140-2 level 3",
+    "ONVIF Profile M/S/T",
+    "privacy guard"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67310-z4-3.json
+++ b/cameras/i-pro/wv-x67310-z4-3.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x67310-z4-3",
+  "brand": "i-PRO",
+  "model": "WV-X67310-Z4-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "24V AC/DC or PoE++ (90W Type 4 / 60W Type 3)",
+    "consumption_w": 61
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": false,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI auto-tracking",
+    "built-in wiper",
+    "auto defroster",
+    "wind resistance 90m/s",
+    "H.265 encoding"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-3"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67310-z4l1.json
+++ b/cameras/i-pro/wv-x67310-z4l1.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x67310-z4l1",
+  "brand": "i-PRO",
+  "model": "WV-X67310-Z4L1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "66 (horizontal, wide end)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 560,
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (Type 4 Class 8) / 24V AC / 24V DC",
+    "consumption_w": 78.7
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "360° endless pan",
+    "AI",
+    "IR illuminator",
+    "two-way audio",
+    "ONVIF Profile S/T/M",
+    "MQTT"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l1"
+  ]
+}

--- a/cameras/i-pro/wv-x67310-z4l3.json
+++ b/cameras/i-pro/wv-x67310-z4l3.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x67310-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67310-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 560,
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (802.3bt Type 3/Type 4) or 24V AC/DC",
+    "consumption_w": 79.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "IR LEDs",
+    "AI analytics",
+    "built-in wiper",
+    "auto defroster",
+    "edge AI (2 slots)",
+    "MQTT",
+    "half/full duplex audio"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l3"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67310a-z4-1.json
+++ b/cameras/i-pro/wv-x67310a-z4-1.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-x67310a-z4-1",
+  "brand": "i-PRO",
+  "model": "WV-X67310A-Z4-1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt Type4), 24V AC, 24V DC",
+    "consumption_w": 61
+  },
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "PTZ",
+    "IP68/IP66",
+    "IK10"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67310a-z4-3.json
+++ b/cameras/i-pro/wv-x67310a-z4-3.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x67310a-z4-3",
+  "brand": "i-PRO",
+  "model": "WV-X67310A-Z4-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "24V AC / 24V DC / PoE++ (90W)",
+    "consumption_w": 61
+  },
+  "power_source": [
+    "poe",
+    "dc",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "IP68/IP66",
+    "IK10",
+    "360° endless pan",
+    "built-in wiper",
+    "auto defroster",
+    "FIPS 140-3 Level 3",
+    "NDAA compliant",
+    "AI"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-3"
+  ]
+}

--- a/cameras/i-pro/wv-x67310a-z4l1.json
+++ b/cameras/i-pro/wv-x67310a-z4l1.json
@@ -1,0 +1,96 @@
+{
+  "id": "i-pro-wv-x67310a-z4l1",
+  "brand": "i-PRO",
+  "model": "WV-X67310A-Z4L1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 560,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ Type4 Class 8 / PoE++ Type3 Class 6 / 24V AC/DC",
+    "consumption_w": 70.2
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "40x optical zoom",
+    "AI auto-tracking",
+    "360° endless pan",
+    "AI video motion detection",
+    "face/people/vehicle detection",
+    "built-in wiper",
+    "auto defroster",
+    "256 presets",
+    "4 simultaneous streams",
+    "FIPS 140-3 level 3 security",
+    "32 privacy zones",
+    "wind resistance up to 75 m/s"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l1"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67310a-z4l3.json
+++ b/cameras/i-pro/wv-x67310a-z4l3.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-x67310a-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67310A-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.011,
+    "range_m": 560
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE++ (802.3bt Type 4 Class 8 / Type 3 Class 6), 24V AC, 24V DC",
+    "consumption_w": 70.2
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "640x digital zoom",
+    "IR illumination up to 560m",
+    "built-in wiper",
+    "auto defroster",
+    "gyro-stabilization",
+    "256 preset positions",
+    "360° endless pan",
+    "AI analytics (2 edge AI apps)",
+    "FIPS 140-3 Level 3",
+    "NDAA compliant",
+    "4 VMD zones",
+    "32 privacy zones"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67311-z4l3.json
+++ b/cameras/i-pro/wv-x67311-z4l3.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x67311-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67311-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "range_m": 280
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++ (IEEE802.3bt Type4 Class 8) / 24V AC / 24V DC",
+    "consumption_w": 79.2
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "audio": {
+    "microphone": false,
+    "speaker": false,
+    "two_way": false
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "40x optical zoom",
+    "White LED illumination",
+    "ONVIF Profile M/S/T",
+    "4 simultaneous streams",
+    "Pan-Tilt-Zoom",
+    "Color night vision"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67311a-z4l3.json
+++ b/cameras/i-pro/wv-x67311a-z4l3.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x67311a-z4l3",
+  "brand": "i-PRO",
+  "model": "WV-X67311A-Z4L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.07,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-F4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "range_m": 280,
+    "min_lux": 0.006
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "24V AC / 24V DC / PoE++ (IEEE802.3bt Type4 Class 8)",
+    "consumption_w": 78.7
+  },
+  "power_source": [
+    "poe",
+    "ac-mains",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "features": [
+    "40x optical zoom",
+    "white LED illumination",
+    "ONVIF Profile M/S/T",
+    "pan-tilt-zoom",
+    "IP68/IP66",
+    "IK10"
+  ],
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311a-z4l3"
+  ]
+}

--- a/cameras/i-pro/wv-x67700-z3-3.json
+++ b/cameras/i-pro/wv-x67700-z3-3.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x67700-z3-3",
+  "brand": "i-PRO",
+  "model": "WV-X67700-Z3-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "AC 100-240V or PoE++",
+    "consumption_w": 61.4
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "360° endless pan",
+    "256 preset positions",
+    "built-in wiper",
+    "auto-defroster",
+    "edge AI analytics",
+    "FIPS 140-2 Level 3",
+    "ONVIF Profile M/S/T",
+    "wind resistance up to 90 m/s"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3-3"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x67700-z3l3.json
+++ b/cameras/i-pro/wv-x67700-z3l3.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x67700-z3l3",
+  "brand": "i-PRO",
+  "model": "WV-X67700-Z3L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13,
+    "range_m": 350
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE++ (802.3bt) or AC 100-240V",
+    "consumption_w": 70.2
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "IR illumination",
+    "30x optical zoom",
+    "4K AI",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "autotracking"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3l3"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67700a-z3-3.json
+++ b/cameras/i-pro/wv-x67700a-z3-3.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-x67700a-z3-3",
+  "brand": "i-PRO",
+  "model": "WV-X67700A-Z3-3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (H, wide end)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "AC 100-240V / PoE++",
+    "consumption_w": 61.4
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": false,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "auto-tracking",
+    "30x optical zoom",
+    "360° endless pan",
+    "AI",
+    "wind resistance up to 270km/h",
+    "ONVIF Profile M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3-3"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-x67700a-z3l3.json
+++ b/cameras/i-pro/wv-x67700a-z3l3.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-x67700a-z3l3",
+  "brand": "i-PRO",
+  "model": "WV-X67700A-Z3L3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "2.5-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.13,
+    "range_m": 350
+  },
+  "ip_rating": "IP68",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE802.3bt Type4 Class8 / Type3 Class6) or AC 100-240V",
+    "consumption_w": 78.9
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "480x digital zoom",
+    "AI analytics",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "occupancy analytics",
+    "privacy guard",
+    "4 simultaneous streams",
+    "wind resistance 90m/s"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3l3"
+  ]
+}

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -2010,12 +2010,72 @@ i-pro-wv-s22500-v3l,i-PRO,WV-S22500-V3L,dome,5MP,5,"1/2.8"" CMOS","105-33 horizo
 i-pro-wv-s25500-v3l,i-PRO,WV-S25500-V3L,dome,5MP,5,"1/2.8"" CMOS","103-33 horizontal, 55-19 vertical",hybrid,IP66,IK10,true,2022
 i-pro-wv-s25700-v2l,i-PRO,WV-S25700-V2L,dome,4K,8.3,"1/1.8"" CMOS","101-52 horizontal, 55-29 vertical",hybrid,IP66,IK10,true,2022
 i-pro-wv-s6532ln,i-PRO,WV-S6532LN,ptz,1080p,2,"1/2.8"" CMOS",66-3.4 horizontal,hybrid,IP66,IK10,true,2022
+i-pro-wv-s65340-z2n1,i-PRO,WV-S65340-Z2N1,ptz,1080p,2.07,"1/2.8"" CMOS",77 (wide) to 3.7 (tele),color,IP66,IK10,true,
+i-pro-wv-s65340-z4,i-PRO,WV-S65340-Z4,ptz,1080p,2,"1/2.8"" CMOS",2.1-65,color,IP66,IK10,true,
+i-pro-wv-s65340-z4g,i-PRO,WV-S65340-Z4G,ptz,1080p,2,"1/2.8"" CMOS",2.1-65,color,IP66,IK10,true,
+i-pro-wv-s65340-z4k,i-PRO,WV-S65340-Z4K,ptz,1080p,2.07,"1/2.8"" CMOS",2.1-65,color,IP66,IK10,true,
+i-pro-wv-s65340-z4n,i-PRO,WV-S65340-Z4N,ptz,1080p,2,"1/2.8"" CMOS",2.1-65,color,IP66,IK10,true,
+i-pro-wv-s65340-z4n1,i-PRO,WV-S65340-Z4N1,ptz,1080p,2,"1/2.8"" CMOS",65 (wide) – 2.1 (tele),ir,IP66,IK10,true,
+i-pro-wv-s65501-z1,i-PRO,WV-S65501-Z1,ptz,5MP,5,"1/2.8"" CMOS",6.2-58,none,IP66,IK10,false,
+i-pro-wv-s65501-z1g,i-PRO,WV-S65501-Z1G,ptz,5MP,5,"1/2.8"" CMOS",58 (wide) - 6.2 (tele),none,IP66,IK10,true,
+i-pro-wv-s66300-z3,i-PRO,WV-S66300-Z3,ptz,1080p,2.1,"1/2.8"" CMOS",65 (wide) – 2.4 (tele),none,IP66,IK10,true,
+i-pro-wv-s66300-z3l,i-PRO,WV-S66300-Z3L,ptz,1080p,2.1,"1/2.8"" CMOS",2.4-65,ir,IP66,IK10,true,2023
+i-pro-wv-s66300-z3ln,i-PRO,WV-S66300-Z3LN,ptz,1080p,2,"1/2.8"" CMOS",2.4-65,ir,IP66,IK10,true,
+i-pro-wv-s66300-z3n,i-PRO,WV-S66300-Z3N,ptz,1080p,2,"1/2.8"" CMOS",65 (wide) – 2.4 (tele),color,IP66,IK10,true,
+i-pro-wv-s66300-z4,i-PRO,WV-S66300-Z4,ptz,1080p,2.1,"1/2.8"" CMOS",65 (Wide) – 2.0 (Tele) horizontal,color,IP66,IK10,true,
+i-pro-wv-s66300-z4l,i-PRO,WV-S66300-Z4L,ptz,1080p,2,"1/2.8"" CMOS",2.0-65 (H),ir,IP66,IK10,true,2023
+i-pro-wv-s66300-z4ln,i-PRO,WV-S66300-Z4LN,ptz,1080p,2.1,"1/2.8"" CMOS",2.0-65,ir,IP66,IK10,true,
+i-pro-wv-s66300-z4n,i-PRO,WV-S66300-Z4N,ptz,1080p,2.1,"1/2.8"" CMOS",65 (wide) – 2.0 (tele),none,IP66,IK10,true,
+i-pro-wv-s66600-z3,i-PRO,WV-S66600-Z3,ptz,6MP,6.2,"1/2.8"" CMOS",2.5-62,color,IP66,IK10,true,
+i-pro-wv-s66600-z3l,i-PRO,WV-S66600-Z3L,ptz,6MP,6,"1/2.8"" CMOS",2.5-62 (H),ir,IP66,IK10,true,
+i-pro-wv-s66600-z3ln,i-PRO,WV-S66600-Z3LN,ptz,6MP,6,"1/2.8"" CMOS",2.5-62,ir,IP66,IK10,true,
+i-pro-wv-s66600-z3n,i-PRO,WV-S66600-Z3N,ptz,6MP,6,"1/2.8"" CMOS",2.5-62,none,IP66,IK10,true,
+i-pro-wv-s66700-z3,i-PRO,WV-S66700-Z3,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62 (H),color,IP66,IK10,true,
+i-pro-wv-s66700-z3l,i-PRO,WV-S66700-Z3L,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62,ir,IP66,IK10,false,
+i-pro-wv-s66700-z3ln,i-PRO,WV-S66700-Z3LN,ptz,4K,8.3,"1/2.8"" CMOS",62-2.5,ir,IP66,IK10,true,
+i-pro-wv-s66700-z3n,i-PRO,WV-S66700-Z3N,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62,color,IP66,IK10,true,
 i-pro-wv-s8530n,i-PRO,WV-S8530N,dome,4K UHD,8,"1/1.7"" CMOS",92-31 horizontal,color,IP66,,false,2022
 i-pro-wv-s8574l,i-PRO,WV-S8574L,panoramic,"4x 4K per sensor (~33MP total, 4-sensor)",8,"4 x 1/2.8"" CMOS (four independently steerable sensors)","108 horizontal, 56 vertical (per sensor); 360 total coverage",hybrid,IP66/IP67,IK10,true,2023
 i-pro-wv-u2532la,i-PRO,WV-U2532LA,dome,1080p,2,"1/3"" CMOS","42-97 horizontal, 23-54 vertical",hybrid,IP66,IK10,false,2022
 i-pro-wv-x22300-v3l,i-PRO,WV-X22300-V3L,dome,1080p,2,"1/2.8"" CMOS",36 (tele) - 114 (wide) horizontal / 20 - 60 vertical,ir,,IK10,true,2023
 i-pro-wv-x2251l,i-PRO,WV-X2251L,dome,5MP,5,"1/2.3"" CMOS",99-42 horizontal,ir,IP66,,false,2023
 i-pro-wv-x2571ln,i-PRO,WV-X2571LN,dome,4K,8.3,"1/1.8"" CMOS","101-52 horizontal, 55-29 vertical",hybrid,IP66,IK10,true,
+i-pro-wv-x66300-z3k,i-PRO,WV-X66300-Z3K,ptz,1080p,2.1,"1/2.8"" CMOS",65 (wide) - 2.4 (tele),color,IP66,IK10,true,
+i-pro-wv-x66300-z3lk,i-PRO,WV-X66300-Z3LK,ptz,1080p,2,"1/2.8"" CMOS",65 (wide) to 2.4 (tele),ir,IP66,IK10,true,
+i-pro-wv-x66300-z3ls,i-PRO,WV-X66300-Z3LS,ptz,1080p,2.1,"1/2.8"" CMOS",2.4-65 (H),ir,IP66,IK10,true,
+i-pro-wv-x66300-z3s,i-PRO,WV-X66300-Z3S,ptz,1080p,2,"1/2.8"" CMOS",2.4-65,none,IP66,IK10,true,
+i-pro-wv-x66300-z4k,i-PRO,WV-X66300-Z4K,ptz,1080p,2,"1/2.8"" CMOS",2.0-65,color,IP66,IK10,true,
+i-pro-wv-x66300-z4lk,i-PRO,WV-X66300-Z4LK,ptz,1080p,2.1,"1/2.8"" CMOS","2.0-65 (H, 16:9)",ir,IP66,IK10,true,
+i-pro-wv-x66300-z4ls,i-PRO,WV-X66300-Z4LS,ptz,1080p,2,"1/2.8"" CMOS",65 (Wide) – 2.0 (Tele),ir,IP66,IK10,true,
+i-pro-wv-x66300-z4s,i-PRO,WV-X66300-Z4S,ptz,1080p,2.1,"1/2.8"" CMOS",65 (wide) - 2.0 (tele),color,IP66,IK10,true,
+i-pro-wv-x66600-z3k,i-PRO,WV-X66600-Z3K,ptz,6MP,6.2,"1/2.8"" CMOS",2.5-62,color,IP66,IK10,true,
+i-pro-wv-x66600-z3lk,i-PRO,WV-X66600-Z3LK,ptz,6MP,6.2,"1/2.8"" CMOS",62 (wide) - 2.5 (tele),ir,IP66,IK10,false,
+i-pro-wv-x66600-z3ls,i-PRO,WV-X66600-Z3LS,ptz,6MP,6.2,"1/2.8"" CMOS",62 (wide) - 2.5 (tele),ir,IP66,IK10,true,
+i-pro-wv-x66600-z3s,i-PRO,WV-X66600-Z3S,ptz,6MP,6,"1/2.8"" CMOS",62-2.5,ir,IP66,IK10,true,
+i-pro-wv-x66700-z3k,i-PRO,WV-X66700-Z3K,ptz,4K,8.29,"1/2.8"" CMOS",62-2.5,ir,IP66,IK10,true,
+i-pro-wv-x66700-z3lk,i-PRO,WV-X66700-Z3LK,ptz,4K,8.3,"1/2.8"" CMOS",62-2.5 (H),ir,IP66,IK10,true,
+i-pro-wv-x66700-z3ls,i-PRO,WV-X66700-Z3LS,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62,ir,IP66,IK10,true,
+i-pro-wv-x66700-z3s,i-PRO,WV-X66700-Z3S,ptz,4K,8.29,"1/2.8"" CMOS",62 (WIDE) – 2.5 (TELE),none,IP66,IK10,true,
+i-pro-wv-x67300-z4-3,i-PRO,WV-X67300-Z4-3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66,none,IP68,IK10,true,
+i-pro-wv-x67300-z4l3,i-PRO,WV-X67300-Z4L3,ptz,1080p,2.1,"1/2.8"" CMOS",1.9-66,ir,IP68,IK10,true,
+i-pro-wv-x67300a-z4-3,i-PRO,WV-X67300A-Z4-3,ptz,1080p,2.07,"1/2.8"" CMOS",66 (wide) – 1.9 (tele),none,IP68,IK10,true,
+i-pro-wv-x67300a-z4l3,i-PRO,WV-X67300A-Z4L3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66 (H),ir,IP68,IK10,true,
+i-pro-wv-x67301-z4l3,i-PRO,WV-X67301-Z4L3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66,color,IP68,IK10,true,2024
+i-pro-wv-x67301a-z4l3,i-PRO,WV-X67301A-Z4L3,ptz,1080p,2,"1/2.8"" CMOS",66 (wide) – 1.9 (tele),color,IP68,IK10,true,
+i-pro-wv-x67310-z4-1,i-PRO,WV-X67310-Z4-1,ptz,1080p,2,"1/2.8"" CMOS",1.9-66,none,IP68,IK10,false,
+i-pro-wv-x67310-z4-3,i-PRO,WV-X67310-Z4-3,ptz,1080p,2.1,"1/2.8"" CMOS",66 (wide) – 1.9 (tele),color,IP68,IK10,true,
+i-pro-wv-x67310-z4l1,i-PRO,WV-X67310-Z4L1,ptz,1080p,2,"1/2.8"" CMOS","66 (horizontal, wide end)",ir,IP68,IK10,true,
+i-pro-wv-x67310-z4l3,i-PRO,WV-X67310-Z4L3,ptz,1080p,2.1,"1/2.8"" CMOS",1.9-66,ir,IP68,IK10,true,
+i-pro-wv-x67310a-z4-1,i-PRO,WV-X67310A-Z4-1,ptz,1080p,2.1,"1/2.8"" CMOS",1.9-66,none,IP68,IK10,false,
+i-pro-wv-x67310a-z4-3,i-PRO,WV-X67310A-Z4-3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66,color,IP68,IK10,true,
+i-pro-wv-x67310a-z4l1,i-PRO,WV-X67310A-Z4L1,ptz,1080p,2.1,"1/2.8"" CMOS",1.9-66,ir,IP68,IK10,true,
+i-pro-wv-x67310a-z4l3,i-PRO,WV-X67310A-Z4L3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66,ir,IP68,IK10,true,
+i-pro-wv-x67311-z4l3,i-PRO,WV-X67311-Z4L3,ptz,1080p,2,"1/2.8"" CMOS",1.9-66 (H),color,IP68,IK10,false,
+i-pro-wv-x67311a-z4l3,i-PRO,WV-X67311A-Z4L3,ptz,1080p,2.07,"1/2.8"" CMOS",1.9-66,color,IP68,IK10,true,
+i-pro-wv-x67700-z3-3,i-PRO,WV-X67700-Z3-3,ptz,4K,8.3,"1/2.8"" CMOS",62 (wide) - 2.5 (tele),none,IP68,IK10,true,
+i-pro-wv-x67700-z3l3,i-PRO,WV-X67700-Z3L3,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62,ir,IP66,IK10,true,
+i-pro-wv-x67700a-z3-3,i-PRO,WV-X67700A-Z3-3,ptz,4K,8.3,"1/2.8"" CMOS","62 (H, wide end)",color,IP68,IK10,true,
+i-pro-wv-x67700a-z3l3,i-PRO,WV-X67700A-Z3L3,ptz,4K,8.3,"1/2.8"" CMOS",2.5-62,ir,IP68,IK10,true,
 i-pro-wv-x86531-z2,i-PRO,WV-X86531-Z2,ptz,4 x 5MP multi-directional + 1080p 21x PTZ,5,"4x 1/2.7"" CMOS (multi-directional) + 1/2.8"" CMOS (PTZ)",PTZ 3.7-77 horizontal / 2.2-44 vertical; multi 97 horizontal / 71 vertical (per sensor),color,IP67,IK10,true,2023
 idis-dc-d4516wrx,IDIS,DC-D4516WRX,dome,5MP,5,"1/2.8"" CMOS",101 horizontal,ir,,IK10,false,2022
 imou-a1-pro-4k,IMOU,A1 Pro 4K,ptz,4K,8,,91 H; pan 355 / tilt -5~80,hybrid,,,true,

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -200783,6 +200783,2099 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-s65340-z2n1",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2N1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI motion detection",
+      "auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "scene change detection",
+      "privacy guard",
+      "21x optical zoom",
+      "256 preset positions",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "ClearSight Coating"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "AC 24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI autotracking",
+      "360° endless pan",
+      "Super Dynamic 144dB WDR",
+      "Image stabilizer",
+      "FIPS 140-2 Level 3",
+      "256 preset positions",
+      "Motion detection",
+      "Face/people/vehicle detection",
+      "Privacy guard"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4g",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V or PoE++ (IEEE 802.3bt)",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "Super Dynamic 144dB HDR",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4g"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4k",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "Privacy guard",
+      "Face detection",
+      "Vehicle detection",
+      "144dB Super Dynamic WDR",
+      "40x optical zoom",
+      "360° endless pan",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "Salt damage resistant (ISO 14993)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4k"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4n",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "Super Dynamic WDR (144dB)",
+      "FIPS 140-2 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4n1",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4N1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) – 2.1 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ / PoE+ / AC24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65501-z1",
+    "brand": "i-PRO",
+    "model": "WV-S65501-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.2-58",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.06,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.9
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65501-z1g",
+    "brand": "i-PRO",
+    "model": "WV-S65501-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "58 (wide) - 6.2 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.18,
+      "min_lux_color": 0.32
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE / PoE+ / DC12V",
+      "consumption_w": 18.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "PoE+",
+      "two-way audio",
+      "microSD 512GB"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1g"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 45.9
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3l"
+    ],
+    "release_year": 2023
+  },
+  {
+    "id": "i-pro-wv-s66300-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 350,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3ln"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "32x optical zoom",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3 SecureElement",
+      "360° endless pan",
+      "256 preset positions",
+      "wind resistance up to 40 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3n"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z4",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (Wide) – 2.0 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI analytics",
+      "image stabilizer",
+      "256 preset positions",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66300-z4l",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux_color": 0.015
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI engine",
+      "IR LED",
+      "motorized zoom",
+      "vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2023,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z4ln",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto tracking",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 SecureElement",
+      "Edge AI analytics",
+      "Image stabilization",
+      "360° endless pan",
+      "256 presets",
+      "144dB dynamic range",
+      "Up to 32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4ln"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s66300-z4n",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) – 2.0 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "60x extra zoom",
+      "PTZ"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4n"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.012
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "360° endless pan",
+      "motorized zoom",
+      "low-light"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3l"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "Rapid PTZ",
+      "ONVIF Profile G/M/S/T",
+      "IR illuminator",
+      "PoE++"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 280
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "IR illumination",
+      "AI engine",
+      "edge AI applications",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "High speed PTZ (Pan: 700deg/s, Tilt: 500deg/s)",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66600-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "360° endless pan",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "privacy guard",
+      "132dB Super Dynamic WDR",
+      "FIPS 140-2 Level 3 security"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3n"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66700-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "4K",
+      "motorized zoom",
+      "motorized focus",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66700-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "Edge AI analytics",
+      "256 preset positions",
+      "30x optical zoom",
+      "motorized zoom/focus",
+      "ONVIF Profile G/M/S/T",
+      "IR LED 200m"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66700-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "IR LEDs",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "256 preset positions",
+      "360° endless pan",
+      "super dynamic 132dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66700-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI auto tracking",
+      "360° endless pan",
+      "FIPS 140-2 Level 3 SecureElement",
+      "Super Dynamic 132dB WDR",
+      "Edge AI analytics"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
     "id": "i-pro-wv-s8530n",
     "brand": "i-PRO",
     "model": "WV-S8530N",
@@ -201509,6 +203602,3219 @@
     },
     "status": "discontinued",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-x66300-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) - 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "32x optical zoom",
+      "AI auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "video motion detection",
+      "edge AI analytics",
+      "FIPS 140-2 level 3",
+      "NDAA compliant",
+      "360° endless pan",
+      "GOP control"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3k"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66300-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) to 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 250
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "32x optical zoom",
+      "48x extra zoom",
+      "AI auto tracking",
+      "256 presets",
+      "360° endless pan",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "Heavy salt damage resistance",
+      "Face/people/vehicle detection",
+      "Occupancy detection",
+      "Scene change detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3lk"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66300-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.4-65 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3ls"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66300-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "32x optical zoom",
+      "AI engine",
+      "IP66",
+      "IK10",
+      "salt-resistant (ISO 14993)",
+      "ONVIF Profile G/M/S/T",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3s"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4k",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "60x extra zoom",
+      "360° endless pan",
+      "ONVIF Profile G/M/S/T",
+      "Super resolution (2048x1536 via upscaling)"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4k"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4lk",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65 (H, 16:9)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (54V, 45.9W) or PoE+ (54V, 25.4W)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "IR illumination",
+      "ONVIF Profile G/M/S/T",
+      "MQTT",
+      "microSDXC up to 512GB"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4lk"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4ls",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (Wide) – 2.0 (Tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "IR illumination",
+      "AI analytics",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "H.265 SD recording"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4ls"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4s",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) - 2.0 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++/PoE+",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "60x extra zoom",
+      "360° endless pan",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "AI sound classification",
+      "FIPS 140-2 level 3 encryption",
+      "NDAA compliant",
+      "salt damage resistance",
+      "wind resistance up to 40m/s",
+      "256 preset positions",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI Video Motion Detection",
+      "AI Privacy Guard",
+      "AI Face Detection",
+      "AI People Detection",
+      "AI Vehicle Detection",
+      "AI Occupancy Detection",
+      "30x optical zoom",
+      "360° endless panning",
+      "FIPS 140-2 Level 3 security",
+      "Up to 32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3k"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI auto-tracking",
+      "Edge AI applications",
+      "360° endless pan",
+      "FIPS 140-2 level 3 security"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3lk"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66600-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 280,
+      "min_lux": 0.006,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "IR LEDs",
+      "PTZ",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3ls"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "30x optical zoom",
+      "AI analytics",
+      "360° pan",
+      "256 presets",
+      "Privacy guard",
+      "Face detection",
+      "People detection",
+      "Vehicle detection",
+      "Motion detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66700-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) or DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "30x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "256 preset positions",
+      "Edge AI analytics (up to 3 apps)",
+      "FIPS 140-2 Level 3 security",
+      "NDAA compliant",
+      "Heavy salt damage resistance (ISO 14993)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3k"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66700-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62-2.5 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 280
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "30x optical zoom",
+      "heavy salt damage resistance",
+      "IR LED 280m",
+      "autotracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3lk"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66700-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "PTZ",
+      "30x optical zoom",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "vehicle detection",
+      "people detection",
+      "occupancy detection",
+      "scene change detection",
+      "gunshot detection",
+      "privacy guard",
+      "FIPS 140-2 level 3",
+      "salt resistance"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3ls"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66700-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (WIDE) – 2.5 (TELE)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67300-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67300-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "f/1.6-4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.001,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt) or AC 100-240V",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "H.265",
+      "IP68",
+      "IK10",
+      "ONVIF Profile M/S/T",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4-3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67300-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67300-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 560
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class 8) or AC 100-240V",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "40x-640x digital zoom",
+      "Built-in wiper",
+      "Auto defroster",
+      "Edge AI (2 apps)",
+      "FIPS 140-2 security",
+      "Auto tracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4l3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67300a-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67300A-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) or AC 100-240V",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": true,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "AI autotracking",
+      "256 preset positions",
+      "built-in wiper",
+      "auto defroster",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "ONVIF Profile S/T/M"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4-3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67300a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67300A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 560
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V or PoE++ (802.3bt Class 8 / Class 6)",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "IR LED",
+      "AI",
+      "PoE++",
+      "MQTT",
+      "HTTPS",
+      "H.265",
+      "rugged"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67301-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67301-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "range_m": 280
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "power": {
+      "method": "PoE++ (Type 4 Class 8 / Type 3 Class 6) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "built-in wiper",
+      "auto-defroster",
+      "white LED illuminator",
+      "AI sound classification",
+      "Edge AI analytics",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 SecureElement",
+      "MIL-STD-810-H compliant",
+      "wind resistance up to 75 m/s",
+      "corrosion resistant ISO14993"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2024,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67301a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67301A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011,
+      "range_m": 280
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt Type 4 Class 8, 90W) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "white LED illumination",
+      "280m illumination range",
+      "IP68/IP66",
+      "IK10",
+      "PoE++ Type4"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310-z4-1",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt Type 4) or 24V AC/DC",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "40x digital zoom",
+      "256 presets",
+      "image stabilizer",
+      "gyro sensor",
+      "built-in wiper",
+      "auto-defroster",
+      "edge AI analytics",
+      "NDAA compliant",
+      "FIPS 140-2 level 3",
+      "ONVIF Profile M/S/T",
+      "privacy guard"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "24V AC/DC or PoE++ (90W Type 4 / 60W Type 3)",
+      "consumption_w": 61
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "built-in wiper",
+      "auto defroster",
+      "wind resistance 90m/s",
+      "H.265 encoding"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67310-z4l1",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4L1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (horizontal, wide end)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (Type 4 Class 8) / 24V AC / 24V DC",
+      "consumption_w": 78.7
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "AI",
+      "IR illuminator",
+      "two-way audio",
+      "ONVIF Profile S/T/M",
+      "MQTT"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (802.3bt Type 3/Type 4) or 24V AC/DC",
+      "consumption_w": 79.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "IR LEDs",
+      "AI analytics",
+      "built-in wiper",
+      "auto defroster",
+      "edge AI (2 slots)",
+      "MQTT",
+      "half/full duplex audio"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4-1",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4), 24V AC, 24V DC",
+      "consumption_w": 61
+    },
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "PTZ",
+      "IP68/IP66",
+      "IK10"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "24V AC / 24V DC / PoE++ (90W)",
+      "consumption_w": 61
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "IP68/IP66",
+      "IK10",
+      "360° endless pan",
+      "built-in wiper",
+      "auto defroster",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "AI"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4l1",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4L1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ Type4 Class 8 / PoE++ Type3 Class 6 / 24V AC/DC",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "AI video motion detection",
+      "face/people/vehicle detection",
+      "built-in wiper",
+      "auto defroster",
+      "256 presets",
+      "4 simultaneous streams",
+      "FIPS 140-3 level 3 security",
+      "32 privacy zones",
+      "wind resistance up to 75 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.011,
+      "range_m": 560
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (802.3bt Type 4 Class 8 / Type 3 Class 6), 24V AC, 24V DC",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "640x digital zoom",
+      "IR illumination up to 560m",
+      "built-in wiper",
+      "auto defroster",
+      "gyro-stabilization",
+      "256 preset positions",
+      "360° endless pan",
+      "AI analytics (2 edge AI apps)",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "4 VMD zones",
+      "32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67311-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67311-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "range_m": 280
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class 8) / 24V AC / 24V DC",
+      "consumption_w": 79.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "White LED illumination",
+      "ONVIF Profile M/S/T",
+      "4 simultaneous streams",
+      "Pan-Tilt-Zoom",
+      "Color night vision"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67311a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67311A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 280,
+      "min_lux": 0.006
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "24V AC / 24V DC / PoE++ (IEEE802.3bt Type4 Class 8)",
+      "consumption_w": 78.7
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "white LED illumination",
+      "ONVIF Profile M/S/T",
+      "pan-tilt-zoom",
+      "IP68/IP66",
+      "IK10"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67700-z3-3",
+    "brand": "i-PRO",
+    "model": "WV-X67700-Z3-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V or PoE++",
+      "consumption_w": 61.4
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "built-in wiper",
+      "auto-defroster",
+      "edge AI analytics",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile M/S/T",
+      "wind resistance up to 90 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3-3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67700-z3l3",
+    "brand": "i-PRO",
+    "model": "WV-X67700-Z3L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 350
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR illumination",
+      "30x optical zoom",
+      "4K AI",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "autotracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3l3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67700a-z3-3",
+    "brand": "i-PRO",
+    "model": "WV-X67700A-Z3-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (H, wide end)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V / PoE++",
+      "consumption_w": 61.4
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "auto-tracking",
+      "30x optical zoom",
+      "360° endless pan",
+      "AI",
+      "wind resistance up to 270km/h",
+      "ONVIF Profile M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3-3"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67700a-z3l3",
+    "brand": "i-PRO",
+    "model": "WV-X67700A-Z3L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 350
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class8 / Type3 Class6) or AC 100-240V",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "480x digital zoom",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy analytics",
+      "privacy guard",
+      "4 simultaneous streams",
+      "wind resistance 90m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3l3"
+    ]
   },
   {
     "id": "i-pro-wv-x86531-z2",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -200783,6 +200783,2099 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-s65340-z2n1",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2N1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI motion detection",
+      "auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "scene change detection",
+      "privacy guard",
+      "21x optical zoom",
+      "256 preset positions",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "ClearSight Coating"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "AC 24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI autotracking",
+      "360° endless pan",
+      "Super Dynamic 144dB WDR",
+      "Image stabilizer",
+      "FIPS 140-2 Level 3",
+      "256 preset positions",
+      "Motion detection",
+      "Face/people/vehicle detection",
+      "Privacy guard"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4g",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V or PoE++ (IEEE 802.3bt)",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "Super Dynamic 144dB HDR",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4g"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4k",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "Privacy guard",
+      "Face detection",
+      "Vehicle detection",
+      "144dB Super Dynamic WDR",
+      "40x optical zoom",
+      "360° endless pan",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "Salt damage resistant (ISO 14993)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4k"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4n",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.1-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "Super Dynamic WDR (144dB)",
+      "FIPS 140-2 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z4n1",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z4N1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) – 2.1 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ / PoE+ / AC24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65501-z1",
+    "brand": "i-PRO",
+    "model": "WV-S65501-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.2-58",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.06,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.9
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65501-z1g",
+    "brand": "i-PRO",
+    "model": "WV-S65501-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "58 (wide) - 6.2 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.18,
+      "min_lux_color": 0.32
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE / PoE+ / DC12V",
+      "consumption_w": 18.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "PoE+",
+      "two-way audio",
+      "microSD 512GB"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1g"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 45.9
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3l"
+    ],
+    "release_year": 2023
+  },
+  {
+    "id": "i-pro-wv-s66300-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 350,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3ln"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) – 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "32x optical zoom",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3 SecureElement",
+      "360° endless pan",
+      "256 preset positions",
+      "wind resistance up to 40 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3n"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z4",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (Wide) – 2.0 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI analytics",
+      "image stabilizer",
+      "256 preset positions",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66300-z4l",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux_color": 0.015
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at)"
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI engine",
+      "IR LED",
+      "motorized zoom",
+      "vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2023,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66300-z4ln",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto tracking",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 SecureElement",
+      "Edge AI analytics",
+      "Image stabilization",
+      "360° endless pan",
+      "256 presets",
+      "144dB dynamic range",
+      "Up to 32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4ln"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s66300-z4n",
+    "brand": "i-PRO",
+    "model": "WV-S66300-Z4N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) – 2.0 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "60x extra zoom",
+      "PTZ"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4n"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.012
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "360° endless pan",
+      "motorized zoom",
+      "low-light"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3l"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "Rapid PTZ",
+      "ONVIF Profile G/M/S/T",
+      "IR illuminator",
+      "PoE++"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66600-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 280
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "IR illumination",
+      "AI engine",
+      "edge AI applications",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "High speed PTZ (Pan: 700deg/s, Tilt: 500deg/s)",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66600-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66600-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "360° endless pan",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "privacy guard",
+      "132dB Super Dynamic WDR",
+      "FIPS 140-2 Level 3 security"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3n"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66700-z3",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "features": [
+      "30x optical zoom",
+      "AI engine",
+      "4K",
+      "motorized zoom",
+      "motorized focus",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66700-z3l",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3L",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "Edge AI analytics",
+      "256 preset positions",
+      "30x optical zoom",
+      "motorized zoom/focus",
+      "ONVIF Profile G/M/S/T",
+      "IR LED 200m"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s66700-z3ln",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3LN",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 200,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "IR LEDs",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "256 preset positions",
+      "360° endless pan",
+      "super dynamic 132dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s66700-z3n",
+    "brand": "i-PRO",
+    "model": "WV-S66700-Z3N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI auto tracking",
+      "360° endless pan",
+      "FIPS 140-2 Level 3 SecureElement",
+      "Super Dynamic 132dB WDR",
+      "Edge AI analytics"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
     "id": "i-pro-wv-s8530n",
     "brand": "i-PRO",
     "model": "WV-S8530N",
@@ -201509,6 +203602,3219 @@
     },
     "status": "discontinued",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-x66300-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) - 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "32x optical zoom",
+      "AI auto-tracking",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "video motion detection",
+      "edge AI analytics",
+      "FIPS 140-2 level 3",
+      "NDAA compliant",
+      "360° endless pan",
+      "GOP control"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3k"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66300-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (wide) to 2.4 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 250
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "32x optical zoom",
+      "48x extra zoom",
+      "AI auto tracking",
+      "256 presets",
+      "360° endless pan",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "Heavy salt damage resistance",
+      "Face/people/vehicle detection",
+      "Occupancy detection",
+      "Scene change detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3lk"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66300-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.4-65 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 250,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3ls"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66300-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-136",
+      "aperture": "F1.6-F4.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.4-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "32x optical zoom",
+      "AI engine",
+      "IP66",
+      "IK10",
+      "salt-resistant (ISO 14993)",
+      "ONVIF Profile G/M/S/T",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3s"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4k",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "60x extra zoom",
+      "360° endless pan",
+      "ONVIF Profile G/M/S/T",
+      "Super resolution (2048x1536 via upscaling)"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4k"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4lk",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.0-65 (H, 16:9)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (54V, 45.9W) or PoE+ (54V, 25.4W)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "IR illumination",
+      "ONVIF Profile G/M/S/T",
+      "MQTT",
+      "microSDXC up to 512GB"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4lk"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4ls",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "65 (Wide) – 2.0 (Tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 350
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "IR illumination",
+      "AI analytics",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "H.265 SD recording"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4ls"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66300-z4s",
+    "brand": "i-PRO",
+    "model": "WV-X66300-Z4S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "65 (wide) - 2.0 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++/PoE+",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "60x extra zoom",
+      "360° endless pan",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "AI sound classification",
+      "FIPS 140-2 level 3 encryption",
+      "NDAA compliant",
+      "salt damage resistance",
+      "wind resistance up to 40m/s",
+      "256 preset positions",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI Video Motion Detection",
+      "AI Privacy Guard",
+      "AI Face Detection",
+      "AI People Detection",
+      "AI Vehicle Detection",
+      "AI Occupancy Detection",
+      "30x optical zoom",
+      "360° endless panning",
+      "FIPS 140-2 Level 3 security",
+      "Up to 32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3k"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "30x optical zoom",
+      "AI auto-tracking",
+      "Edge AI applications",
+      "360° endless pan",
+      "FIPS 140-2 level 3 security"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3lk"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66600-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 280,
+      "min_lux": 0.006,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "IR LEDs",
+      "PTZ",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3ls"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66600-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66600-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "features": [
+      "30x optical zoom",
+      "AI analytics",
+      "360° pan",
+      "256 presets",
+      "Privacy guard",
+      "Face detection",
+      "People detection",
+      "Vehicle detection",
+      "Motion detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x66700-z3k",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62-2.5",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) or DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "30x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "256 preset positions",
+      "Edge AI analytics (up to 3 apps)",
+      "FIPS 140-2 Level 3 security",
+      "NDAA compliant",
+      "Heavy salt damage resistance (ISO 14993)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3k"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66700-z3lk",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3LK",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62-2.5 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 280
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) or DC 54V",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "30x optical zoom",
+      "heavy salt damage resistance",
+      "IR LED 280m",
+      "autotracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3lk"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x66700-z3ls",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3LS",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 200
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt)",
+      "consumption_w": 45.9
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "PTZ",
+      "30x optical zoom",
+      "AI analytics",
+      "motion detection",
+      "face detection",
+      "vehicle detection",
+      "people detection",
+      "occupancy detection",
+      "scene change detection",
+      "gunshot detection",
+      "privacy guard",
+      "FIPS 140-2 level 3",
+      "salt resistance"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3ls"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x66700-z3s",
+    "brand": "i-PRO",
+    "model": "WV-X66700-Z3S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (WIDE) – 2.5 (TELE)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt) / DC 54V",
+      "consumption_w": 37.8
+    },
+    "power_source": [
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3s"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67300-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67300-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "f/1.6-4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.001,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt) or AC 100-240V",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "H.265",
+      "IP68",
+      "IK10",
+      "ONVIF Profile M/S/T",
+      "PoE++"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4-3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67300-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67300-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 560
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class 8) or AC 100-240V",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "40x-640x digital zoom",
+      "Built-in wiper",
+      "Auto defroster",
+      "Edge AI (2 apps)",
+      "FIPS 140-2 security",
+      "Auto tracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4l3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67300a-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67300A-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) or AC 100-240V",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": true,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "AI autotracking",
+      "256 preset positions",
+      "built-in wiper",
+      "auto defroster",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "ONVIF Profile S/T/M"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4-3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67300a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67300A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.011,
+      "range_m": 560
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V or PoE++ (802.3bt Class 8 / Class 6)",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "IR LED",
+      "AI",
+      "PoE++",
+      "MQTT",
+      "HTTPS",
+      "H.265",
+      "rugged"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67301-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67301-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "range_m": 280
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "power": {
+      "method": "PoE++ (Type 4 Class 8 / Type 3 Class 6) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "built-in wiper",
+      "auto-defroster",
+      "white LED illuminator",
+      "AI sound classification",
+      "Edge AI analytics",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 SecureElement",
+      "MIL-STD-810-H compliant",
+      "wind resistance up to 75 m/s",
+      "corrosion resistant ISO14993"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2024,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67301a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67301A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011,
+      "range_m": 280
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt Type 4 Class 8, 90W) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "white LED illumination",
+      "280m illumination range",
+      "IP68/IP66",
+      "IK10",
+      "PoE++ Type4"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310-z4-1",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt Type 4) or 24V AC/DC",
+      "consumption_w": 54
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 1024,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "40x digital zoom",
+      "256 presets",
+      "image stabilizer",
+      "gyro sensor",
+      "built-in wiper",
+      "auto-defroster",
+      "edge AI analytics",
+      "NDAA compliant",
+      "FIPS 140-2 level 3",
+      "ONVIF Profile M/S/T",
+      "privacy guard"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (wide) – 1.9 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "24V AC/DC or PoE++ (90W Type 4 / 60W Type 3)",
+      "consumption_w": 61
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "built-in wiper",
+      "auto defroster",
+      "wind resistance 90m/s",
+      "H.265 encoding"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67310-z4l1",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4L1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "66 (horizontal, wide end)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (Type 4 Class 8) / 24V AC / 24V DC",
+      "consumption_w": 78.7
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "360° endless pan",
+      "AI",
+      "IR illuminator",
+      "two-way audio",
+      "ONVIF Profile S/T/M",
+      "MQTT"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67310-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (802.3bt Type 3/Type 4) or 24V AC/DC",
+      "consumption_w": 79.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "IR LEDs",
+      "AI analytics",
+      "built-in wiper",
+      "auto defroster",
+      "edge AI (2 slots)",
+      "MQTT",
+      "half/full duplex audio"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4-1",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4), 24V AC, 24V DC",
+      "consumption_w": 61
+    },
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "PTZ",
+      "IP68/IP66",
+      "IK10"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4-3",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "24V AC / 24V DC / PoE++ (90W)",
+      "consumption_w": 61
+    },
+    "power_source": [
+      "poe",
+      "dc",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "IP68/IP66",
+      "IK10",
+      "360° endless pan",
+      "built-in wiper",
+      "auto defroster",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "AI"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4l1",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4L1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 560,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ Type4 Class 8 / PoE++ Type3 Class 6 / 24V AC/DC",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "AI video motion detection",
+      "face/people/vehicle detection",
+      "built-in wiper",
+      "auto defroster",
+      "256 presets",
+      "4 simultaneous streams",
+      "FIPS 140-3 level 3 security",
+      "32 privacy zones",
+      "wind resistance up to 75 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67310a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67310A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.011,
+      "range_m": 560
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (802.3bt Type 4 Class 8 / Type 3 Class 6), 24V AC, 24V DC",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "640x digital zoom",
+      "IR illumination up to 560m",
+      "built-in wiper",
+      "auto defroster",
+      "gyro-stabilization",
+      "256 preset positions",
+      "360° endless pan",
+      "AI analytics (2 edge AI apps)",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "4 VMD zones",
+      "32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67311-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67311-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "range_m": 280
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class 8) / 24V AC / 24V DC",
+      "consumption_w": 79.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "audio": {
+      "microphone": false,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "40x optical zoom",
+      "White LED illumination",
+      "ONVIF Profile M/S/T",
+      "4 simultaneous streams",
+      "Pan-Tilt-Zoom",
+      "Color night vision"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67311a-z4l3",
+    "brand": "i-PRO",
+    "model": "WV-X67311A-Z4L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.07,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-F4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "range_m": 280,
+      "min_lux": 0.006
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "24V AC / 24V DC / PoE++ (IEEE802.3bt Type4 Class 8)",
+      "consumption_w": 78.7
+    },
+    "power_source": [
+      "poe",
+      "ac-mains",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "features": [
+      "40x optical zoom",
+      "white LED illumination",
+      "ONVIF Profile M/S/T",
+      "pan-tilt-zoom",
+      "IP68/IP66",
+      "IK10"
+    ],
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311a-z4l3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x67700-z3-3",
+    "brand": "i-PRO",
+    "model": "WV-X67700-Z3-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V or PoE++",
+      "consumption_w": 61.4
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "built-in wiper",
+      "auto-defroster",
+      "edge AI analytics",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile M/S/T",
+      "wind resistance up to 90 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3-3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x67700-z3l3",
+    "brand": "i-PRO",
+    "model": "WV-X67700-Z3L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13,
+      "range_m": 350
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE++ (802.3bt) or AC 100-240V",
+      "consumption_w": 70.2
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR illumination",
+      "30x optical zoom",
+      "4K AI",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "autotracking"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3l3"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67700a-z3-3",
+    "brand": "i-PRO",
+    "model": "WV-X67700A-Z3-3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (H, wide end)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "AC 100-240V / PoE++",
+      "consumption_w": 61.4
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": false,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "auto-tracking",
+      "30x optical zoom",
+      "360° endless pan",
+      "AI",
+      "wind resistance up to 270km/h",
+      "ONVIF Profile M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3-3"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-x67700a-z3l3",
+    "brand": "i-PRO",
+    "model": "WV-X67700A-Z3L3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "2.5-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.13,
+      "range_m": 350
+    },
+    "ip_rating": "IP68",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE802.3bt Type4 Class8 / Type3 Class6) or AC 100-240V",
+      "consumption_w": 78.9
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "480x digital zoom",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy analytics",
+      "privacy guard",
+      "4 simultaneous streams",
+      "wind resistance 90m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3l3"
+    ]
   },
   {
     "id": "i-pro-wv-x86531-z2",

--- a/docs/cameras/i-pro/wv-s65340-z2n1.md
+++ b/docs/cameras/i-pro/wv-s65340-z2n1.md
@@ -1,0 +1,42 @@
+# i-PRO WV-S65340-Z2N1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z2N1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.07MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (wide) to 3.7 (tele)° |
+| Night vision | color, 0.0004 lux, 0.011 lux color |
+| Power | AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI motion detection
+- auto-tracking
+- face detection
+- people detection
+- vehicle detection
+- occupancy detection
+- scene change detection
+- privacy guard
+- 21x optical zoom
+- 256 preset positions
+- FIPS 140-2 Level 3
+- NDAA compliant
+- ClearSight Coating
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n1
+
+---
+*Auto-generated from i-pro-wv-s65340-z2n1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z4.md
+++ b/docs/cameras/i-pro/wv-s65340-z4.md
@@ -1,0 +1,39 @@
+# i-PRO WV-S65340-Z4
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z4 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.1-65° |
+| Night vision | color, 0.001 lux, 0.011 lux color |
+| Power | AC 24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI autotracking
+- 360° endless pan
+- Super Dynamic 144dB WDR
+- Image stabilizer
+- FIPS 140-2 Level 3
+- 256 preset positions
+- Motion detection
+- Face/people/vehicle detection
+- Privacy guard
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4
+
+---
+*Auto-generated from i-pro-wv-s65340-z4.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z4g.md
+++ b/docs/cameras/i-pro/wv-s65340-z4g.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S65340-Z4G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z4G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.1-65° |
+| Night vision | color, 0.017 lux, 0.03 lux color |
+| Power | AC24V or PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto-tracking
+- Super Dynamic 144dB HDR
+- NDAA compliant
+- FIPS 140-2 Level 3
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4g
+
+---
+*Auto-generated from i-pro-wv-s65340-z4g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z4k.md
+++ b/docs/cameras/i-pro/wv-s65340-z4k.md
@@ -1,0 +1,39 @@
+# i-PRO WV-S65340-Z4K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z4K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.07MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.1-65° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- Privacy guard
+- Face detection
+- Vehicle detection
+- 144dB Super Dynamic WDR
+- 40x optical zoom
+- 360° endless pan
+- FIPS 140-2 Level 3
+- NDAA compliant
+- Salt damage resistant (ISO 14993)
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4k
+
+---
+*Auto-generated from i-pro-wv-s65340-z4k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z4n.md
+++ b/docs/cameras/i-pro/wv-s65340-z4n.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S65340-Z4N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z4N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.1-65° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | AC24V / PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto-tracking
+- face detection
+- people detection
+- vehicle detection
+- privacy guard
+- Super Dynamic WDR (144dB)
+- FIPS 140-2 Level 3 secure element
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n
+
+---
+*Auto-generated from i-pro-wv-s65340-z4n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z4n1.md
+++ b/docs/cameras/i-pro/wv-s65340-z4n1.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S65340-Z4N1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z4N1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 65 (wide) – 2.1 (tele)° |
+| Night vision | ir, 0.006 lux, 0.011 lux color |
+| Power | PoE++ / PoE+ / AC24V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z4n1
+
+---
+*Auto-generated from i-pro-wv-s65340-z4n1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65501-z1.md
+++ b/docs/cameras/i-pro/wv-s65501-z1.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S65501-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65501-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 6.2-58° |
+| Night vision | none, 0.06 lux, 0.08 lux color |
+| Power | DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1
+
+---
+*Auto-generated from i-pro-wv-s65501-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65501-z1g.md
+++ b/docs/cameras/i-pro/wv-s65501-z1g.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S65501-Z1G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65501-Z1G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 58 (wide) - 6.2 (tele)° |
+| Night vision | none, 0.18 lux, 0.32 lux color |
+| Power | PoE / PoE+ / DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- motorized zoom
+- motorized focus
+- PoE+
+- two-way audio
+- microSD 512GB
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65501-z1g
+
+---
+*Auto-generated from i-pro-wv-s65501-z1g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z3.md
+++ b/docs/cameras/i-pro/wv-s66300-z3.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S66300-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 65 (wide) – 2.4 (tele)° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3
+
+---
+*Auto-generated from i-pro-wv-s66300-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z3l.md
+++ b/docs/cameras/i-pro/wv-s66300-z3l.md
@@ -1,0 +1,27 @@
+# i-PRO WV-S66300-Z3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z3L |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6 |
+| Field of view | 2.4-65° |
+| Night vision | ir (250m), 0.0004 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Released | 2023 |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3l
+
+---
+*Auto-generated from i-pro-wv-s66300-z3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z3ln.md
+++ b/docs/cameras/i-pro/wv-s66300-z3ln.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S66300-Z3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z3LN |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 2.4-65° |
+| Night vision | ir (350m), 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3ln
+
+---
+*Auto-generated from i-pro-wv-s66300-z3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z3n.md
+++ b/docs/cameras/i-pro/wv-s66300-z3n.md
@@ -1,0 +1,40 @@
+# i-PRO WV-S66300-Z3N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z3N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 65 (wide) – 2.4 (tele)° |
+| Night vision | color, 0.0004 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 32x optical zoom
+- AI analytics
+- motion detection
+- face detection
+- people detection
+- vehicle detection
+- ONVIF Profile G/M/S/T
+- FIPS 140-2 Level 3 SecureElement
+- 360° endless pan
+- 256 preset positions
+- wind resistance up to 40 m/s
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z3n
+
+---
+*Auto-generated from i-pro-wv-s66300-z3n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z4.md
+++ b/docs/cameras/i-pro/wv-s66300-z4.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66300-Z4
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z4 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 65 (Wide) – 2.0 (Tele) horizontal° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI analytics
+- image stabilizer
+- 256 preset positions
+- ONVIF Profile G/M/S/T
+- FIPS 140-2 Level 3
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4
+
+---
+*Auto-generated from i-pro-wv-s66300-z4.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z4l.md
+++ b/docs/cameras/i-pro/wv-s66300-z4l.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66300-Z4L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z4L |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.0-65 (H)° |
+| Night vision | ir (250m), 0.015 lux color |
+| Power | PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Released | 2023 |
+
+## Features
+
+- 40x optical zoom
+- AI engine
+- IR LED
+- motorized zoom
+- vandal resistant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4l
+
+---
+*Auto-generated from i-pro-wv-s66300-z4l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z4ln.md
+++ b/docs/cameras/i-pro/wv-s66300-z4ln.md
@@ -1,0 +1,39 @@
+# i-PRO WV-S66300-Z4LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z4LN |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.0-65° |
+| Night vision | ir (350m), 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto tracking
+- NDAA compliant
+- FIPS 140-2 Level 3 SecureElement
+- Edge AI analytics
+- Image stabilization
+- 360° endless pan
+- 256 presets
+- 144dB dynamic range
+- Up to 32 privacy zones
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4ln
+
+---
+*Auto-generated from i-pro-wv-s66300-z4ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66300-z4n.md
+++ b/docs/cameras/i-pro/wv-s66300-z4n.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S66300-Z4N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66300-Z4N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 65 (wide) – 2.0 (tele)° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- motorized zoom
+- motorized focus
+- 60x extra zoom
+- PTZ
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66300-z4n
+
+---
+*Auto-generated from i-pro-wv-s66300-z4n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66600-z3.md
+++ b/docs/cameras/i-pro/wv-s66600-z3.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S66600-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66600-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | color, 0.006 lux, 0.012 lux color |
+| Power | PoE++ (IEEE802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI engine
+- 360° endless pan
+- motorized zoom
+- low-light
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3
+
+---
+*Auto-generated from i-pro-wv-s66600-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66600-z3l.md
+++ b/docs/cameras/i-pro/wv-s66600-z3l.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66600-Z3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66600-Z3L |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62 (H)° |
+| Night vision | ir (200m), 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI engine
+- Rapid PTZ
+- ONVIF Profile G/M/S/T
+- IR illuminator
+- PoE++
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3l
+
+---
+*Auto-generated from i-pro-wv-s66600-z3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66600-z3ln.md
+++ b/docs/cameras/i-pro/wv-s66600-z3ln.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S66600-Z3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66600-Z3LN |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | ir (280m), 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) / DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- IR illumination
+- AI engine
+- edge AI applications
+- FIPS 140-2 Level 3
+- NDAA compliant
+- High speed PTZ (Pan: 700deg/s, Tilt: 500deg/s)
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3ln
+
+---
+*Auto-generated from i-pro-wv-s66600-z3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66600-z3n.md
+++ b/docs/cameras/i-pro/wv-s66600-z3n.md
@@ -1,0 +1,39 @@
+# i-PRO WV-S66600-Z3N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66600-Z3N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- 360° endless pan
+- AI analytics
+- face detection
+- people detection
+- vehicle detection
+- occupancy detection
+- privacy guard
+- 132dB Super Dynamic WDR
+- FIPS 140-2 Level 3 security
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66600-z3n
+
+---
+*Auto-generated from i-pro-wv-s66600-z3n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66700-z3.md
+++ b/docs/cameras/i-pro/wv-s66700-z3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66700-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66700-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-4.7 |
+| Field of view | 2.5-62 (H)° |
+| Night vision | color, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI engine
+- 4K
+- motorized zoom
+- motorized focus
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3
+
+---
+*Auto-generated from i-pro-wv-s66700-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66700-z3l.md
+++ b/docs/cameras/i-pro/wv-s66700-z3l.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66700-Z3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66700-Z3L |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | ir (200m), 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) or DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- Edge AI analytics
+- 256 preset positions
+- 30x optical zoom
+- motorized zoom/focus
+- ONVIF Profile G/M/S/T
+- IR LED 200m
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3l
+
+---
+*Auto-generated from i-pro-wv-s66700-z3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66700-z3ln.md
+++ b/docs/cameras/i-pro/wv-s66700-z3ln.md
@@ -1,0 +1,40 @@
+# i-PRO WV-S66700-Z3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66700-Z3LN |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62-2.5° |
+| Night vision | ir (200m), 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- IR LEDs
+- AI analytics
+- motion detection
+- face detection
+- people detection
+- vehicle detection
+- privacy guard
+- 256 preset positions
+- 360° endless pan
+- super dynamic 132dB WDR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3ln
+
+---
+*Auto-generated from i-pro-wv-s66700-z3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s66700-z3n.md
+++ b/docs/cameras/i-pro/wv-s66700-z3n.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S66700-Z3N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S66700-Z3N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | color, 0.13 lux |
+| Power | PoE++ (IEEE802.3bt) / DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI auto tracking
+- 360° endless pan
+- FIPS 140-2 Level 3 SecureElement
+- Super Dynamic 132dB WDR
+- Edge AI analytics
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s66700-z3n
+
+---
+*Auto-generated from i-pro-wv-s66700-z3n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z3k.md
+++ b/docs/cameras/i-pro/wv-x66300-z3k.md
@@ -1,0 +1,41 @@
+# i-PRO WV-X66300-Z3K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z3K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 65 (wide) - 2.4 (tele)° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 32x optical zoom
+- AI auto-tracking
+- face detection
+- people detection
+- vehicle detection
+- occupancy detection
+- video motion detection
+- edge AI analytics
+- FIPS 140-2 level 3
+- NDAA compliant
+- 360° endless pan
+- GOP control
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3k
+
+---
+*Auto-generated from i-pro-wv-x66300-z3k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z3lk.md
+++ b/docs/cameras/i-pro/wv-x66300-z3lk.md
@@ -1,0 +1,40 @@
+# i-PRO WV-X66300-Z3LK
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z3LK |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 65 (wide) to 2.4 (tele)° |
+| Night vision | ir (250m), 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 32x optical zoom
+- 48x extra zoom
+- AI auto tracking
+- 256 presets
+- 360° endless pan
+- NDAA compliant
+- FIPS 140-2 Level 3
+- Heavy salt damage resistance
+- Face/people/vehicle detection
+- Occupancy detection
+- Scene change detection
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3lk
+
+---
+*Auto-generated from i-pro-wv-x66300-z3lk.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z3ls.md
+++ b/docs/cameras/i-pro/wv-x66300-z3ls.md
@@ -1,0 +1,26 @@
+# i-PRO WV-X66300-Z3LS
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z3LS |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 2.4-65 (H)° |
+| Night vision | ir (250m), 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3ls
+
+---
+*Auto-generated from i-pro-wv-x66300-z3ls.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z3s.md
+++ b/docs/cameras/i-pro/wv-x66300-z3s.md
@@ -1,0 +1,36 @@
+# i-PRO WV-X66300-Z3S
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z3S |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-136mm F1.6-F4.4 |
+| Field of view | 2.4-65° |
+| Night vision | none, 0.0004 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 32x optical zoom
+- AI engine
+- IP66
+- IK10
+- salt-resistant (ISO 14993)
+- ONVIF Profile G/M/S/T
+- PoE++
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z3s
+
+---
+*Auto-generated from i-pro-wv-x66300-z3s.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z4k.md
+++ b/docs/cameras/i-pro/wv-x66300-z4k.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X66300-Z4K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z4K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.0-65° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 60x extra zoom
+- 360° endless pan
+- ONVIF Profile G/M/S/T
+- Super resolution (2048x1536 via upscaling)
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4k
+
+---
+*Auto-generated from i-pro-wv-x66300-z4k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z4lk.md
+++ b/docs/cameras/i-pro/wv-x66300-z4lk.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X66300-Z4LK
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z4LK |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 2.0-65 (H, 16:9)° |
+| Night vision | ir (350m), 0.006 lux, 0.011 lux color |
+| Power | PoE++ (54V, 45.9W) or PoE+ (54V, 25.4W) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- IR illumination
+- ONVIF Profile G/M/S/T
+- MQTT
+- microSDXC up to 512GB
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4lk
+
+---
+*Auto-generated from i-pro-wv-x66300-z4lk.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z4ls.md
+++ b/docs/cameras/i-pro/wv-x66300-z4ls.md
@@ -1,0 +1,36 @@
+# i-PRO WV-X66300-Z4LS
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z4LS |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 65 (Wide) – 2.0 (Tele)° |
+| Night vision | ir (350m), 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- IR illumination
+- AI analytics
+- ONVIF Profile G/M/S/T
+- FIPS 140-2 Level 3
+- NDAA compliant
+- H.265 SD recording
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4ls
+
+---
+*Auto-generated from i-pro-wv-x66300-z4ls.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66300-z4s.md
+++ b/docs/cameras/i-pro/wv-x66300-z4s.md
@@ -1,0 +1,43 @@
+# i-PRO WV-X66300-Z4S
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66300-Z4S |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 65 (wide) - 2.0 (tele)° |
+| Night vision | color, 0.0004 lux, 0.011 lux color |
+| Power | PoE++/PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 60x extra zoom
+- 360° endless pan
+- AI analytics
+- face detection
+- people detection
+- vehicle detection
+- AI sound classification
+- FIPS 140-2 level 3 encryption
+- NDAA compliant
+- salt damage resistance
+- wind resistance up to 40m/s
+- 256 preset positions
+- Super Dynamic 144dB WDR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66300-z4s
+
+---
+*Auto-generated from i-pro-wv-x66300-z4s.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66600-z3k.md
+++ b/docs/cameras/i-pro/wv-x66600-z3k.md
@@ -1,0 +1,39 @@
+# i-PRO WV-X66600-Z3K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66600-Z3K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | color, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI Video Motion Detection
+- AI Privacy Guard
+- AI Face Detection
+- AI People Detection
+- AI Vehicle Detection
+- AI Occupancy Detection
+- 30x optical zoom
+- 360° endless panning
+- FIPS 140-2 Level 3 security
+- Up to 32 privacy zones
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3k
+
+---
+*Auto-generated from i-pro-wv-x66600-z3k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66600-z3lk.md
+++ b/docs/cameras/i-pro/wv-x66600-z3lk.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X66600-Z3LK
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66600-Z3LK |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (wide) - 2.5 (tele)° |
+| Night vision | ir (200m), 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) or DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- 30x optical zoom
+- AI auto-tracking
+- Edge AI applications
+- 360° endless pan
+- FIPS 140-2 level 3 security
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3lk
+
+---
+*Auto-generated from i-pro-wv-x66600-z3lk.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66600-z3ls.md
+++ b/docs/cameras/i-pro/wv-x66600-z3ls.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X66600-Z3LS
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66600-Z3LS |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (wide) - 2.5 (tele)° |
+| Night vision | ir (280m), 0.006 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- motorized zoom
+- motorized focus
+- IR LEDs
+- PTZ
+- PoE++
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3ls
+
+---
+*Auto-generated from i-pro-wv-x66600-z3ls.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66600-z3s.md
+++ b/docs/cameras/i-pro/wv-x66600-z3s.md
@@ -1,0 +1,38 @@
+# i-PRO WV-X66600-Z3S
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66600-Z3S |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62-2.5° |
+| Night vision | ir, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI analytics
+- 360° pan
+- 256 presets
+- Privacy guard
+- Face detection
+- People detection
+- Vehicle detection
+- Motion detection
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66600-z3s
+
+---
+*Auto-generated from i-pro-wv-x66600-z3s.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66700-z3k.md
+++ b/docs/cameras/i-pro/wv-x66700-z3k.md
@@ -1,0 +1,37 @@
+# i-PRO WV-X66700-Z3K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66700-Z3K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.29MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62-2.5° |
+| Night vision | ir, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) or DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- AI auto-tracking
+- 360° endless pan
+- 256 preset positions
+- Edge AI analytics (up to 3 apps)
+- FIPS 140-2 Level 3 security
+- NDAA compliant
+- Heavy salt damage resistance (ISO 14993)
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3k
+
+---
+*Auto-generated from i-pro-wv-x66700-z3k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66700-z3lk.md
+++ b/docs/cameras/i-pro/wv-x66700-z3lk.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X66700-Z3LK
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66700-Z3LK |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62-2.5 (H)° |
+| Night vision | ir (280m), 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) or DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI engine
+- 30x optical zoom
+- heavy salt damage resistance
+- IR LED 280m
+- autotracking
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3lk
+
+---
+*Auto-generated from i-pro-wv-x66700-z3lk.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66700-z3ls.md
+++ b/docs/cameras/i-pro/wv-x66700-z3ls.md
@@ -1,0 +1,43 @@
+# i-PRO WV-X66700-Z3LS
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66700-Z3LS |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | ir (200m), 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE 802.3bt) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- IR
+- PTZ
+- 30x optical zoom
+- AI analytics
+- motion detection
+- face detection
+- vehicle detection
+- people detection
+- occupancy detection
+- scene change detection
+- gunshot detection
+- privacy guard
+- FIPS 140-2 level 3
+- salt resistance
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3ls
+
+---
+*Auto-generated from i-pro-wv-x66700-z3ls.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x66700-z3s.md
+++ b/docs/cameras/i-pro/wv-x66700-z3s.md
@@ -1,0 +1,26 @@
+# i-PRO WV-X66700-Z3S
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X66700-Z3S |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.29MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (WIDE) – 2.5 (TELE)° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt) / DC 54V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x66700-z3s
+
+---
+*Auto-generated from i-pro-wv-x66700-z3s.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67300-z4-3.md
+++ b/docs/cameras/i-pro/wv-x67300-z4-3.md
@@ -1,0 +1,36 @@
+# i-PRO WV-X67300-Z4-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67300-Z4-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm f/1.6-4.95 |
+| Field of view | 1.9-66° |
+| Night vision | none, 0.001 lux, 0.011 lux color |
+| Power | PoE++ (802.3bt) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 360° endless pan
+- H.265
+- IP68
+- IK10
+- ONVIF Profile M/S/T
+- PoE++
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4-3
+
+---
+*Auto-generated from i-pro-wv-x67300-z4-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67300-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67300-z4l3.md
@@ -1,0 +1,36 @@
+# i-PRO WV-X67300-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67300-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | ir (560m), 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt Type4 Class 8) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 40x-640x digital zoom
+- Built-in wiper
+- Auto defroster
+- Edge AI (2 apps)
+- FIPS 140-2 security
+- Auto tracking
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67300-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67300a-z4-3.md
+++ b/docs/cameras/i-pro/wv-x67300a-z4-3.md
@@ -1,0 +1,37 @@
+# i-PRO WV-X67300A-Z4-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67300A-Z4-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.07MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6 |
+| Field of view | 66 (wide) – 1.9 (tele)° |
+| Night vision | none, 0.0004 lux, 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI autotracking
+- 256 preset positions
+- built-in wiper
+- auto defroster
+- FIPS 140-3 Level 3
+- NDAA compliant
+- ONVIF Profile S/T/M
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4-3
+
+---
+*Auto-generated from i-pro-wv-x67300a-z4-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67300a-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67300a-z4l3.md
@@ -1,0 +1,37 @@
+# i-PRO WV-X67300A-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67300A-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66 (H)° |
+| Night vision | ir (560m), 0.011 lux color |
+| Power | AC 100-240V or PoE++ (802.3bt Class 8 / Class 6) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- IR LED
+- AI
+- PoE++
+- MQTT
+- HTTPS
+- H.265
+- rugged
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67300a-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67300a-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67301-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67301-z4l3.md
@@ -1,0 +1,43 @@
+# i-PRO WV-X67301-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67301-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | color (280m), 0.0004 lux |
+| Power | PoE++ (Type 4 Class 8 / Type 3 Class 6) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Released | 2024 |
+
+## Features
+
+- 40x optical zoom
+- 360° endless pan
+- 256 preset positions
+- built-in wiper
+- auto-defroster
+- white LED illuminator
+- AI sound classification
+- Edge AI analytics
+- NDAA compliant
+- FIPS 140-2 Level 3 SecureElement
+- MIL-STD-810-H compliant
+- wind resistance up to 75 m/s
+- corrosion resistant ISO14993
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67301-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67301a-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67301a-z4l3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67301A-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67301A-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6 |
+| Field of view | 66 (wide) – 1.9 (tele)° |
+| Night vision | color (280m), 0.006 lux, 0.011 lux color |
+| Power | PoE++ (802.3bt Type 4 Class 8, 90W) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- white LED illumination
+- 280m illumination range
+- IP68/IP66
+- IK10
+- PoE++ Type4
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67301a-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67301a-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310-z4-1.md
+++ b/docs/cameras/i-pro/wv-x67310-z4-1.md
@@ -1,0 +1,41 @@
+# i-PRO WV-X67310-Z4-1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310-Z4-1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE 802.3bt Type 4) or 24V AC/DC |
+| Storage | microSD ≤ 1024GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- 40x optical zoom
+- 40x digital zoom
+- 256 presets
+- image stabilizer
+- gyro sensor
+- built-in wiper
+- auto-defroster
+- edge AI analytics
+- NDAA compliant
+- FIPS 140-2 level 3
+- ONVIF Profile M/S/T
+- privacy guard
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-1
+
+---
+*Auto-generated from i-pro-wv-x67310-z4-1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310-z4-3.md
+++ b/docs/cameras/i-pro/wv-x67310-z4-3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67310-Z4-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310-Z4-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 66 (wide) – 1.9 (tele)° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | 24V AC/DC or PoE++ (90W Type 4 / 60W Type 3) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto-tracking
+- built-in wiper
+- auto defroster
+- wind resistance 90m/s
+- H.265 encoding
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4-3
+
+---
+*Auto-generated from i-pro-wv-x67310-z4-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310-z4l1.md
+++ b/docs/cameras/i-pro/wv-x67310-z4l1.md
@@ -1,0 +1,36 @@
+# i-PRO WV-X67310-Z4L1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310-Z4L1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6 |
+| Field of view | 66 (horizontal, wide end)° |
+| Night vision | ir (560m), 0.006 lux, 0.011 lux color |
+| Power | PoE++ (Type 4 Class 8) / 24V AC / 24V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 360° endless pan
+- AI
+- IR illuminator
+- two-way audio
+- ONVIF Profile S/T/M
+- MQTT
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l1
+
+---
+*Auto-generated from i-pro-wv-x67310-z4l1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67310-z4l3.md
@@ -1,0 +1,37 @@
+# i-PRO WV-X67310-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | ir (560m), 0.006 lux, 0.011 lux color |
+| Power | PoE++ (802.3bt Type 3/Type 4) or 24V AC/DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- IR LEDs
+- AI analytics
+- built-in wiper
+- auto defroster
+- edge AI (2 slots)
+- MQTT
+- half/full duplex audio
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67310-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310a-z4-1.md
+++ b/docs/cameras/i-pro/wv-x67310a-z4-1.md
@@ -1,0 +1,33 @@
+# i-PRO WV-X67310A-Z4-1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310A-Z4-1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | PoE++ (IEEE802.3bt Type4), 24V AC, 24V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- 40x optical zoom
+- PTZ
+- IP68/IP66
+- IK10
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-1
+
+---
+*Auto-generated from i-pro-wv-x67310a-z4-1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310a-z4-3.md
+++ b/docs/cameras/i-pro/wv-x67310a-z4-3.md
@@ -1,0 +1,38 @@
+# i-PRO WV-X67310A-Z4-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310A-Z4-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6 |
+| Field of view | 1.9-66° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | 24V AC / 24V DC / PoE++ (90W) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- IP68/IP66
+- IK10
+- 360° endless pan
+- built-in wiper
+- auto defroster
+- FIPS 140-3 Level 3
+- NDAA compliant
+- AI
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4-3
+
+---
+*Auto-generated from i-pro-wv-x67310a-z4-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310a-z4l1.md
+++ b/docs/cameras/i-pro/wv-x67310a-z4l1.md
@@ -1,0 +1,41 @@
+# i-PRO WV-X67310A-Z4L1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310A-Z4L1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6 |
+| Field of view | 1.9-66° |
+| Night vision | ir (560m), 0.011 lux color |
+| Power | PoE++ Type4 Class 8 / PoE++ Type3 Class 6 / 24V AC/DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto-tracking
+- 360° endless pan
+- AI video motion detection
+- face/people/vehicle detection
+- built-in wiper
+- auto defroster
+- 256 presets
+- 4 simultaneous streams
+- FIPS 140-3 level 3 security
+- 32 privacy zones
+- wind resistance up to 75 m/s
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l1
+
+---
+*Auto-generated from i-pro-wv-x67310a-z4l1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67310a-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67310a-z4l3.md
@@ -1,0 +1,42 @@
+# i-PRO WV-X67310A-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67310A-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | ir (560m), 0.011 lux |
+| Power | PoE++ (802.3bt Type 4 Class 8 / Type 3 Class 6), 24V AC, 24V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- 640x digital zoom
+- IR illumination up to 560m
+- built-in wiper
+- auto defroster
+- gyro-stabilization
+- 256 preset positions
+- 360° endless pan
+- AI analytics (2 edge AI apps)
+- FIPS 140-3 Level 3
+- NDAA compliant
+- 4 VMD zones
+- 32 privacy zones
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67310a-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67310a-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67311-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67311-z4l3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67311-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67311-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66 (H)° |
+| Night vision | color (280m), 0.006 lux |
+| Power | PoE++ (IEEE802.3bt Type4 Class 8) / 24V AC / 24V DC |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- 40x optical zoom
+- White LED illumination
+- ONVIF Profile M/S/T
+- 4 simultaneous streams
+- Pan-Tilt-Zoom
+- Color night vision
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67311-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67311a-z4l3.md
+++ b/docs/cameras/i-pro/wv-x67311a-z4l3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67311A-Z4L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67311A-Z4L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.07MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-F4.95 |
+| Field of view | 1.9-66° |
+| Night vision | color (280m), 0.006 lux |
+| Power | 24V AC / 24V DC / PoE++ (IEEE802.3bt Type4 Class 8) |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- white LED illumination
+- ONVIF Profile M/S/T
+- pan-tilt-zoom
+- IP68/IP66
+- IK10
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67311a-z4l3
+
+---
+*Auto-generated from i-pro-wv-x67311a-z4l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67700-z3-3.md
+++ b/docs/cameras/i-pro/wv-x67700-z3-3.md
@@ -1,0 +1,38 @@
+# i-PRO WV-X67700-Z3-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67700-Z3-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (wide) - 2.5 (tele)° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | AC 100-240V or PoE++ |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- 360° endless pan
+- 256 preset positions
+- built-in wiper
+- auto-defroster
+- edge AI analytics
+- FIPS 140-2 Level 3
+- ONVIF Profile M/S/T
+- wind resistance up to 90 m/s
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3-3
+
+---
+*Auto-generated from i-pro-wv-x67700-z3-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67700-z3l3.md
+++ b/docs/cameras/i-pro/wv-x67700-z3l3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67700-Z3L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67700-Z3L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | ir (350m), 0.1 lux, 0.13 lux color |
+| Power | PoE++ (802.3bt) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- IR illumination
+- 30x optical zoom
+- 4K AI
+- FIPS 140-2 Level 3
+- NDAA compliant
+- autotracking
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700-z3l3
+
+---
+*Auto-generated from i-pro-wv-x67700-z3l3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67700a-z3-3.md
+++ b/docs/cameras/i-pro/wv-x67700a-z3-3.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X67700A-Z3-3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67700A-Z3-3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (H, wide end)° |
+| Night vision | color, 0.1 lux, 0.13 lux color |
+| Power | AC 100-240V / PoE++ |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- auto-tracking
+- 30x optical zoom
+- 360° endless pan
+- AI
+- wind resistance up to 270km/h
+- ONVIF Profile M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3-3
+
+---
+*Auto-generated from i-pro-wv-x67700a-z3-3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x67700a-z3l3.md
+++ b/docs/cameras/i-pro/wv-x67700a-z3l3.md
@@ -1,0 +1,39 @@
+# i-PRO WV-X67700A-Z3L3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X67700A-Z3L3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 2.5-62° |
+| Night vision | ir (350m), 0.13 lux color |
+| Power | PoE++ (IEEE802.3bt Type4 Class8 / Type3 Class6) or AC 100-240V |
+| Storage | NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP68 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- 480x digital zoom
+- AI analytics
+- face detection
+- people detection
+- vehicle detection
+- occupancy analytics
+- privacy guard
+- 4 simultaneous streams
+- wind resistance 90m/s
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x67700a-z3l3
+
+---
+*Auto-generated from i-pro-wv-x67700a-z3l3.json — do not edit by hand.*


### PR DESCRIPTION
## Summary

- Adds 60 i-PRO PTZ network cameras from the WV-S and WV-X series
- Models include:
  - **WV-X677xx** 4K 30x PTZ series (WV-X67700A-Z3L3, WV-X67700A-Z3-3, WV-X67700-Z3L3, WV-X67700-Z3-3)
  - **WV-X6731x/6730x/6731x** 1080p 40x PTZ series (WV-X67311A-Z4L3, WV-X67311-Z4L3, WV-X67310A-Z4L3, WV-X67310A-Z4L1, WV-X67310A-Z4-3, WV-X67310A-Z4-1, WV-X67310-Z4L3, WV-X67310-Z4L1, WV-X67310-Z4-3, WV-X67310-Z4-1, WV-X67301A-Z4L3, WV-X67301-Z4L3, WV-X67300A-Z4L3, WV-X67300A-Z4-3, WV-X67300-Z4L3, WV-X67300-Z4-3)
  - **WV-X666xx** 4K/6MP 30x PTZ series (WV-X66700-Z3S, WV-X66700-Z3LS, WV-X66700-Z3LK, WV-X66700-Z3K, WV-X66600-Z3S, WV-X66600-Z3LS, WV-X66600-Z3LK, WV-X66600-Z3K)
  - **WV-X663xx** 1080p 32x/40x PTZ series (WV-X66300-Z4S, WV-X66300-Z4LS, WV-X66300-Z4LK, WV-X66300-Z4K, WV-X66300-Z3S, WV-X66300-Z3LS, WV-X66300-Z3LK, WV-X66300-Z3K)
  - **WV-S667xx** 4K 30x PTZ series (WV-S66700-Z3N, WV-S66700-Z3LN, WV-S66700-Z3L, WV-S66700-Z3)
  - **WV-S666xx** 6MP 30x PTZ series (WV-S66600-Z3N, WV-S66600-Z3LN, WV-S66600-Z3L, WV-S66600-Z3)
  - **WV-S663xx** 1080p 40x/32x PTZ series (WV-S66300-Z4N, WV-S66300-Z4LN, WV-S66300-Z4L, WV-S66300-Z4, WV-S66300-Z3N, WV-S66300-Z3LN, WV-S66300-Z3L, WV-S66300-Z3)
  - **WV-S655xx** 5MP 10x PTZ (WV-S65501-Z1G, WV-S65501-Z1)
  - **WV-S6534x** 1080p 40x/21x PTZ series (WV-S65340-Z4N1, WV-S65340-Z4N, WV-S65340-Z4K, WV-S65340-Z4G, WV-S65340-Z4, WV-S65340-Z2N1)
- All entries include Frigate NVR RTSP config with main/sub stream URLs
- AI auto-tracking flagged via `ptz.autotracking: true` where cameras expose the feature
- Sources from i-PRO official product pages: https://i-pro.com/products_and_solutions/en/surveillance/documentation-database

## Test plan

- [x] `npm run lint` passes (no errors, 65 pre-existing advisory warnings)
- [x] `npm run build` passes, 2990 cameras built successfully
- [ ] Spot-check a few camera pages on the frontend after merge and deploy