### PR TITLE
data: add i-PRO network cameras (batch 3, 60 models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CCTV Camera Database
 
-An open, structured database of 2,930 CCTV / IP camera models and their technical specifications, covering 76 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
+An open, structured database of 2,990 CCTV / IP camera models and their technical specifications, covering 76 brands across every market segment — from budget consumer WiFi cameras to enterprise PTZ domes and thermal imaging systems. Each camera is a validated JSON file, aggregated into a single queryable dataset (JSON + CSV).
 
-[![cameras](https://img.shields.io/badge/cameras-2%2C930-blue)](data/cameras.json)
+[![cameras](https://img.shields.io/badge/cameras-2%2C990-blue)](data/cameras.json)
 [![brands](https://img.shields.io/badge/brands-76-green)](cameras/)
 [![license](https://img.shields.io/badge/license-CC0-lightgrey)](LICENSE)
 
@@ -47,7 +47,7 @@ Prefer to self-host or browse offline? A [standalone demo](docs/demo.html) (just
 - **Filter** — narrow by brand, camera type, night vision, resolution, or market
 - **Sort** — click any column header to sort ascending/descending
 - **Detail drawer** — click a row to slide open the full spec sheet (resolution, connectivity, protocols, storage, audio, pricing, source links)
-- **Pagination** — page through all 2,930 cameras, 25 per page
+- **Pagination** — page through all 2,990 cameras, 25 per page
 - **Stats bar** — live counts for total cameras, brands, 4K+, WiFi, and no-subscription models
 
 ---
@@ -80,9 +80,9 @@ cctv-camera-database/
 │   ├── reolink/          # 127 cameras
 │   └── …70 more brands
 ├── data/                 # GENERATED — do not edit by hand
-│   ├── cameras.json      # all 2,930 cameras as one array
+│   ├── cameras.json      # all 2,990 cameras as one array
 │   ├── cameras.csv       # flattened, spreadsheet-friendly
-│   └── rtsp-patterns.json  # CC0 brand-level RTSP URL layer (170 brands)
+│   └── rtsp-patterns.json  # CC0 brand-level RTSP URL layer (122 brands)
 ├── strix/
 │   └── verified/         # per-brand RTSP source files → rtsp-patterns.json
 ├── schema/
@@ -163,17 +163,17 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 
 | Metric | Count |
 |--------|-------|
-| Total cameras | **2,930** |
+| Total cameras | **2,990** |
 | Brands | **76** |
 | Form factors | 11 (bullet, dome, turret, PTZ, dual-lens, panoramic, covert, box, fisheye, floodlight, doorbell) |
-| PoE wired | 2,148 |
+| PoE wired | 2,208 |
 | WiFi | 599 |
 | Battery / wire-free | 203 |
-| 4K / 8MP+ | 814 |
-| 4–5MP | 1,222 |
-| 1080p–2MP | 893 |
-| With integration configs (Frigate / Home Assistant) | 2,455 |
-| With color-lux rating (`night_vision.min_lux_color`) | 1,744 |
+| 4K / 8MP+ | 823 |
+| 4–5MP | 1,238 |
+| 1080p–2MP | 928 |
+| With integration configs (Frigate / Home Assistant) | 2,515 |
+| With color-lux rating (`night_vision.min_lux_color`) | 1,803 |
 
 ### All 76 brands
 
@@ -189,6 +189,7 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | Uniview | 101 | Enterprise NDAA, global |
 | EZVIZ (Hikvision) | 87 | Consumer, global |
 | Axis | 81 | Enterprise premium, global |
+| i-PRO | 74 | Enterprise AI (ex-Panasonic), JP/global |
 | Annke | 64 | Prosumer, global |
 | Speco | 61 | Professional/commercial (NDAA), US |
 | Hi-Focus | 60 | Made-in-India, BIS certified, IN |
@@ -214,7 +215,6 @@ Or open `data/cameras.csv` in any spreadsheet for a quick browse.
 | Vivotek | 19 | Enterprise AI, global |
 | Avigilon | 18 | Enterprise NDAA, global |
 | SV3C | 17 | Budget consumer, CN/US |
-| i-PRO | 14 | Enterprise AI (ex-Panasonic), JP/global |
 | Wyze | 14 | Budget consumer, US |
 | Blink (Amazon) | 12 | Budget battery, US/UK/EU |
 | GeoVision | 12 | Enterprise, TW/Asia/global |

--- a/cameras/i-pro/wv-s25500-v3ln1.json
+++ b/cameras/i-pro/wv-s25500-v3ln1.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s25500-v3ln1",
+  "brand": "i-PRO",
+  "model": "WV-S25500-V3LN1",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5.3,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "33-103",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.05,
+    "range_m": 55
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V or PoE (IEEE802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25500-v3ln1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s25600-v2l.json
+++ b/cameras/i-pro/wv-s25600-v2l.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-s25600-v2l",
+  "brand": "i-PRO",
+  "model": "WV-S25600-V2L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.002,
+    "min_lux_color": 0.04
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "AI engine",
+    "FIPS 140-2 Level 3 secure element",
+    "motorized varifocal",
+    "IR LEDs",
+    "MQTT support"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2l"
+  ]
+}

--- a/cameras/i-pro/wv-s25600-v2lg.json
+++ b/cameras/i-pro/wv-s25600-v2lg.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-s25600-v2lg",
+  "brand": "i-PRO",
+  "model": "WV-S25600-V2LG",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "f/1.5-2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.09,
+    "min_lux_color": 0.12,
+    "range_m": 45
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V or PoE (IEEE802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "AI processor (up to 3 simultaneous AI apps)",
+    "Super Dynamic 132dB WDR",
+    "FIPS 140-2 Level 3 secure element",
+    "NDAA compliant",
+    "Motorized 2x optical zoom",
+    "IR LED (High/Middle/Low/Off)",
+    "Vandal-resistant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2lg"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s25600-v2ln.json
+++ b/cameras/i-pro/wv-s25600-v2ln.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-s25600-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-S25600-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "f/1.5-2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.03,
+    "min_lux_color": 0.04,
+    "range_m": 70
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "AI Engine",
+    "Super Dynamic 132dB WDR",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "Motorized zoom",
+    "Vandal resistant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2ln"
+  ]
+}

--- a/cameras/i-pro/wv-s25700-v2lg.json
+++ b/cameras/i-pro/wv-s25700-v2lg.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-s25700-v2lg",
+  "brand": "i-PRO",
+  "model": "WV-S25700-V2LG",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.09,
+    "min_lux_color": 0.12,
+    "range_m": 45
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) or DC12V",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "IR",
+    "motorized zoom",
+    "2x optical zoom",
+    "varifocal",
+    "4K",
+    "Super Dynamic WDR 132dB",
+    "AI analytics",
+    "AI sound detection",
+    "FIPS 140-2 Level 3",
+    "ONVIF Profile G/M/S/T",
+    "smart coding",
+    "auto focus"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2lg"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s25700-v2ln.json
+++ b/cameras/i-pro/wv-s25700-v2ln.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s25700-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-S25700-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.04,
+    "range_m": 70
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC 12V / PoE (IEEE 802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "varifocal",
+    "motorized-zoom",
+    "AI-analytics",
+    "Super-Dynamic-WDR",
+    "FIPS-140-2"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s25700-v2ln1.json
+++ b/cameras/i-pro/wv-s25700-v2ln1.json
@@ -1,0 +1,80 @@
+{
+  "id": "i-pro-wv-s25700-v2ln1",
+  "brand": "i-PRO",
+  "model": "WV-S25700-V2LN1",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.29,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.04,
+    "min_lux_color": 0.04
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE (IEEE802.3af) or DC12V",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61300-zy.json
+++ b/cameras/i-pro/wv-s61300-zy.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-s61300-zy",
+  "brand": "i-PRO",
+  "model": "WV-S61300-ZY",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-115",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.004,
+    "min_lux_color": 0.007
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "PTZ",
+    "auto-tracking",
+    "AI engine",
+    "Super Dynamic 144dB WDR",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "256 preset positions",
+    "3.1x optical zoom"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zy"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s61300-zyg.json
+++ b/cameras/i-pro/wv-s61300-zyg.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-s61300-zyg",
+  "brand": "i-PRO",
+  "model": "WV-S61300-ZYG",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "f/1.3-2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "115 (Wide) - 36 (Tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.012,
+    "min_lux_color": 0.02
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "AI Engine",
+    "PTZ",
+    "3.1x optical zoom",
+    "ONVIF Profile G/M/S/T",
+    "Color night vision",
+    "350° pan range"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zyg"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61301-z1.json
+++ b/cameras/i-pro/wv-s61301-z1.json
@@ -1,0 +1,96 @@
+{
+  "id": "i-pro-wv-s61301-z1",
+  "brand": "i-PRO",
+  "model": "WV-S61301-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.7-47",
+    "aperture": "f/1.6-f/3.0",
+    "varifocal": true
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "10x optical zoom",
+    "15x extra zoom",
+    "AI auto-tracking",
+    "AI Privacy Guard",
+    "AI Face Detection",
+    "AI People Detection",
+    "AI Vehicle Detection",
+    "Super Dynamic 144dB WDR",
+    "gyro image stabilizer",
+    "256 preset positions",
+    "audio detection (gunshot/yell/horn/glass)",
+    "FIPS 140-2 level 3 security",
+    "ONVIF Profile G/M/S/T",
+    "32 privacy zones"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z1"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s61301-z2.json
+++ b/cameras/i-pro/wv-s61301-z2.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-s61301-z2",
+  "brand": "i-PRO",
+  "model": "WV-S61301-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "77 (WIDE) - 3.7 (TELE)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "Super Dynamic 144dB WDR",
+    "256 preset positions",
+    "ONVIF Profile G/M/S/T",
+    "FIPS 140-2 Level 3 Secure Element",
+    "Auto-tracking",
+    "Extra zoom up to 31x at 720p"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z2"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s61301a-z2-1.json
+++ b/cameras/i-pro/wv-s61301a-z2-1.json
@@ -1,0 +1,84 @@
+{
+  "id": "i-pro-wv-s61301a-z2-1",
+  "brand": "i-PRO",
+  "model": "WV-S61301A-Z2-1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "77 (Wide) - 3.7 (Tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.08,
+    "min_lux_color": 0.08
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE (IEEE802.3af) or DC 12V",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "AI",
+    "21x optical zoom",
+    "PTZ",
+    "color night vision",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2-1"
+  ]
+}

--- a/cameras/i-pro/wv-s61301a-z2.json
+++ b/cameras/i-pro/wv-s61301a-z2.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-s61301a-z2",
+  "brand": "i-PRO",
+  "model": "WV-S61301A-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.08
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE IEEE802.3af",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "AI analytics",
+    "ONVIF Profile G/M/S/T",
+    "256 preset positions",
+    "FIPS 140-3",
+    "NDAA compliant",
+    "Edge AI",
+    "Super Dynamic 144dB WDR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61302-z4.json
+++ b/cameras/i-pro/wv-s61302-z4.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-s61302-z4",
+  "brand": "i-PRO",
+  "model": "WV-S61302-Z4",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI auto-tracking",
+    "person detection",
+    "vehicle detection",
+    "360° endless pan",
+    "privacy guard",
+    "occupancy detection",
+    "scene change detection",
+    "FIPS 140-2 level 3",
+    "Super Dynamic 144dB WDR",
+    "256 presets"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302-z4"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s61302a-z4.json
+++ b/cameras/i-pro/wv-s61302a-z4.json
@@ -1,0 +1,89 @@
+{
+  "id": "i-pro-wv-s61302a-z4",
+  "brand": "i-PRO",
+  "model": "WV-S61302A-Z4",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8 type CMOS",
+  "lens": {
+    "focal_length_mm": "4.25-170",
+    "aperture": "F1.6-4.95",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "1.9-66 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.001,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "40x optical zoom",
+    "AI analytics",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "audio classification",
+    "privacy masking",
+    "256 presets",
+    "360 degree pan",
+    "FIPS 140-3"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302a-z4"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61501-z1.json
+++ b/cameras/i-pro/wv-s61501-z1.json
@@ -1,0 +1,77 @@
+{
+  "id": "i-pro-wv-s61501-z1",
+  "brand": "i-PRO",
+  "model": "WV-S61501-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "6.2-58 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.06,
+    "min_lux_color": 0.08
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61501-z1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61602-z3.json
+++ b/cameras/i-pro/wv-s61602-z3.json
@@ -1,0 +1,83 @@
+{
+  "id": "i-pro-wv-s61602-z3",
+  "brand": "i-PRO",
+  "model": "WV-S61602-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (Wide) - 2.5 (Tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE802.3at) or DC12V",
+    "consumption_w": 16.7
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "AI engine",
+    "30x optical zoom",
+    "motorized zoom/focus",
+    "ONVIF Profile G/S/T/M"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602-z3"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61602a-z3.json
+++ b/cameras/i-pro/wv-s61602a-z3.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-s61602a-z3",
+  "brand": "i-PRO",
+  "model": "WV-S61602A-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE+ (IEEE 802.3at)",
+    "consumption_w": 16.7
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "30x optical zoom",
+    "PTZ",
+    "256 preset positions",
+    "4 simultaneous streams",
+    "ONVIF Profile G/S/T/M",
+    "Edge AI analytics",
+    "FIPS 140-3 level 3",
+    "NDAA compliant",
+    "Auto-tracking capable"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602a-z3"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s61702-z3.json
+++ b/cameras/i-pro/wv-s61702-z3.json
@@ -1,0 +1,77 @@
+{
+  "id": "i-pro-wv-s61702-z3",
+  "brand": "i-PRO",
+  "model": "WV-S61702-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true
+  },
+  "field_of_view_deg": "62-2.5 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "environment": [
+    "indoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "power": {
+    "method": "PoE+ (IEEE802.3at) or DC 12V",
+    "consumption_w": 16.7
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702-z3"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s61702a-z3.json
+++ b/cameras/i-pro/wv-s61702a-z3.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s61702a-z3",
+  "brand": "i-PRO",
+  "model": "WV-S61702A-Z3",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/2\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.5-135",
+    "aperture": "F1.8-F4.7",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.1,
+    "min_lux_color": 0.13
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "environment": [
+    "indoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "power": {
+    "method": "PoE+ (IEEE802.3at) or DC12V",
+    "consumption_w": 16.7
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "4K",
+    "30x optical zoom",
+    "AI",
+    "ONVIF Profile G/S/T/M",
+    "FIPS 140-3 Level 3",
+    "IEEE802.1X",
+    "4 simultaneous streams"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702a-z3"
+  ]
+}

--- a/cameras/i-pro/wv-s65300-zy.json
+++ b/cameras/i-pro/wv-s65300-zy.json
@@ -1,0 +1,94 @@
+{
+  "id": "i-pro-wv-s65300-zy",
+  "brand": "i-PRO",
+  "model": "WV-S65300-ZY",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "113-36",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.001,
+    "min_lux_color": 0.001
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI auto-tracking",
+    "people detection",
+    "vehicle detection",
+    "face detection",
+    "privacy zones",
+    "video motion detection",
+    "256 preset positions",
+    "3.1x optical zoom",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3 secure element"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zy"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65300-zyg.json
+++ b/cameras/i-pro/wv-s65300-zyg.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-s65300-zyg",
+  "brand": "i-PRO",
+  "model": "WV-S65300-ZYG",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-113",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.012,
+    "min_lux_color": 0.02
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "auto-tracking",
+    "AI engine",
+    "ONVIF Profile G/M/S/T",
+    "Super Dynamic 144dB WDR",
+    "FIPS 140-2 Level 3",
+    "256 preset positions",
+    "3.1x optical zoom"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "release_year": 2023,
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zyg"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65301-z1-1.json
+++ b/cameras/i-pro/wv-s65301-z1-1.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-s65301-z1-1",
+  "brand": "i-PRO",
+  "model": "WV-S65301-Z1-1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (wide) - 6.7 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "DC 12V / PoE / PoE+",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "AI auto-tracking",
+    "Face detection",
+    "Vehicle detection",
+    "People detection",
+    "360° endless pan",
+    "256 presets",
+    "10x optical zoom",
+    "FIPS 140-2 Level 3 secure element",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1-1"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65301-z1.json
+++ b/cameras/i-pro/wv-s65301-z1.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-s65301-z1",
+  "brand": "i-PRO",
+  "model": "WV-S65301-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.7-47",
+    "aperture": "f/1.6-3.0",
+    "varifocal": true
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE / PoE+ / DC12V",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor",
+    "indoor"
+  ],
+  "features": [
+    "10x optical zoom",
+    "motorized varifocal",
+    "ONVIF Profile G/M/S/T",
+    "wind resistance up to 40 m/s"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s65301-z1g.json
+++ b/cameras/i-pro/wv-s65301-z1g.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-s65301-z1g",
+  "brand": "i-PRO",
+  "model": "WV-S65301-Z1G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.017,
+    "min_lux_color": 0.03
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI auto-tracking",
+    "AI people/vehicle detection",
+    "10x optical zoom",
+    "360° endless pan",
+    "Image stabilizer (gyro)",
+    "FIPS 140-2 Level 3 secure element",
+    "NDAA compliant",
+    "32 privacy zones",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1g"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65301-z1s.json
+++ b/cameras/i-pro/wv-s65301-z1s.json
@@ -1,0 +1,97 @@
+{
+  "id": "i-pro-wv-s65301-z1s",
+  "brand": "i-PRO",
+  "model": "WV-S65301-Z1S",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.7-47",
+    "aperture": "f/1.6-f/3.0",
+    "varifocal": true
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.001,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "power": {
+    "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+    "consumption_w": 18.4
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "features": [
+    "10x optical zoom",
+    "auto-tracking",
+    "360° endless pan",
+    "256 preset positions",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "occupancy detection",
+    "scene change detection",
+    "privacy masking",
+    "FIPS 140-2 level 3 security",
+    "heavy salt damage resistance",
+    "Super Dynamic 144dB WDR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1s"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65302-z2-1.json
+++ b/cameras/i-pro/wv-s65302-z2-1.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-s65302-z2-1",
+  "brand": "i-PRO",
+  "model": "WV-S65302-Z2-1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "power": {
+    "method": "DC12V / PoE (802.3af) / PoE+ (802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "AI auto-tracking",
+    "360° endless pan",
+    "256 presets",
+    "NDAA compliant",
+    "FIPS 140-2 Level 3",
+    "AI Sound Classification",
+    "Super Dynamic HDR (144dB)"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2-1"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65302-z2.json
+++ b/cameras/i-pro/wv-s65302-z2.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s65302-z2",
+  "brand": "i-PRO",
+  "model": "WV-S65302-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true
+  },
+  "field_of_view_deg": "77 (wide) - 3.7 (tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.015
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V / PoE / PoE+",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s65302-z2g.json
+++ b/cameras/i-pro/wv-s65302-z2g.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-s65302-z2g",
+  "brand": "i-PRO",
+  "model": "WV-S65302-Z2G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true
+  },
+  "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0011,
+    "min_lux_color": 0.003
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "power": {
+    "method": "PoE+ (IEEE 802.3at) / DC 12V",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI auto-tracking",
+    "360° endless pan",
+    "21x optical zoom",
+    "Super Dynamic 144dB WDR",
+    "256 preset positions",
+    "FIPS 140-2 Level 3 secure element",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2g"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z2.json
+++ b/cameras/i-pro/wv-s65340-z2.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-s65340-z2",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-s65340-z2g.json
+++ b/cameras/i-pro/wv-s65340-z2g.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-s65340-z2g",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z2G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.017,
+    "min_lux_color": 0.03
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE++/PoE+/AC24V",
+    "consumption_w": 50.84
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "features": [
+    "AI auto-tracking",
+    "21x optical zoom",
+    "Super Dynamic 144dB HDR",
+    "256 presets",
+    "Image stabilization",
+    "FIPS 140-2 Level 3 secure element",
+    "32 privacy zones",
+    "Smart Coding"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2g"
+  ],
+  "last_verified": "2026-08-15",
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-s65340-z2k.json
+++ b/cameras/i-pro/wv-s65340-z2k.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-s65340-z2k",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z2K",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "nvr_compatible": true,
+    "cloud": false
+  },
+  "power": {
+    "method": "PoE++ or AC24V",
+    "consumption_w": 53.3
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "motorized zoom",
+    "motorized focus",
+    "IR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2k"
+  ]
+}

--- a/cameras/i-pro/wv-s65340-z2n.json
+++ b/cameras/i-pro/wv-s65340-z2n.json
@@ -1,0 +1,96 @@
+{
+  "id": "i-pro-wv-s65340-z2n",
+  "brand": "i-PRO",
+  "model": "WV-S65340-Z2N",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) / AC 24V",
+    "consumption_w": 50.84
+  },
+  "power_source": [
+    "poe",
+    "ac-mains"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "PTZ",
+    "21x optical zoom",
+    "AI auto-tracking",
+    "AI video motion detection",
+    "AI privacy guard",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "FIPS 140-2 Level 3 secure element",
+    "256 preset positions",
+    "IEEE 802.1X",
+    "HTTPS"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n"
+  ],
+  "ptz": {
+    "autotracking": true
+  }
+}

--- a/cameras/i-pro/wv-u61300-zy.json
+++ b/cameras/i-pro/wv-u61300-zy.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-u61300-zy",
+  "brand": "i-PRO",
+  "model": "WV-U61300-ZY",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "environment": [
+    "indoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-115",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.004,
+    "min_lux_color": 0.007
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE802.3af)",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "dc",
+    "poe"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "3.1x optical zoom",
+    "motorized zoom",
+    "motorized focus",
+    "256 preset positions",
+    "pan 350°",
+    "tilt 90°",
+    "ONVIF Profile G/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zy"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u61300-zyg.json
+++ b/cameras/i-pro/wv-u61300-zyg.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-u61300-zyg",
+  "brand": "i-PRO",
+  "model": "WV-U61300-ZYG",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-115",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.012,
+    "min_lux_color": 0.02
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) or DC12V",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "PTZ",
+    "3.1x optical zoom",
+    "350° pan",
+    "90° tilt",
+    "256 presets",
+    "Super Dynamic 144dB WDR",
+    "ONVIF Profile G/S/T",
+    "FIPS 140-2 level 3",
+    "privacy zones"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zyg"
+  ]
+}

--- a/cameras/i-pro/wv-u61301-z1.json
+++ b/cameras/i-pro/wv-u61301-z1.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-u61301-z1",
+  "brand": "i-PRO",
+  "model": "WV-U61301-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "none",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "10x optical zoom",
+    "PTZ",
+    "256 preset positions",
+    "Super Dynamic (144dB WDR)",
+    "autofocus",
+    "FIPS 140-2 level 3"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z1"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u61301-z2.json
+++ b/cameras/i-pro/wv-u61301-z2.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-u61301-z2",
+  "brand": "i-PRO",
+  "model": "WV-U61301-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "256 presets",
+    "auto focus",
+    "image stabilizer",
+    "144dB super dynamic range",
+    "privacy zones",
+    "video motion detection",
+    "ICR",
+    "FIPS 140-2 level 3 security",
+    "NDAA compliant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u61301a-z2.json
+++ b/cameras/i-pro/wv-u61301a-z2.json
@@ -1,0 +1,77 @@
+{
+  "id": "i-pro-wv-u61301a-z2",
+  "brand": "i-PRO",
+  "model": "WV-U61301A-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77 (H)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0004,
+    "min_lux_color": 0.001
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE (IEEE 802.3af)",
+    "consumption_w": 12.95
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301a-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u65300-zy.json
+++ b/cameras/i-pro/wv-u65300-zy.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-u65300-zy",
+  "brand": "i-PRO",
+  "model": "WV-U65300-ZY",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-113",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.0003,
+    "min_lux_color": 0.007
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "PoE (IEEE802.3af) or DC12V",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zy"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u65300-zyg.json
+++ b/cameras/i-pro/wv-u65300-zyg.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-u65300-zyg",
+  "brand": "i-PRO",
+  "model": "WV-U65300-ZYG",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "113 (wide) - 36 (tele)",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.012,
+    "min_lux_color": 0.02
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE IEEE 802.3af",
+    "consumption_w": 12
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "3.1x optical zoom",
+    "color night vision",
+    "motorized varifocal",
+    "PTZ"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zyg"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u65301-z1.json
+++ b/cameras/i-pro/wv-u65301-z1.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-u65301-z1",
+  "brand": "i-PRO",
+  "model": "WV-U65301-Z1",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "62 (Wide) - 6.7 (Tele) horizontal",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "10x optical zoom",
+    "color night vision",
+    "ONVIF Profile G/S/T",
+    "full duplex audio"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1"
+  ]
+}

--- a/cameras/i-pro/wv-u65301-z1g.json
+++ b/cameras/i-pro/wv-u65301-z1g.json
@@ -1,0 +1,90 @@
+{
+  "id": "i-pro-wv-u65301-z1g",
+  "brand": "i-PRO",
+  "model": "WV-U65301-Z1G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.7-47",
+    "aperture": "F1.6-F3.0",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "6.7-62",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.017,
+    "min_lux_color": 0.03
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "10x optical zoom",
+    "360° endless pan",
+    "256 preset positions",
+    "Super Dynamic 144dB WDR",
+    "ONVIF Profile G/S/T",
+    "Privacy zones",
+    "IEEE 802.1X",
+    "FIPS 140-2 Level 3 secure element",
+    "Intelligent auto mode"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1g"
+  ]
+}

--- a/cameras/i-pro/wv-u65302-z2.json
+++ b/cameras/i-pro/wv-u65302-z2.json
@@ -1,0 +1,93 @@
+{
+  "id": "i-pro-wv-u65302-z2",
+  "brand": "i-PRO",
+  "model": "WV-U65302-Z2",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "3.7-77",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "color",
+    "min_lux": 0.006,
+    "min_lux_color": 0.011
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "21x optical zoom",
+    "31x HD Extra Optical Zoom",
+    "Color night vision",
+    "Image stabilizer (gyro)",
+    "Super Dynamic 144dB WDR",
+    "Intelligent Auto",
+    "Privacy zones (up to 8)",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "ONVIF Profile G/S/T",
+    "360° endless pan",
+    "Alarm recording"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-u65302-z2g.json
+++ b/cameras/i-pro/wv-u65302-z2g.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-u65302-z2g",
+  "brand": "i-PRO",
+  "model": "WV-U65302-Z2G",
+  "type": "ptz",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.0-84.6",
+    "aperture": "F1.6-F4.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "77-3.7",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.017,
+    "min_lux_color": 0.03
+  },
+  "ip_rating": "IP66",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+    "consumption_w": 18.4
+  },
+  "power_source": [
+    "dc",
+    "poe"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "21x optical zoom",
+    "31x HD extra optical zoom",
+    "FIPS 140-2 Level 3 secure element",
+    "NDAA compliant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2g"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x22300a-v3l.json
+++ b/cameras/i-pro/wv-x22300a-v3l.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-x22300a-v3l",
+  "brand": "i-PRO",
+  "model": "WV-X22300A-V3L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 2.1,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true
+  },
+  "field_of_view_deg": "36-114",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux_color": 0.007
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE+ (IEEE802.3at)",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "ik_rating": "IK10",
+  "features": [
+    "AI",
+    "varifocal",
+    "motorized-zoom",
+    "IR",
+    "vandal-resistant",
+    "ONVIF Profile G/M/S/T"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22300a-v3l"
+  ]
+}

--- a/cameras/i-pro/wv-x22500-v3l.json
+++ b/cameras/i-pro/wv-x22500-v3l.json
@@ -1,0 +1,78 @@
+{
+  "id": "i-pro-wv-x22500-v3l",
+  "brand": "i-PRO",
+  "model": "WV-X22500-V3L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5.3,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "33-105",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.03,
+    "range_m": 70
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE 802.3at) or DC12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "ik_rating": "IK10",
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500-v3l"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x22500a-v3l.json
+++ b/cameras/i-pro/wv-x22500a-v3l.json
@@ -1,0 +1,85 @@
+{
+  "id": "i-pro-wv-x22500a-v3l",
+  "brand": "i-PRO",
+  "model": "WV-X22500A-V3L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 2304,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true
+  },
+  "field_of_view_deg": "33-105",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux_color": 0.03
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE 802.3at) or DC 12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "environment": [
+    "indoor"
+  ],
+  "ik_rating": "IK10",
+  "features": [
+    "AI",
+    "motorized zoom",
+    "3.1x optical zoom",
+    "vandal resistant",
+    "IR illumination"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500a-v3l"
+  ]
+}

--- a/cameras/i-pro/wv-x22600-v2l.json
+++ b/cameras/i-pro/wv-x22600-v2l.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x22600-v2l",
+  "brand": "i-PRO",
+  "model": "WV-X22600-V2L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.03,
+    "min_lux_color": 0.04
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE802.3at) or DC12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "ik_rating": "IK10",
+  "features": [
+    "AI analytics",
+    "motorized zoom",
+    "motorized focus",
+    "FIPS 140-2 Level 3 security",
+    "ONVIF Profile G/S/T/M",
+    "vandal resistant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600-v2l"
+  ]
+}

--- a/cameras/i-pro/wv-x22600a-v2l.json
+++ b/cameras/i-pro/wv-x22600a-v2l.json
@@ -1,0 +1,91 @@
+{
+  "id": "i-pro-wv-x22600a-v2l",
+  "brand": "i-PRO",
+  "model": "WV-X22600A-V2L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.04,
+    "range_m": 70
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE+ (IEEE 802.3at)",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "ik_rating": "IK10",
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "varifocal",
+    "motorized-zoom",
+    "ir",
+    "edge-ai",
+    "vandal-resistant",
+    "wide-dynamic-range",
+    "onvif-profile-g",
+    "onvif-profile-m",
+    "onvif-profile-s",
+    "onvif-profile-t",
+    "fips-140-3"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600a-v2l"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x22700-v2l.json
+++ b/cameras/i-pro/wv-x22700-v2l.json
@@ -1,0 +1,96 @@
+{
+  "id": "i-pro-wv-x22700-v2l",
+  "brand": "i-PRO",
+  "model": "WV-X22700-V2L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.29,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.03,
+    "min_lux_color": 0.04
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE+ (IEEE 802.3at)",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor"
+  ],
+  "ik_rating": "IK10",
+  "features": [
+    "varifocal",
+    "motorized-zoom",
+    "motorized-focus",
+    "AI-analytics",
+    "edge-AI",
+    "face-detection",
+    "vehicle-detection",
+    "occupancy-detection",
+    "privacy-guard",
+    "ONVIF-Profile-G",
+    "ONVIF-Profile-S",
+    "ONVIF-Profile-T",
+    "ONVIF-Profile-M",
+    "MQTT",
+    "vandal-resistant"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700-v2l"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x22700a-v2l.json
+++ b/cameras/i-pro/wv-x22700a-v2l.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x22700a-v2l",
+  "brand": "i-PRO",
+  "model": "WV-X22700A-V2L",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.03,
+    "min_lux_color": 0.04
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (802.3at) or DC12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "ik_rating": "IK10",
+  "environment": [
+    "indoor"
+  ],
+  "features": [
+    "2x optical zoom",
+    "AI analytics",
+    "image stabilizer",
+    "privacy zones",
+    "ONVIF Profile G/M/S/T",
+    "FIPS 140-3 Level 3 secure element"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700a-v2l"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25300-v3ln.json
+++ b/cameras/i-pro/wv-x25300-v3ln.json
@@ -1,0 +1,86 @@
+{
+  "id": "i-pro-wv-x25300-v3ln",
+  "brand": "i-PRO",
+  "model": "WV-X25300-V3LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-113",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.007,
+    "range_m": 70
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "power": {
+    "method": "DC12V or PoE+",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "AI engine",
+    "FIPS 140-2 Level 3",
+    "NDAA compliant",
+    "motorized zoom",
+    "IR"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300-v3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25300a-v3ln.json
+++ b/cameras/i-pro/wv-x25300a-v3ln.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x25300a-v3ln",
+  "brand": "i-PRO",
+  "model": "WV-X25300A-V3LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 2,
+    "max_width": 1920,
+    "max_height": 1080,
+    "label": "1080p"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "36-113",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux_color": 0.007
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE+",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "motorized zoom",
+    "autofocus",
+    "Edge AI",
+    "NDAA compliant",
+    "FIPS 140-3 Level 3",
+    "IR illumination"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300a-v3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25500-v3ln.json
+++ b/cameras/i-pro/wv-x25500-v3ln.json
@@ -1,0 +1,92 @@
+{
+  "id": "i-pro-wv-x25500-v3ln",
+  "brand": "i-PRO",
+  "model": "WV-X25500-V3LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "33-103",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.03,
+    "range_m": 70
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC12V or PoE+ (IEEE802.3at)",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "motorized zoom",
+    "3.1x optical zoom",
+    "IR",
+    "Edge AI analytics",
+    "FIPS 140-2 level 3 security",
+    "132dB WDR",
+    "face detection",
+    "people detection",
+    "vehicle detection",
+    "privacy guard",
+    "occupancy detection"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500-v3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25500a-v3ln.json
+++ b/cameras/i-pro/wv-x25500a-v3ln.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-x25500a-v3ln",
+  "brand": "i-PRO",
+  "model": "WV-X25500A-V3LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.9-9",
+    "aperture": "F1.3-F2.5",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "33-103",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.03,
+    "range_m": 70
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "DC 12V or PoE+",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500a-v3ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25580-f2ln2.json
+++ b/cameras/i-pro/wv-x25580-f2ln2.json
@@ -1,0 +1,87 @@
+{
+  "id": "i-pro-wv-x25580-f2ln2",
+  "brand": "i-PRO",
+  "model": "WV-X25580-F2LN2",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 5.3,
+    "max_width": 3072,
+    "max_height": 1728,
+    "label": "5MP"
+  },
+  "sensor": "1/2.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "2.3",
+    "aperture": "F2.2",
+    "varifocal": false,
+    "count": 1
+  },
+  "field_of_view_deg": "131",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 21,
+    "min_lux": 0.07,
+    "min_lux_color": 0.08
+  },
+  "ip_rating": "IP69",
+  "ik_rating": "IK11",
+  "audio": {
+    "microphone": true,
+    "speaker": false,
+    "two_way": false
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE (IEEE 802.3af) or DC 12V",
+    "consumption_w": 12.6
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "indoor",
+    "outdoor"
+  ],
+  "features": [
+    "AI engine",
+    "anti-ligature",
+    "IR illumination",
+    "MQTT support"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25580-f2ln2"
+  ]
+}

--- a/cameras/i-pro/wv-x25600-v2ln.json
+++ b/cameras/i-pro/wv-x25600-v2ln.json
@@ -1,0 +1,79 @@
+{
+  "id": "i-pro-wv-x25600-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-X25600-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux_color": 0.04,
+    "range_m": 70
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "power": {
+    "method": "DC12V or PoE+",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600-v2ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25600a-v2ln.json
+++ b/cameras/i-pro/wv-x25600a-v2ln.json
@@ -1,0 +1,80 @@
+{
+  "id": "i-pro-wv-x25600a-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-X25600A-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 6.2,
+    "max_width": 3328,
+    "max_height": 1872,
+    "label": "6MP"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "count": 1,
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.04,
+    "min_lux_color": 0.04
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "power": {
+    "method": "PoE+ / DC 12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600a-v2ln"
+  ],
+  "last_verified": "2026-08-15"
+}

--- a/cameras/i-pro/wv-x25700-v2ln.json
+++ b/cameras/i-pro/wv-x25700-v2ln.json
@@ -1,0 +1,96 @@
+{
+  "id": "i-pro-wv-x25700-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-X25700-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.29,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "min_lux": 0.03,
+    "min_lux_color": 0.04,
+    "range_m": 70
+  },
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "power": {
+    "method": "PoE+ (IEEE 802.3at) or DC 12V",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "poe",
+    "dc"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp",
+    "http"
+  ],
+  "environment": [
+    "outdoor"
+  ],
+  "features": [
+    "IR",
+    "Motorized Zoom",
+    "AI Analytics",
+    "Edge AI",
+    "Face Detection",
+    "People Detection",
+    "Vehicle Detection",
+    "Occupancy Detection",
+    "Privacy Masking",
+    "FIPS 140-2 Level 3",
+    "IEEE 802.1X",
+    "ONVIF Profile G/S/T/M",
+    "4K"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700-v2ln"
+  ]
+}

--- a/cameras/i-pro/wv-x25700a-v2ln.json
+++ b/cameras/i-pro/wv-x25700a-v2ln.json
@@ -1,0 +1,88 @@
+{
+  "id": "i-pro-wv-x25700a-v2ln",
+  "brand": "i-PRO",
+  "model": "WV-X25700A-V2LN",
+  "type": "dome",
+  "resolution": {
+    "megapixels": 8.3,
+    "max_width": 3840,
+    "max_height": 2160,
+    "label": "4K"
+  },
+  "sensor": "1/1.8\" CMOS",
+  "lens": {
+    "focal_length_mm": "4.3-8.6",
+    "aperture": "F1.5-F2.4",
+    "varifocal": true,
+    "count": 1
+  },
+  "field_of_view_deg": "52-101",
+  "video": {
+    "codecs": [
+      "H.265",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 60
+  },
+  "night_vision": {
+    "type": "ir",
+    "range_m": 70,
+    "min_lux": 0.02,
+    "min_lux_color": 0.04
+  },
+  "ip_rating": "IP66/IP67",
+  "ik_rating": "IK10",
+  "environment": [
+    "outdoor"
+  ],
+  "connectivity": [
+    "ethernet"
+  ],
+  "protocols": [
+    "onvif",
+    "rtsp"
+  ],
+  "power": {
+    "method": "DC 12V or PoE+",
+    "consumption_w": 14.2
+  },
+  "power_source": [
+    "dc",
+    "poe"
+  ],
+  "audio": {
+    "microphone": true,
+    "speaker": true,
+    "two_way": true
+  },
+  "storage": {
+    "onboard": true,
+    "max_microsd_gb": 512,
+    "cloud": false,
+    "nvr_compatible": true
+  },
+  "features": [
+    "AI analytics",
+    "FIPS 140-3 Level 3",
+    "NDAA compliant",
+    "Smart Coding",
+    "motorized zoom",
+    "motorized focus"
+  ],
+  "configs": {
+    "frigate": {
+      "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+      "detect": {
+        "width": 640,
+        "height": 480,
+        "fps": 5
+      }
+    }
+  },
+  "last_verified": "2026-08-15",
+  "sources": [
+    "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700a-v2ln"
+  ]
+}

--- a/data/cameras.csv
+++ b/data/cameras.csv
@@ -2008,13 +2008,73 @@ i-pro-wv-s15700-v2ln,i-PRO,WV-S15700-V2LN,bullet,4K,8.3,1/1.8 type CMOS,"104-53 
 i-pro-wv-s2236l,i-PRO,WV-S2236L,dome,1080p HD,2,"1/3"" CMOS",100-31 horizontal,color,,IK10,false,2021
 i-pro-wv-s22500-v3l,i-PRO,WV-S22500-V3L,dome,5MP,5,"1/2.8"" CMOS","105-33 horizontal, 56-19 vertical",hybrid,,IK10,true,2022
 i-pro-wv-s25500-v3l,i-PRO,WV-S25500-V3L,dome,5MP,5,"1/2.8"" CMOS","103-33 horizontal, 55-19 vertical",hybrid,IP66,IK10,true,2022
+i-pro-wv-s25500-v3ln1,i-PRO,WV-S25500-V3LN1,dome,5MP,5.3,"1/2.8"" CMOS",33-103,ir,IP66,IK10,true,
+i-pro-wv-s25600-v2l,i-PRO,WV-S25600-V2L,dome,6MP,6.2,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
+i-pro-wv-s25600-v2lg,i-PRO,WV-S25600-V2LG,dome,6MP,6,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
+i-pro-wv-s25600-v2ln,i-PRO,WV-S25600-V2LN,dome,6MP,6,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
 i-pro-wv-s25700-v2l,i-PRO,WV-S25700-V2L,dome,4K,8.3,"1/1.8"" CMOS","101-52 horizontal, 55-29 vertical",hybrid,IP66,IK10,true,2022
+i-pro-wv-s25700-v2lg,i-PRO,WV-S25700-V2LG,dome,4K,8.3,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
+i-pro-wv-s25700-v2ln,i-PRO,WV-S25700-V2LN,dome,4K,8.3,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
+i-pro-wv-s25700-v2ln1,i-PRO,WV-S25700-V2LN1,dome,4K,8.29,"1/1.8"" CMOS",52-101,ir,IP66,IK10,true,
+i-pro-wv-s61300-zy,i-PRO,WV-S61300-ZY,ptz,1080p,2,"1/2.8"" CMOS",36-115,color,,,true,
+i-pro-wv-s61300-zyg,i-PRO,WV-S61300-ZYG,ptz,1080p,2,"1/2.8"" CMOS",115 (Wide) - 36 (Tele) horizontal,color,,,true,
+i-pro-wv-s61301-z1,i-PRO,WV-S61301-Z1,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,color,,,true,
+i-pro-wv-s61301-z2,i-PRO,WV-S61301-Z2,ptz,1080p,2.1,"1/2.8"" CMOS",77 (WIDE) - 3.7 (TELE),color,,,true,
+i-pro-wv-s61301a-z2,i-PRO,WV-S61301A-Z2,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,,,true,
+i-pro-wv-s61301a-z2-1,i-PRO,WV-S61301A-Z2-1,ptz,1080p,2,"1/2.8"" CMOS",77 (Wide) - 3.7 (Tele) horizontal,color,,,true,
+i-pro-wv-s61302-z4,i-PRO,WV-S61302-Z4,ptz,1080p,2,"1/2.8"" CMOS",1.9-66 (H),color,,,true,
+i-pro-wv-s61302a-z4,i-PRO,WV-S61302A-Z4,ptz,1080p,2,1/2.8 type CMOS,1.9-66 (H),color,,,true,
+i-pro-wv-s61501-z1,i-PRO,WV-S61501-Z1,ptz,5MP,5,"1/2.8"" CMOS",6.2-58 (H),color,,,true,
+i-pro-wv-s61602-z3,i-PRO,WV-S61602-Z3,ptz,6MP,6,"1/2.8"" CMOS",62 (Wide) - 2.5 (Tele) horizontal,none,,,true,
+i-pro-wv-s61602a-z3,i-PRO,WV-S61602A-Z3,ptz,6MP,6.2,"1/2.8"" CMOS",62 (wide) - 2.5 (tele),none,,,true,
+i-pro-wv-s61702-z3,i-PRO,WV-S61702-Z3,ptz,4K,8.3,"1/2.8"" CMOS",62-2.5 (H),none,,,true,
+i-pro-wv-s61702a-z3,i-PRO,WV-S61702A-Z3,ptz,4K,8.3,"1/2"" CMOS",62,none,,,true,
+i-pro-wv-s65300-zy,i-PRO,WV-S65300-ZY,ptz,1080p,2,"1/2.8"" CMOS",113-36,color,IP66,IK10,true,
+i-pro-wv-s65300-zyg,i-PRO,WV-S65300-ZYG,ptz,1080p,2,"1/2.8"" CMOS",36-113,color,IP66,IK10,true,2023
+i-pro-wv-s65301-z1,i-PRO,WV-S65301-Z1,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,none,IP66,IK10,true,
+i-pro-wv-s65301-z1-1,i-PRO,WV-S65301-Z1-1,ptz,1080p,2,"1/2.8"" CMOS",62 (wide) - 6.7 (tele),color,IP66,IK10,true,
+i-pro-wv-s65301-z1g,i-PRO,WV-S65301-Z1G,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,color,IP66,IK10,true,
+i-pro-wv-s65301-z1s,i-PRO,WV-S65301-Z1S,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,color,IP66,IK10,true,
+i-pro-wv-s65302-z2,i-PRO,WV-S65302-Z2,ptz,1080p,2,"1/2.8"" CMOS",77 (wide) - 3.7 (tele) horizontal,color,IP66,IK10,true,
+i-pro-wv-s65302-z2-1,i-PRO,WV-S65302-Z2-1,ptz,1080p,2,"1/2.8"" CMOS",77 (wide) to 3.7 (tele),color,IP66,IK10,true,
+i-pro-wv-s65302-z2g,i-PRO,WV-S65302-Z2G,ptz,1080p,2,"1/2.8"" CMOS",77 (wide) to 3.7 (tele),color,IP66,IK10,true,
 i-pro-wv-s6532ln,i-PRO,WV-S6532LN,ptz,1080p,2,"1/2.8"" CMOS",66-3.4 horizontal,hybrid,IP66,IK10,true,2022
+i-pro-wv-s65340-z2,i-PRO,WV-S65340-Z2,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,IP66/IP67,IK10,true,
+i-pro-wv-s65340-z2g,i-PRO,WV-S65340-Z2G,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,IP66/IP67,IK10,true,
+i-pro-wv-s65340-z2k,i-PRO,WV-S65340-Z2K,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,IP66/IP67,IK10,true,
+i-pro-wv-s65340-z2n,i-PRO,WV-S65340-Z2N,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,IP66/IP67,IK10,true,
 i-pro-wv-s8530n,i-PRO,WV-S8530N,dome,4K UHD,8,"1/1.7"" CMOS",92-31 horizontal,color,IP66,,false,2022
 i-pro-wv-s8574l,i-PRO,WV-S8574L,panoramic,"4x 4K per sensor (~33MP total, 4-sensor)",8,"4 x 1/2.8"" CMOS (four independently steerable sensors)","108 horizontal, 56 vertical (per sensor); 360 total coverage",hybrid,IP66/IP67,IK10,true,2023
 i-pro-wv-u2532la,i-PRO,WV-U2532LA,dome,1080p,2,"1/3"" CMOS","42-97 horizontal, 23-54 vertical",hybrid,IP66,IK10,false,2022
+i-pro-wv-u61300-zy,i-PRO,WV-U61300-ZY,ptz,1080p,2,"1/2.8"" CMOS",36-115,color,,,true,
+i-pro-wv-u61300-zyg,i-PRO,WV-U61300-ZYG,ptz,1080p,2,"1/2.8"" CMOS",36-115,color,,,true,
+i-pro-wv-u61301-z1,i-PRO,WV-U61301-Z1,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,none,,,true,
+i-pro-wv-u61301-z2,i-PRO,WV-U61301-Z2,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,,,true,
+i-pro-wv-u61301a-z2,i-PRO,WV-U61301A-Z2,ptz,1080p,2,"1/2.8"" CMOS",3.7-77 (H),color,,,true,
+i-pro-wv-u65300-zy,i-PRO,WV-U65300-ZY,ptz,1080p,2,"1/2.8"" CMOS",36-113,color,IP66,IK10,true,
+i-pro-wv-u65300-zyg,i-PRO,WV-U65300-ZYG,ptz,1080p,2,"1/2.8"" CMOS",113 (wide) - 36 (tele),color,IP66,IK10,true,
+i-pro-wv-u65301-z1,i-PRO,WV-U65301-Z1,ptz,1080p,2,"1/2.8"" CMOS",62 (Wide) - 6.7 (Tele) horizontal,color,IP66,IK10,true,
+i-pro-wv-u65301-z1g,i-PRO,WV-U65301-Z1G,ptz,1080p,2,"1/2.8"" CMOS",6.7-62,color,IP66,IK10,true,
+i-pro-wv-u65302-z2,i-PRO,WV-U65302-Z2,ptz,1080p,2,"1/2.8"" CMOS",3.7-77,color,IP66,IK10,true,
+i-pro-wv-u65302-z2g,i-PRO,WV-U65302-Z2G,ptz,1080p,2,"1/2.8"" CMOS",77-3.7,ir,IP66,IK10,true,
 i-pro-wv-x22300-v3l,i-PRO,WV-X22300-V3L,dome,1080p,2,"1/2.8"" CMOS",36 (tele) - 114 (wide) horizontal / 20 - 60 vertical,ir,,IK10,true,2023
+i-pro-wv-x22300a-v3l,i-PRO,WV-X22300A-V3L,dome,1080p,2.1,"1/2.8"" CMOS",36-114,ir,,IK10,true,
+i-pro-wv-x22500-v3l,i-PRO,WV-X22500-V3L,dome,5MP,5.3,"1/2.8"" CMOS",33-105,ir,,IK10,true,
+i-pro-wv-x22500a-v3l,i-PRO,WV-X22500A-V3L,dome,5MP,5,"1/2.8"" CMOS",33-105,ir,,IK10,true,
 i-pro-wv-x2251l,i-PRO,WV-X2251L,dome,5MP,5,"1/2.3"" CMOS",99-42 horizontal,ir,IP66,,false,2023
+i-pro-wv-x22600-v2l,i-PRO,WV-X22600-V2L,dome,6MP,6.2,"1/1.8"" CMOS",52-101,ir,,IK10,true,
+i-pro-wv-x22600a-v2l,i-PRO,WV-X22600A-V2L,dome,6MP,6.2,"1/1.8"" CMOS",52-101,ir,,IK10,true,
+i-pro-wv-x22700-v2l,i-PRO,WV-X22700-V2L,dome,4K,8.29,"1/1.8"" CMOS",52-101,ir,,IK10,true,
+i-pro-wv-x22700a-v2l,i-PRO,WV-X22700A-V2L,dome,4K,8.3,"1/1.8"" CMOS",52-101,ir,,IK10,true,
+i-pro-wv-x25300-v3ln,i-PRO,WV-X25300-V3LN,dome,1080p,2,"1/2.8"" CMOS",36-113,ir,IP66/IP67,IK10,false,
+i-pro-wv-x25300a-v3ln,i-PRO,WV-X25300A-V3LN,dome,1080p,2,"1/2.8"" CMOS",36-113,ir,IP66/IP67,IK10,true,
+i-pro-wv-x25500-v3ln,i-PRO,WV-X25500-V3LN,dome,5MP,5,"1/2.8"" CMOS",33-103,ir,IP66/IP67,IK10,false,
+i-pro-wv-x25500a-v3ln,i-PRO,WV-X25500A-V3LN,dome,5MP,5,"1/2.8"" CMOS",33-103,ir,IP66/IP67,IK10,true,
+i-pro-wv-x25580-f2ln2,i-PRO,WV-X25580-F2LN2,dome,5MP,5.3,"1/2.8"" CMOS",131,ir,IP69,IK11,false,
+i-pro-wv-x25600-v2ln,i-PRO,WV-X25600-V2LN,dome,6MP,6,"1/1.8"" CMOS",52-101,ir,IP66/IP67,IK10,true,
+i-pro-wv-x25600a-v2ln,i-PRO,WV-X25600A-V2LN,dome,6MP,6.2,"1/1.8"" CMOS",52-101,ir,IP66/IP67,IK10,true,
+i-pro-wv-x25700-v2ln,i-PRO,WV-X25700-V2LN,dome,4K,8.29,"1/1.8"" CMOS",52-101,ir,IP66/IP67,IK10,true,
+i-pro-wv-x25700a-v2ln,i-PRO,WV-X25700A-V2LN,dome,4K,8.3,"1/1.8"" CMOS",52-101,ir,IP66/IP67,IK10,true,
 i-pro-wv-x2571ln,i-PRO,WV-X2571LN,dome,4K,8.3,"1/1.8"" CMOS","101-52 horizontal, 55-29 vertical",hybrid,IP66,IK10,true,
 i-pro-wv-x86531-z2,i-PRO,WV-X86531-Z2,ptz,4 x 5MP multi-directional + 1080p 21x PTZ,5,"4x 1/2.7"" CMOS (multi-directional) + 1/2.8"" CMOS (PTZ)",PTZ 3.7-77 horizontal / 2.2-44 vertical; multi 97 horizontal / 71 vertical (per sensor),color,IP67,IK10,true,2023
 idis-dc-d4516wrx,IDIS,DC-D4516WRX,dome,5MP,5,"1/2.8"" CMOS",101 horizontal,ir,,IK10,false,2022

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -200506,6 +200506,349 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-s25500-v3ln1",
+    "brand": "i-PRO",
+    "model": "WV-S25500-V3LN1",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.05,
+      "range_m": 55
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25500-v3ln1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25600-v2l",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.002,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI engine",
+      "FIPS 140-2 Level 3 secure element",
+      "motorized varifocal",
+      "IR LEDs",
+      "MQTT support"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s25600-v2lg",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2LG",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "f/1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.09,
+      "min_lux_color": 0.12,
+      "range_m": 45
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI processor (up to 3 simultaneous AI apps)",
+      "Super Dynamic 132dB WDR",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant",
+      "Motorized 2x optical zoom",
+      "IR LED (High/Middle/Low/Off)",
+      "Vandal-resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2lg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25600-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "f/1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.03,
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI Engine",
+      "Super Dynamic 132dB WDR",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "Motorized zoom",
+      "Vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2ln"
+    ]
+  },
+  {
     "id": "i-pro-wv-s25700-v2l",
     "brand": "i-PRO",
     "model": "WV-S25700-V2L",
@@ -200638,6 +200981,2210 @@
     },
     "status": "available",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2lg",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LG",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.09,
+      "min_lux_color": 0.12,
+      "range_m": 45
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "motorized zoom",
+      "2x optical zoom",
+      "varifocal",
+      "4K",
+      "Super Dynamic WDR 132dB",
+      "AI analytics",
+      "AI sound detection",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile G/M/S/T",
+      "smart coding",
+      "auto focus"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2lg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC 12V / PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "AI-analytics",
+      "Super-Dynamic-WDR",
+      "FIPS-140-2"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2ln1",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LN1",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.04,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61300-zy",
+    "brand": "i-PRO",
+    "model": "WV-S61300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.004,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "PTZ",
+      "auto-tracking",
+      "AI engine",
+      "Super Dynamic 144dB WDR",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "256 preset positions",
+      "3.1x optical zoom"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zy"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-S61300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "f/1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "115 (Wide) - 36 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI Engine",
+      "PTZ",
+      "3.1x optical zoom",
+      "ONVIF Profile G/M/S/T",
+      "Color night vision",
+      "350° pan range"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zyg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61301-z1",
+    "brand": "i-PRO",
+    "model": "WV-S61301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-f/3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "15x extra zoom",
+      "AI auto-tracking",
+      "AI Privacy Guard",
+      "AI Face Detection",
+      "AI People Detection",
+      "AI Vehicle Detection",
+      "Super Dynamic 144dB WDR",
+      "gyro image stabilizer",
+      "256 preset positions",
+      "audio detection (gunshot/yell/horn/glass)",
+      "FIPS 140-2 level 3 security",
+      "ONVIF Profile G/M/S/T",
+      "32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61301-z2",
+    "brand": "i-PRO",
+    "model": "WV-S61301-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (WIDE) - 3.7 (TELE)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "Super Dynamic 144dB WDR",
+      "256 preset positions",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3 Secure Element",
+      "Auto-tracking",
+      "Extra zoom up to 31x at 720p"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z2"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61301a-z2",
+    "brand": "i-PRO",
+    "model": "WV-S61301A-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE IEEE802.3af",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "AI analytics",
+      "ONVIF Profile G/M/S/T",
+      "256 preset positions",
+      "FIPS 140-3",
+      "NDAA compliant",
+      "Edge AI",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61301a-z2-1",
+    "brand": "i-PRO",
+    "model": "WV-S61301A-Z2-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (Wide) - 3.7 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.08,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC 12V",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI",
+      "21x optical zoom",
+      "PTZ",
+      "color night vision",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2-1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s61302-z4",
+    "brand": "i-PRO",
+    "model": "WV-S61302-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "person detection",
+      "vehicle detection",
+      "360° endless pan",
+      "privacy guard",
+      "occupancy detection",
+      "scene change detection",
+      "FIPS 140-2 level 3",
+      "Super Dynamic 144dB WDR",
+      "256 presets"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302-z4"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61302a-z4",
+    "brand": "i-PRO",
+    "model": "WV-S61302A-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8 type CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "audio classification",
+      "privacy masking",
+      "256 presets",
+      "360 degree pan",
+      "FIPS 140-3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302a-z4"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61501-z1",
+    "brand": "i-PRO",
+    "model": "WV-S61501-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.2-58 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.06,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61501-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61602-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61602-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (Wide) - 2.5 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 16.7
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI engine",
+      "30x optical zoom",
+      "motorized zoom/focus",
+      "ONVIF Profile G/S/T/M"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602-z3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61602a-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61602A-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 16.7
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "PTZ",
+      "256 preset positions",
+      "4 simultaneous streams",
+      "ONVIF Profile G/S/T/M",
+      "Edge AI analytics",
+      "FIPS 140-3 level 3",
+      "NDAA compliant",
+      "Auto-tracking capable"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602a-z3"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61702-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61702-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC 12V",
+      "consumption_w": 16.7
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702-z3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61702a-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61702A-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 16.7
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "4K",
+      "30x optical zoom",
+      "AI",
+      "ONVIF Profile G/S/T/M",
+      "FIPS 140-3 Level 3",
+      "IEEE802.1X",
+      "4 simultaneous streams"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702a-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s65300-zy",
+    "brand": "i-PRO",
+    "model": "WV-S65300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "113-36",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "people detection",
+      "vehicle detection",
+      "face detection",
+      "privacy zones",
+      "video motion detection",
+      "256 preset positions",
+      "3.1x optical zoom",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zy"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-S65300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "auto-tracking",
+      "AI engine",
+      "ONVIF Profile G/M/S/T",
+      "Super Dynamic 144dB WDR",
+      "FIPS 140-2 Level 3",
+      "256 preset positions",
+      "3.1x optical zoom"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2023,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zyg"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE / PoE+ / DC12V",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "motorized varifocal",
+      "ONVIF Profile G/M/S/T",
+      "wind resistance up to 40 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65301-z1-1",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 6.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "DC 12V / PoE / PoE+",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI auto-tracking",
+      "Face detection",
+      "Vehicle detection",
+      "People detection",
+      "360° endless pan",
+      "256 presets",
+      "10x optical zoom",
+      "FIPS 140-2 Level 3 secure element",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1-1"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1g",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "AI people/vehicle detection",
+      "10x optical zoom",
+      "360° endless pan",
+      "Image stabilizer (gyro)",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant",
+      "32 privacy zones",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1s",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-f/3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+      "consumption_w": 18.4
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "features": [
+      "10x optical zoom",
+      "auto-tracking",
+      "360° endless pan",
+      "256 preset positions",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "scene change detection",
+      "privacy masking",
+      "FIPS 140-2 level 3 security",
+      "heavy salt damage resistance",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1s"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65302-z2",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "77 (wide) - 3.7 (tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.015
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V / PoE / PoE+",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65302-z2-1",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "DC12V / PoE (802.3af) / PoE+ (802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "256 presets",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "AI Sound Classification",
+      "Super Dynamic HDR (144dB)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2-1"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65302-z2g",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0011,
+      "min_lux_color": 0.003
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) / DC 12V",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "360° endless pan",
+      "21x optical zoom",
+      "Super Dynamic 144dB WDR",
+      "256 preset positions",
+      "FIPS 140-2 Level 3 secure element",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
   },
   {
     "id": "i-pro-wv-s6532ln",
@@ -200781,6 +203328,358 @@
     },
     "last_verified": "2026-08-13",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-s65340-z2",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65340-z2g",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++/PoE+/AC24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "21x optical zoom",
+      "Super Dynamic 144dB HDR",
+      "256 presets",
+      "Image stabilization",
+      "FIPS 140-2 Level 3 secure element",
+      "32 privacy zones",
+      "Smart Coding"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z2k",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE++ or AC24V",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "IR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2k"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s65340-z2n",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) / AC 24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "PTZ",
+      "21x optical zoom",
+      "AI auto-tracking",
+      "AI video motion detection",
+      "AI privacy guard",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "FIPS 140-2 Level 3 secure element",
+      "256 preset positions",
+      "IEEE 802.1X",
+      "HTTPS"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -201158,6 +204057,947 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-u61300-zy",
+    "brand": "i-PRO",
+    "model": "WV-U61300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.004,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "3.1x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "256 preset positions",
+      "pan 350°",
+      "tilt 90°",
+      "ONVIF Profile G/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zy"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-U61300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "PTZ",
+      "3.1x optical zoom",
+      "350° pan",
+      "90° tilt",
+      "256 presets",
+      "Super Dynamic 144dB WDR",
+      "ONVIF Profile G/S/T",
+      "FIPS 140-2 level 3",
+      "privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zyg"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u61301-z1",
+    "brand": "i-PRO",
+    "model": "WV-U61301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "PTZ",
+      "256 preset positions",
+      "Super Dynamic (144dB WDR)",
+      "autofocus",
+      "FIPS 140-2 level 3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61301-z2",
+    "brand": "i-PRO",
+    "model": "WV-U61301-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "256 presets",
+      "auto focus",
+      "image stabilizer",
+      "144dB super dynamic range",
+      "privacy zones",
+      "video motion detection",
+      "ICR",
+      "FIPS 140-2 level 3 security",
+      "NDAA compliant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61301a-z2",
+    "brand": "i-PRO",
+    "model": "WV-U61301A-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301a-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65300-zy",
+    "brand": "i-PRO",
+    "model": "WV-U65300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0003,
+      "min_lux_color": 0.007
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zy"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-U65300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "113 (wide) - 36 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE IEEE 802.3af",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "3.1x optical zoom",
+      "color night vision",
+      "motorized varifocal",
+      "PTZ"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zyg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65301-z1",
+    "brand": "i-PRO",
+    "model": "WV-U65301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (Wide) - 6.7 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "color night vision",
+      "ONVIF Profile G/S/T",
+      "full duplex audio"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u65301-z1g",
+    "brand": "i-PRO",
+    "model": "WV-U65301-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "10x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "Super Dynamic 144dB WDR",
+      "ONVIF Profile G/S/T",
+      "Privacy zones",
+      "IEEE 802.1X",
+      "FIPS 140-2 Level 3 secure element",
+      "Intelligent auto mode"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1g"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u65302-z2",
+    "brand": "i-PRO",
+    "model": "WV-U65302-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "31x HD Extra Optical Zoom",
+      "Color night vision",
+      "Image stabilizer (gyro)",
+      "Super Dynamic 144dB WDR",
+      "Intelligent Auto",
+      "Privacy zones (up to 8)",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "ONVIF Profile G/S/T",
+      "360° endless pan",
+      "Alarm recording"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65302-z2g",
+    "brand": "i-PRO",
+    "model": "WV-U65302-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77-3.7",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "21x optical zoom",
+      "31x HD extra optical zoom",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2g"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
     "id": "i-pro-wv-x22300-v3l",
     "brand": "i-PRO",
     "model": "WV-X22300-V3L",
@@ -201285,6 +205125,255 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-x22300a-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22300A-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "36-114",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI",
+      "varifocal",
+      "motorized-zoom",
+      "IR",
+      "vandal-resistant",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22300a-v3l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x22500-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22500-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-105",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500-v3l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22500a-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22500A-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 2304,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "33-105",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.03
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI",
+      "motorized zoom",
+      "3.1x optical zoom",
+      "vandal resistant",
+      "IR illumination"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500a-v3l"
+    ]
+  },
+  {
     "id": "i-pro-wv-x2251l",
     "brand": "i-PRO",
     "model": "WV-X2251L",
@@ -201378,6 +205467,1141 @@
       "outdoor"
     ],
     "added": "2026-06-06"
+  },
+  {
+    "id": "i-pro-wv-x22600-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22600-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI analytics",
+      "motorized zoom",
+      "motorized focus",
+      "FIPS 140-2 Level 3 security",
+      "ONVIF Profile G/S/T/M",
+      "vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600-v2l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x22600a-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22600A-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "ik_rating": "IK10",
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "ir",
+      "edge-ai",
+      "vandal-resistant",
+      "wide-dynamic-range",
+      "onvif-profile-g",
+      "onvif-profile-m",
+      "onvif-profile-s",
+      "onvif-profile-t",
+      "fips-140-3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600a-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22700-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22700-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "motorized-focus",
+      "AI-analytics",
+      "edge-AI",
+      "face-detection",
+      "vehicle-detection",
+      "occupancy-detection",
+      "privacy-guard",
+      "ONVIF-Profile-G",
+      "ONVIF-Profile-S",
+      "ONVIF-Profile-T",
+      "ONVIF-Profile-M",
+      "MQTT",
+      "vandal-resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22700a-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22700A-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ik_rating": "IK10",
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "2x optical zoom",
+      "AI analytics",
+      "image stabilizer",
+      "privacy zones",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-3 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700a-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25300-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25300-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.007,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "motorized zoom",
+      "IR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25300a-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25300A-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "motorized zoom",
+      "autofocus",
+      "Edge AI",
+      "NDAA compliant",
+      "FIPS 140-3 Level 3",
+      "IR illumination"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300a-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25500-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25500-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "motorized zoom",
+      "3.1x optical zoom",
+      "IR",
+      "Edge AI analytics",
+      "FIPS 140-2 level 3 security",
+      "132dB WDR",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "occupancy detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25500a-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25500A-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500a-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25580-f2ln2",
+    "brand": "i-PRO",
+    "model": "WV-X25580-F2LN2",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.3",
+      "aperture": "F2.2",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "131",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 21,
+      "min_lux": 0.07,
+      "min_lux_color": 0.08
+    },
+    "ip_rating": "IP69",
+    "ik_rating": "IK11",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC 12V",
+      "consumption_w": 12.6
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "anti-ligature",
+      "IR illumination",
+      "MQTT support"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25580-f2ln2"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x25600-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25600-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25600a-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25600A-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.04,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE+ / DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600a-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25700-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25700-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.03,
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "Motorized Zoom",
+      "AI Analytics",
+      "Edge AI",
+      "Face Detection",
+      "People Detection",
+      "Vehicle Detection",
+      "Occupancy Detection",
+      "Privacy Masking",
+      "FIPS 140-2 Level 3",
+      "IEEE 802.1X",
+      "ONVIF Profile G/S/T/M",
+      "4K"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700-v2ln"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x25700a-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25700A-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.02,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "DC 12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI analytics",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "Smart Coding",
+      "motorized zoom",
+      "motorized focus"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700a-v2ln"
+    ]
   },
   {
     "id": "i-pro-wv-x2571ln",

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -200506,6 +200506,349 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-s25500-v3ln1",
+    "brand": "i-PRO",
+    "model": "WV-S25500-V3LN1",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.05,
+      "range_m": 55
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25500-v3ln1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25600-v2l",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.002,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI engine",
+      "FIPS 140-2 Level 3 secure element",
+      "motorized varifocal",
+      "IR LEDs",
+      "MQTT support"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s25600-v2lg",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2LG",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "f/1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.09,
+      "min_lux_color": 0.12,
+      "range_m": 45
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI processor (up to 3 simultaneous AI apps)",
+      "Super Dynamic 132dB WDR",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant",
+      "Motorized 2x optical zoom",
+      "IR LED (High/Middle/Low/Off)",
+      "Vandal-resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2lg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25600-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-S25600-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "f/1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.03,
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI Engine",
+      "Super Dynamic 132dB WDR",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "Motorized zoom",
+      "Vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2ln"
+    ]
+  },
+  {
     "id": "i-pro-wv-s25700-v2l",
     "brand": "i-PRO",
     "model": "WV-S25700-V2L",
@@ -200638,6 +200981,2210 @@
     },
     "status": "available",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2lg",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LG",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.09,
+      "min_lux_color": 0.12,
+      "range_m": 45
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "motorized zoom",
+      "2x optical zoom",
+      "varifocal",
+      "4K",
+      "Super Dynamic WDR 132dB",
+      "AI analytics",
+      "AI sound detection",
+      "FIPS 140-2 Level 3",
+      "ONVIF Profile G/M/S/T",
+      "smart coding",
+      "auto focus"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2lg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC 12V / PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "AI-analytics",
+      "Super-Dynamic-WDR",
+      "FIPS-140-2"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s25700-v2ln1",
+    "brand": "i-PRO",
+    "model": "WV-S25700-V2LN1",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.04,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61300-zy",
+    "brand": "i-PRO",
+    "model": "WV-S61300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.004,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "PTZ",
+      "auto-tracking",
+      "AI engine",
+      "Super Dynamic 144dB WDR",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "256 preset positions",
+      "3.1x optical zoom"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zy"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-S61300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "f/1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "115 (Wide) - 36 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI Engine",
+      "PTZ",
+      "3.1x optical zoom",
+      "ONVIF Profile G/M/S/T",
+      "Color night vision",
+      "350° pan range"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zyg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61301-z1",
+    "brand": "i-PRO",
+    "model": "WV-S61301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-f/3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "15x extra zoom",
+      "AI auto-tracking",
+      "AI Privacy Guard",
+      "AI Face Detection",
+      "AI People Detection",
+      "AI Vehicle Detection",
+      "Super Dynamic 144dB WDR",
+      "gyro image stabilizer",
+      "256 preset positions",
+      "audio detection (gunshot/yell/horn/glass)",
+      "FIPS 140-2 level 3 security",
+      "ONVIF Profile G/M/S/T",
+      "32 privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z1"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61301-z2",
+    "brand": "i-PRO",
+    "model": "WV-S61301-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (WIDE) - 3.7 (TELE)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "Super Dynamic 144dB WDR",
+      "256 preset positions",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-2 Level 3 Secure Element",
+      "Auto-tracking",
+      "Extra zoom up to 31x at 720p"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z2"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61301a-z2",
+    "brand": "i-PRO",
+    "model": "WV-S61301A-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE IEEE802.3af",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "AI analytics",
+      "ONVIF Profile G/M/S/T",
+      "256 preset positions",
+      "FIPS 140-3",
+      "NDAA compliant",
+      "Edge AI",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61301a-z2-1",
+    "brand": "i-PRO",
+    "model": "WV-S61301A-Z2-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (Wide) - 3.7 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.08,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC 12V",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI",
+      "21x optical zoom",
+      "PTZ",
+      "color night vision",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2-1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s61302-z4",
+    "brand": "i-PRO",
+    "model": "WV-S61302-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI auto-tracking",
+      "person detection",
+      "vehicle detection",
+      "360° endless pan",
+      "privacy guard",
+      "occupancy detection",
+      "scene change detection",
+      "FIPS 140-2 level 3",
+      "Super Dynamic 144dB WDR",
+      "256 presets"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302-z4"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61302a-z4",
+    "brand": "i-PRO",
+    "model": "WV-S61302A-Z4",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8 type CMOS",
+    "lens": {
+      "focal_length_mm": "4.25-170",
+      "aperture": "F1.6-4.95",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "1.9-66 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "40x optical zoom",
+      "AI analytics",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "audio classification",
+      "privacy masking",
+      "256 presets",
+      "360 degree pan",
+      "FIPS 140-3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302a-z4"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61501-z1",
+    "brand": "i-PRO",
+    "model": "WV-S61501-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.2-58 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.06,
+      "min_lux_color": 0.08
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61501-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61602-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61602-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (Wide) - 2.5 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 16.7
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "AI engine",
+      "30x optical zoom",
+      "motorized zoom/focus",
+      "ONVIF Profile G/S/T/M"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602-z3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61602a-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61602A-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 2.5 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 16.7
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "30x optical zoom",
+      "PTZ",
+      "256 preset positions",
+      "4 simultaneous streams",
+      "ONVIF Profile G/S/T/M",
+      "Edge AI analytics",
+      "FIPS 140-3 level 3",
+      "NDAA compliant",
+      "Auto-tracking capable"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602a-z3"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s61702-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61702-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true
+    },
+    "field_of_view_deg": "62-2.5 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC 12V",
+      "consumption_w": 16.7
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702-z3"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s61702a-z3",
+    "brand": "i-PRO",
+    "model": "WV-S61702A-Z3",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/2\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.5-135",
+      "aperture": "F1.8-F4.7",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.1,
+      "min_lux_color": 0.13
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 16.7
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "4K",
+      "30x optical zoom",
+      "AI",
+      "ONVIF Profile G/S/T/M",
+      "FIPS 140-3 Level 3",
+      "IEEE802.1X",
+      "4 simultaneous streams"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702a-z3"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s65300-zy",
+    "brand": "i-PRO",
+    "model": "WV-S65300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "113-36",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "people detection",
+      "vehicle detection",
+      "face detection",
+      "privacy zones",
+      "video motion detection",
+      "256 preset positions",
+      "3.1x optical zoom",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zy"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-S65300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "auto-tracking",
+      "AI engine",
+      "ONVIF Profile G/M/S/T",
+      "Super Dynamic 144dB WDR",
+      "FIPS 140-2 Level 3",
+      "256 preset positions",
+      "3.1x optical zoom"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "release_year": 2023,
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zyg"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE / PoE+ / DC12V",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor",
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "motorized varifocal",
+      "ONVIF Profile G/M/S/T",
+      "wind resistance up to 40 m/s"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65301-z1-1",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (wide) - 6.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "DC 12V / PoE / PoE+",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI auto-tracking",
+      "Face detection",
+      "Vehicle detection",
+      "People detection",
+      "360° endless pan",
+      "256 presets",
+      "10x optical zoom",
+      "FIPS 140-2 Level 3 secure element",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1-1"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1g",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "AI people/vehicle detection",
+      "10x optical zoom",
+      "360° endless pan",
+      "Image stabilizer (gyro)",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant",
+      "32 privacy zones",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65301-z1s",
+    "brand": "i-PRO",
+    "model": "WV-S65301-Z1S",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.7-47",
+      "aperture": "f/1.6-f/3.0",
+      "varifocal": true
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.001,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "power": {
+      "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+      "consumption_w": 18.4
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "features": [
+      "10x optical zoom",
+      "auto-tracking",
+      "360° endless pan",
+      "256 preset positions",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "occupancy detection",
+      "scene change detection",
+      "privacy masking",
+      "FIPS 140-2 level 3 security",
+      "heavy salt damage resistance",
+      "Super Dynamic 144dB WDR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1s"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65302-z2",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "77 (wide) - 3.7 (tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.015
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V / PoE / PoE+",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65302-z2-1",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2-1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "DC12V / PoE (802.3af) / PoE+ (802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "AI auto-tracking",
+      "360° endless pan",
+      "256 presets",
+      "NDAA compliant",
+      "FIPS 140-2 Level 3",
+      "AI Sound Classification",
+      "Super Dynamic HDR (144dB)"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2-1"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65302-z2g",
+    "brand": "i-PRO",
+    "model": "WV-S65302-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "77 (wide) to 3.7 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0011,
+      "min_lux_color": 0.003
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) / DC 12V",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "360° endless pan",
+      "21x optical zoom",
+      "Super Dynamic 144dB WDR",
+      "256 preset positions",
+      "FIPS 140-2 Level 3 secure element",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
   },
   {
     "id": "i-pro-wv-s6532ln",
@@ -200781,6 +203328,358 @@
     },
     "last_verified": "2026-08-13",
     "added": "2026-08-13"
+  },
+  {
+    "id": "i-pro-wv-s65340-z2",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at)",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-s65340-z2g",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE++/PoE+/AC24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "features": [
+      "AI auto-tracking",
+      "21x optical zoom",
+      "Super Dynamic 144dB HDR",
+      "256 presets",
+      "Image stabilization",
+      "FIPS 140-2 Level 3 secure element",
+      "32 privacy zones",
+      "Smart Coding"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2g"
+    ],
+    "last_verified": "2026-08-15",
+    "ptz": {
+      "autotracking": true
+    }
+  },
+  {
+    "id": "i-pro-wv-s65340-z2k",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2K",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "nvr_compatible": true,
+      "cloud": false
+    },
+    "power": {
+      "method": "PoE++ or AC24V",
+      "consumption_w": 53.3
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "IR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2k"
+    ]
+  },
+  {
+    "id": "i-pro-wv-s65340-z2n",
+    "brand": "i-PRO",
+    "model": "WV-S65340-Z2N",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) / AC 24V",
+      "consumption_w": 50.84
+    },
+    "power_source": [
+      "poe",
+      "ac-mains"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "PTZ",
+      "21x optical zoom",
+      "AI auto-tracking",
+      "AI video motion detection",
+      "AI privacy guard",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "FIPS 140-2 Level 3 secure element",
+      "256 preset positions",
+      "IEEE 802.1X",
+      "HTTPS"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n"
+    ],
+    "ptz": {
+      "autotracking": true
+    }
   },
   {
     "id": "i-pro-wv-s8530n",
@@ -201158,6 +204057,947 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-u61300-zy",
+    "brand": "i-PRO",
+    "model": "WV-U61300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "environment": [
+      "indoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.004,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE802.3af)",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "3.1x optical zoom",
+      "motorized zoom",
+      "motorized focus",
+      "256 preset positions",
+      "pan 350°",
+      "tilt 90°",
+      "ONVIF Profile G/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zy"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-U61300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-115",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "PTZ",
+      "3.1x optical zoom",
+      "350° pan",
+      "90° tilt",
+      "256 presets",
+      "Super Dynamic 144dB WDR",
+      "ONVIF Profile G/S/T",
+      "FIPS 140-2 level 3",
+      "privacy zones"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zyg"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u61301-z1",
+    "brand": "i-PRO",
+    "model": "WV-U61301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "none",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "PTZ",
+      "256 preset positions",
+      "Super Dynamic (144dB WDR)",
+      "autofocus",
+      "FIPS 140-2 level 3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z1"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61301-z2",
+    "brand": "i-PRO",
+    "model": "WV-U61301-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "256 presets",
+      "auto focus",
+      "image stabilizer",
+      "144dB super dynamic range",
+      "privacy zones",
+      "video motion detection",
+      "ICR",
+      "FIPS 140-2 level 3 security",
+      "NDAA compliant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u61301a-z2",
+    "brand": "i-PRO",
+    "model": "WV-U61301A-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77 (H)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0004,
+      "min_lux_color": 0.001
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE (IEEE 802.3af)",
+      "consumption_w": 12.95
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301a-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65300-zy",
+    "brand": "i-PRO",
+    "model": "WV-U65300-ZY",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.0003,
+      "min_lux_color": 0.007
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "PoE (IEEE802.3af) or DC12V",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zy"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65300-zyg",
+    "brand": "i-PRO",
+    "model": "WV-U65300-ZYG",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "113 (wide) - 36 (tele)",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.012,
+      "min_lux_color": 0.02
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE IEEE 802.3af",
+      "consumption_w": 12
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "3.1x optical zoom",
+      "color night vision",
+      "motorized varifocal",
+      "PTZ"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zyg"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65301-z1",
+    "brand": "i-PRO",
+    "model": "WV-U65301-Z1",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "62 (Wide) - 6.7 (Tele) horizontal",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "10x optical zoom",
+      "color night vision",
+      "ONVIF Profile G/S/T",
+      "full duplex audio"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u65301-z1g",
+    "brand": "i-PRO",
+    "model": "WV-U65301-Z1G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.7-47",
+      "aperture": "F1.6-F3.0",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "6.7-62",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "10x optical zoom",
+      "360° endless pan",
+      "256 preset positions",
+      "Super Dynamic 144dB WDR",
+      "ONVIF Profile G/S/T",
+      "Privacy zones",
+      "IEEE 802.1X",
+      "FIPS 140-2 Level 3 secure element",
+      "Intelligent auto mode"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1g"
+    ]
+  },
+  {
+    "id": "i-pro-wv-u65302-z2",
+    "brand": "i-PRO",
+    "model": "WV-U65302-Z2",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "3.7-77",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "color",
+      "min_lux": 0.006,
+      "min_lux_color": 0.011
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "21x optical zoom",
+      "31x HD Extra Optical Zoom",
+      "Color night vision",
+      "Image stabilizer (gyro)",
+      "Super Dynamic 144dB WDR",
+      "Intelligent Auto",
+      "Privacy zones (up to 8)",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "ONVIF Profile G/S/T",
+      "360° endless pan",
+      "Alarm recording"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-u65302-z2g",
+    "brand": "i-PRO",
+    "model": "WV-U65302-Z2G",
+    "type": "ptz",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.0-84.6",
+      "aperture": "F1.6-F4.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "77-3.7",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.017,
+      "min_lux_color": 0.03
+    },
+    "ip_rating": "IP66",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at)",
+      "consumption_w": 18.4
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "21x optical zoom",
+      "31x HD extra optical zoom",
+      "FIPS 140-2 Level 3 secure element",
+      "NDAA compliant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2g"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
     "id": "i-pro-wv-x22300-v3l",
     "brand": "i-PRO",
     "model": "WV-X22300-V3L",
@@ -201285,6 +205125,255 @@
     "added": "2026-08-13"
   },
   {
+    "id": "i-pro-wv-x22300a-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22300A-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2.1,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "36-114",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI",
+      "varifocal",
+      "motorized-zoom",
+      "IR",
+      "vandal-resistant",
+      "ONVIF Profile G/M/S/T"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22300a-v3l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x22500-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22500-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-105",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500-v3l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22500a-v3l",
+    "brand": "i-PRO",
+    "model": "WV-X22500A-V3L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 2304,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true
+    },
+    "field_of_view_deg": "33-105",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.03
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI",
+      "motorized zoom",
+      "3.1x optical zoom",
+      "vandal resistant",
+      "IR illumination"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500a-v3l"
+    ]
+  },
+  {
     "id": "i-pro-wv-x2251l",
     "brand": "i-PRO",
     "model": "WV-X2251L",
@@ -201378,6 +205467,1141 @@
       "outdoor"
     ],
     "added": "2026-06-06"
+  },
+  {
+    "id": "i-pro-wv-x22600-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22600-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "AI analytics",
+      "motorized zoom",
+      "motorized focus",
+      "FIPS 140-2 Level 3 security",
+      "ONVIF Profile G/S/T/M",
+      "vandal resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600-v2l"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x22600a-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22600A-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "ik_rating": "IK10",
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "ir",
+      "edge-ai",
+      "vandal-resistant",
+      "wide-dynamic-range",
+      "onvif-profile-g",
+      "onvif-profile-m",
+      "onvif-profile-s",
+      "onvif-profile-t",
+      "fips-140-3"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600a-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22700-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22700-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+ (IEEE 802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor"
+    ],
+    "ik_rating": "IK10",
+    "features": [
+      "varifocal",
+      "motorized-zoom",
+      "motorized-focus",
+      "AI-analytics",
+      "edge-AI",
+      "face-detection",
+      "vehicle-detection",
+      "occupancy-detection",
+      "privacy-guard",
+      "ONVIF-Profile-G",
+      "ONVIF-Profile-S",
+      "ONVIF-Profile-T",
+      "ONVIF-Profile-M",
+      "MQTT",
+      "vandal-resistant"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x22700a-v2l",
+    "brand": "i-PRO",
+    "model": "WV-X22700A-V2L",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.03,
+      "min_lux_color": 0.04
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (802.3at) or DC12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "ik_rating": "IK10",
+    "environment": [
+      "indoor"
+    ],
+    "features": [
+      "2x optical zoom",
+      "AI analytics",
+      "image stabilizer",
+      "privacy zones",
+      "ONVIF Profile G/M/S/T",
+      "FIPS 140-3 Level 3 secure element"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700a-v2l"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25300-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25300-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.007,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "FIPS 140-2 Level 3",
+      "NDAA compliant",
+      "motorized zoom",
+      "IR"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25300a-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25300A-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 2,
+      "max_width": 1920,
+      "max_height": 1080,
+      "label": "1080p"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "36-113",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux_color": 0.007
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "motorized zoom",
+      "autofocus",
+      "Edge AI",
+      "NDAA compliant",
+      "FIPS 140-3 Level 3",
+      "IR illumination"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300a-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25500-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25500-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC12V or PoE+ (IEEE802.3at)",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "motorized zoom",
+      "3.1x optical zoom",
+      "IR",
+      "Edge AI analytics",
+      "FIPS 140-2 level 3 security",
+      "132dB WDR",
+      "face detection",
+      "people detection",
+      "vehicle detection",
+      "privacy guard",
+      "occupancy detection"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25500a-v3ln",
+    "brand": "i-PRO",
+    "model": "WV-X25500A-V3LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.9-9",
+      "aperture": "F1.3-F2.5",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "33-103",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.03,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "DC 12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500a-v3ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25580-f2ln2",
+    "brand": "i-PRO",
+    "model": "WV-X25580-F2LN2",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 5.3,
+      "max_width": 3072,
+      "max_height": 1728,
+      "label": "5MP"
+    },
+    "sensor": "1/2.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "2.3",
+      "aperture": "F2.2",
+      "varifocal": false,
+      "count": 1
+    },
+    "field_of_view_deg": "131",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 30
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 21,
+      "min_lux": 0.07,
+      "min_lux_color": 0.08
+    },
+    "ip_rating": "IP69",
+    "ik_rating": "IK11",
+    "audio": {
+      "microphone": true,
+      "speaker": false,
+      "two_way": false
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE (IEEE 802.3af) or DC 12V",
+      "consumption_w": 12.6
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "indoor",
+      "outdoor"
+    ],
+    "features": [
+      "AI engine",
+      "anti-ligature",
+      "IR illumination",
+      "MQTT support"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25580-f2ln2"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x25600-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25600-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "power": {
+      "method": "DC12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25600a-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25600A-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 6.2,
+      "max_width": 3328,
+      "max_height": 1872,
+      "label": "6MP"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "count": 1,
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.04,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "power": {
+      "method": "PoE+ / DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600a-v2ln"
+    ],
+    "last_verified": "2026-08-15"
+  },
+  {
+    "id": "i-pro-wv-x25700-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25700-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.29,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "min_lux": 0.03,
+      "min_lux_color": 0.04,
+      "range_m": 70
+    },
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "power": {
+      "method": "PoE+ (IEEE 802.3at) or DC 12V",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "poe",
+      "dc"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp",
+      "http"
+    ],
+    "environment": [
+      "outdoor"
+    ],
+    "features": [
+      "IR",
+      "Motorized Zoom",
+      "AI Analytics",
+      "Edge AI",
+      "Face Detection",
+      "People Detection",
+      "Vehicle Detection",
+      "Occupancy Detection",
+      "Privacy Masking",
+      "FIPS 140-2 Level 3",
+      "IEEE 802.1X",
+      "ONVIF Profile G/S/T/M",
+      "4K"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700-v2ln"
+    ]
+  },
+  {
+    "id": "i-pro-wv-x25700a-v2ln",
+    "brand": "i-PRO",
+    "model": "WV-X25700A-V2LN",
+    "type": "dome",
+    "resolution": {
+      "megapixels": 8.3,
+      "max_width": 3840,
+      "max_height": 2160,
+      "label": "4K"
+    },
+    "sensor": "1/1.8\" CMOS",
+    "lens": {
+      "focal_length_mm": "4.3-8.6",
+      "aperture": "F1.5-F2.4",
+      "varifocal": true,
+      "count": 1
+    },
+    "field_of_view_deg": "52-101",
+    "video": {
+      "codecs": [
+        "H.265",
+        "H.264",
+        "MJPEG"
+      ],
+      "max_fps": 60
+    },
+    "night_vision": {
+      "type": "ir",
+      "range_m": 70,
+      "min_lux": 0.02,
+      "min_lux_color": 0.04
+    },
+    "ip_rating": "IP66/IP67",
+    "ik_rating": "IK10",
+    "environment": [
+      "outdoor"
+    ],
+    "connectivity": [
+      "ethernet"
+    ],
+    "protocols": [
+      "onvif",
+      "rtsp"
+    ],
+    "power": {
+      "method": "DC 12V or PoE+",
+      "consumption_w": 14.2
+    },
+    "power_source": [
+      "dc",
+      "poe"
+    ],
+    "audio": {
+      "microphone": true,
+      "speaker": true,
+      "two_way": true
+    },
+    "storage": {
+      "onboard": true,
+      "max_microsd_gb": 512,
+      "cloud": false,
+      "nvr_compatible": true
+    },
+    "features": [
+      "AI analytics",
+      "FIPS 140-3 Level 3",
+      "NDAA compliant",
+      "Smart Coding",
+      "motorized zoom",
+      "motorized focus"
+    ],
+    "configs": {
+      "frigate": {
+        "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_1",
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/Src/MediaInput/stream_2",
+        "detect": {
+          "width": 640,
+          "height": 480,
+          "fps": 5
+        }
+      }
+    },
+    "last_verified": "2026-08-15",
+    "sources": [
+      "https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700a-v2ln"
+    ]
   },
   {
     "id": "i-pro-wv-x2571ln",

--- a/docs/cameras/i-pro/wv-s25500-v3ln1.md
+++ b/docs/cameras/i-pro/wv-s25500-v3ln1.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S25500-V3LN1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25500-V3LN1 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5.3MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-2.5 |
+| Field of view | 33-103° |
+| Night vision | ir (55m), 0.05 lux color |
+| Power | DC12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25500-v3ln1
+
+---
+*Auto-generated from i-pro-wv-s25500-v3ln1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25600-v2l.md
+++ b/docs/cameras/i-pro/wv-s25600-v2l.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S25600-V2L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25600-V2L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.002 lux, 0.04 lux color |
+| Power | DC12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI engine
+- FIPS 140-2 Level 3 secure element
+- motorized varifocal
+- IR LEDs
+- MQTT support
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2l
+
+---
+*Auto-generated from i-pro-wv-s25600-v2l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25600-v2lg.md
+++ b/docs/cameras/i-pro/wv-s25600-v2lg.md
@@ -1,0 +1,36 @@
+# i-PRO WV-S25600-V2LG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25600-V2LG |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm f/1.5-2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (45m), 0.09 lux, 0.12 lux color |
+| Power | DC12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI processor (up to 3 simultaneous AI apps)
+- Super Dynamic 132dB WDR
+- FIPS 140-2 Level 3 secure element
+- NDAA compliant
+- Motorized 2x optical zoom
+- IR LED (High/Middle/Low/Off)
+- Vandal-resistant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2lg
+
+---
+*Auto-generated from i-pro-wv-s25600-v2lg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25600-v2ln.md
+++ b/docs/cameras/i-pro/wv-s25600-v2ln.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S25600-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25600-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm f/1.5-2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.03 lux, 0.04 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI Engine
+- Super Dynamic 132dB WDR
+- FIPS 140-2 Level 3
+- NDAA compliant
+- Motorized zoom
+- Vandal resistant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25600-v2ln
+
+---
+*Auto-generated from i-pro-wv-s25600-v2ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25700-v2lg.md
+++ b/docs/cameras/i-pro/wv-s25700-v2lg.md
@@ -1,0 +1,41 @@
+# i-PRO WV-S25700-V2LG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25700-V2LG |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (45m), 0.09 lux, 0.12 lux color |
+| Power | PoE (IEEE 802.3af) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- IR
+- motorized zoom
+- 2x optical zoom
+- varifocal
+- 4K
+- Super Dynamic WDR 132dB
+- AI analytics
+- AI sound detection
+- FIPS 140-2 Level 3
+- ONVIF Profile G/M/S/T
+- smart coding
+- auto focus
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2lg
+
+---
+*Auto-generated from i-pro-wv-s25700-v2lg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25700-v2ln.md
+++ b/docs/cameras/i-pro/wv-s25700-v2ln.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S25700-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25700-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.04 lux |
+| Power | DC 12V / PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- varifocal
+- motorized-zoom
+- AI-analytics
+- Super-Dynamic-WDR
+- FIPS-140-2
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln
+
+---
+*Auto-generated from i-pro-wv-s25700-v2ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s25700-v2ln1.md
+++ b/docs/cameras/i-pro/wv-s25700-v2ln1.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S25700-V2LN1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S25700-V2LN1 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.29MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.04 lux, 0.04 lux color |
+| Power | PoE (IEEE802.3af) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s25700-v2ln1
+
+---
+*Auto-generated from i-pro-wv-s25700-v2ln1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61300-zy.md
+++ b/docs/cameras/i-pro/wv-s61300-zy.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S61300-ZY
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61300-ZY |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-115° |
+| Night vision | color, 0.004 lux, 0.007 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- PTZ
+- auto-tracking
+- AI engine
+- Super Dynamic 144dB WDR
+- FIPS 140-2 Level 3
+- NDAA compliant
+- 256 preset positions
+- 3.1x optical zoom
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zy
+
+---
+*Auto-generated from i-pro-wv-s61300-zy.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61300-zyg.md
+++ b/docs/cameras/i-pro/wv-s61300-zyg.md
@@ -1,0 +1,33 @@
+# i-PRO WV-S61300-ZYG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61300-ZYG |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm f/1.3-2.5 |
+| Field of view | 115 (Wide) - 36 (Tele) horizontal° |
+| Night vision | color, 0.012 lux, 0.02 lux color |
+| Power | DC 12V or PoE |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- AI Engine
+- PTZ
+- 3.1x optical zoom
+- ONVIF Profile G/M/S/T
+- Color night vision
+- 350° pan range
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61300-zyg
+
+---
+*Auto-generated from i-pro-wv-s61300-zyg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61301-z1.md
+++ b/docs/cameras/i-pro/wv-s61301-z1.md
@@ -1,0 +1,41 @@
+# i-PRO WV-S61301-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61301-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm f/1.6-f/3.0 |
+| Field of view | 6.7-62° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | DC12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- 15x extra zoom
+- AI auto-tracking
+- AI Privacy Guard
+- AI Face Detection
+- AI People Detection
+- AI Vehicle Detection
+- Super Dynamic 144dB WDR
+- gyro image stabilizer
+- 256 preset positions
+- audio detection (gunshot/yell/horn/glass)
+- FIPS 140-2 level 3 security
+- ONVIF Profile G/M/S/T
+- 32 privacy zones
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z1
+
+---
+*Auto-generated from i-pro-wv-s61301-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61301-z2.md
+++ b/docs/cameras/i-pro/wv-s61301-z2.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S61301-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61301-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (WIDE) - 3.7 (TELE)° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- Super Dynamic 144dB WDR
+- 256 preset positions
+- ONVIF Profile G/M/S/T
+- FIPS 140-2 Level 3 Secure Element
+- Auto-tracking
+- Extra zoom up to 31x at 720p
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301-z2
+
+---
+*Auto-generated from i-pro-wv-s61301-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61301a-z2-1.md
+++ b/docs/cameras/i-pro/wv-s61301a-z2-1.md
@@ -1,0 +1,32 @@
+# i-PRO WV-S61301A-Z2-1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61301A-Z2-1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (Wide) - 3.7 (Tele) horizontal° |
+| Night vision | color, 0.08 lux, 0.08 lux color |
+| Power | PoE (IEEE802.3af) or DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- AI
+- 21x optical zoom
+- PTZ
+- color night vision
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2-1
+
+---
+*Auto-generated from i-pro-wv-s61301a-z2-1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61301a-z2.md
+++ b/docs/cameras/i-pro/wv-s61301a-z2.md
@@ -1,0 +1,35 @@
+# i-PRO WV-S61301A-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61301A-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.006 lux, 0.08 lux color |
+| Power | DC 12V or PoE IEEE802.3af |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- AI analytics
+- ONVIF Profile G/M/S/T
+- 256 preset positions
+- FIPS 140-3
+- NDAA compliant
+- Edge AI
+- Super Dynamic 144dB WDR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61301a-z2
+
+---
+*Auto-generated from i-pro-wv-s61301a-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61302-z4.md
+++ b/docs/cameras/i-pro/wv-s61302-z4.md
@@ -1,0 +1,38 @@
+# i-PRO WV-S61302-Z4
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61302-Z4 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.25-170mm F1.6-4.5 |
+| Field of view | 1.9-66 (H)° |
+| Night vision | color, 0.006 lux, 0.001 lux color |
+| Power | DC 12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI auto-tracking
+- person detection
+- vehicle detection
+- 360° endless pan
+- privacy guard
+- occupancy detection
+- scene change detection
+- FIPS 140-2 level 3
+- Super Dynamic 144dB WDR
+- 256 presets
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302-z4
+
+---
+*Auto-generated from i-pro-wv-s61302-z4.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61302a-z4.md
+++ b/docs/cameras/i-pro/wv-s61302a-z4.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S61302A-Z4
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61302A-Z4 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8 type CMOS |
+| Lens | 1× 4.25-170mm F1.6-4.95 |
+| Field of view | 1.9-66 (H)° |
+| Night vision | color, 0.001 lux, 0.001 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 40x optical zoom
+- AI analytics
+- face detection
+- people detection
+- vehicle detection
+- audio classification
+- privacy masking
+- 256 presets
+- 360 degree pan
+- FIPS 140-3
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61302a-z4
+
+---
+*Auto-generated from i-pro-wv-s61302a-z4.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61501-z1.md
+++ b/docs/cameras/i-pro/wv-s61501-z1.md
@@ -1,0 +1,24 @@
+# i-PRO WV-S61501-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61501-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 6.2-58 (H)° |
+| Night vision | color, 0.06 lux, 0.08 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61501-z1
+
+---
+*Auto-generated from i-pro-wv-s61501-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61602-z3.md
+++ b/docs/cameras/i-pro/wv-s61602-z3.md
@@ -1,0 +1,31 @@
+# i-PRO WV-S61602-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61602-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (Wide) - 2.5 (Tele) horizontal° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | PoE+ (IEEE802.3at) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- AI engine
+- 30x optical zoom
+- motorized zoom/focus
+- ONVIF Profile G/S/T/M
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602-z3
+
+---
+*Auto-generated from i-pro-wv-s61602-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61602a-z3.md
+++ b/docs/cameras/i-pro/wv-s61602a-z3.md
@@ -1,0 +1,36 @@
+# i-PRO WV-S61602A-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61602A-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62 (wide) - 2.5 (tele)° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | DC 12V or PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 30x optical zoom
+- PTZ
+- 256 preset positions
+- 4 simultaneous streams
+- ONVIF Profile G/S/T/M
+- Edge AI analytics
+- FIPS 140-3 level 3
+- NDAA compliant
+- Auto-tracking capable
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61602a-z3
+
+---
+*Auto-generated from i-pro-wv-s61602a-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61702-z3.md
+++ b/docs/cameras/i-pro/wv-s61702-z3.md
@@ -1,0 +1,24 @@
+# i-PRO WV-S61702-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61702-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62-2.5 (H)° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | PoE+ (IEEE802.3at) or DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702-z3
+
+---
+*Auto-generated from i-pro-wv-s61702-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s61702a-z3.md
+++ b/docs/cameras/i-pro/wv-s61702a-z3.md
@@ -1,0 +1,34 @@
+# i-PRO WV-S61702A-Z3
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S61702A-Z3 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/2" CMOS |
+| Lens | 1× 4.5-135mm F1.8-F4.7 |
+| Field of view | 62° |
+| Night vision | none, 0.1 lux, 0.13 lux color |
+| Power | PoE+ (IEEE802.3at) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 4K
+- 30x optical zoom
+- AI
+- ONVIF Profile G/S/T/M
+- FIPS 140-3 Level 3
+- IEEE802.1X
+- 4 simultaneous streams
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s61702a-z3
+
+---
+*Auto-generated from i-pro-wv-s61702a-z3.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65300-zy.md
+++ b/docs/cameras/i-pro/wv-s65300-zy.md
@@ -1,0 +1,39 @@
+# i-PRO WV-S65300-ZY
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65300-ZY |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 113-36° |
+| Night vision | color, 0.001 lux, 0.001 lux color |
+| Power | DC12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- people detection
+- vehicle detection
+- face detection
+- privacy zones
+- video motion detection
+- 256 preset positions
+- 3.1x optical zoom
+- NDAA compliant
+- FIPS 140-2 Level 3 secure element
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zy
+
+---
+*Auto-generated from i-pro-wv-s65300-zy.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65300-zyg.md
+++ b/docs/cameras/i-pro/wv-s65300-zyg.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S65300-ZYG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65300-ZYG |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-113° |
+| Night vision | color, 0.012 lux, 0.02 lux color |
+| Power | DC12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+| Released | 2023 |
+
+## Features
+
+- auto-tracking
+- AI engine
+- ONVIF Profile G/M/S/T
+- Super Dynamic 144dB WDR
+- FIPS 140-2 Level 3
+- 256 preset positions
+- 3.1x optical zoom
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65300-zyg
+
+---
+*Auto-generated from i-pro-wv-s65300-zyg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65301-z1-1.md
+++ b/docs/cameras/i-pro/wv-s65301-z1-1.md
@@ -1,0 +1,38 @@
+# i-PRO WV-S65301-Z1-1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65301-Z1-1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 62 (wide) - 6.7 (tele)° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | DC 12V / PoE / PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- Face detection
+- Vehicle detection
+- People detection
+- 360° endless pan
+- 256 presets
+- 10x optical zoom
+- FIPS 140-2 Level 3 secure element
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1-1
+
+---
+*Auto-generated from i-pro-wv-s65301-z1-1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65301-z1.md
+++ b/docs/cameras/i-pro/wv-s65301-z1.md
@@ -1,0 +1,33 @@
+# i-PRO WV-S65301-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65301-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm f/1.6-3.0 |
+| Field of view | 6.7-62° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | PoE / PoE+ / DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- motorized varifocal
+- ONVIF Profile G/M/S/T
+- wind resistance up to 40 m/s
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1
+
+---
+*Auto-generated from i-pro-wv-s65301-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65301-z1g.md
+++ b/docs/cameras/i-pro/wv-s65301-z1g.md
@@ -1,0 +1,38 @@
+# i-PRO WV-S65301-Z1G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65301-Z1G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 6.7-62° |
+| Night vision | color, 0.017 lux, 0.03 lux color |
+| Power | DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- AI people/vehicle detection
+- 10x optical zoom
+- 360° endless pan
+- Image stabilizer (gyro)
+- FIPS 140-2 Level 3 secure element
+- NDAA compliant
+- 32 privacy zones
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1g
+
+---
+*Auto-generated from i-pro-wv-s65301-z1g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65301-z1s.md
+++ b/docs/cameras/i-pro/wv-s65301-z1s.md
@@ -1,0 +1,42 @@
+# i-PRO WV-S65301-Z1S
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65301-Z1S |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm f/1.6-f/3.0 |
+| Field of view | 6.7-62° |
+| Night vision | color, 0.001 lux, 0.001 lux color |
+| Power | DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- auto-tracking
+- 360° endless pan
+- 256 preset positions
+- face detection
+- people detection
+- vehicle detection
+- occupancy detection
+- scene change detection
+- privacy masking
+- FIPS 140-2 level 3 security
+- heavy salt damage resistance
+- Super Dynamic 144dB WDR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65301-z1s
+
+---
+*Auto-generated from i-pro-wv-s65301-z1s.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65302-z2-1.md
+++ b/docs/cameras/i-pro/wv-s65302-z2-1.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S65302-Z2-1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65302-Z2-1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (wide) to 3.7 (tele)° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | DC12V / PoE (802.3af) / PoE+ (802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- AI auto-tracking
+- 360° endless pan
+- 256 presets
+- NDAA compliant
+- FIPS 140-2 Level 3
+- AI Sound Classification
+- Super Dynamic HDR (144dB)
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2-1
+
+---
+*Auto-generated from i-pro-wv-s65302-z2-1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65302-z2.md
+++ b/docs/cameras/i-pro/wv-s65302-z2.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S65302-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65302-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (wide) - 3.7 (tele) horizontal° |
+| Night vision | color, 0.006 lux, 0.015 lux color |
+| Power | DC 12V / PoE / PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2
+
+---
+*Auto-generated from i-pro-wv-s65302-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65302-z2g.md
+++ b/docs/cameras/i-pro/wv-s65302-z2g.md
@@ -1,0 +1,36 @@
+# i-PRO WV-S65302-Z2G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65302-Z2G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77 (wide) to 3.7 (tele)° |
+| Night vision | color, 0.0011 lux, 0.003 lux color |
+| Power | PoE+ (IEEE 802.3at) / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- 360° endless pan
+- 21x optical zoom
+- Super Dynamic 144dB WDR
+- 256 preset positions
+- FIPS 140-2 Level 3 secure element
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65302-z2g
+
+---
+*Auto-generated from i-pro-wv-s65302-z2g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z2.md
+++ b/docs/cameras/i-pro/wv-s65340-z2.md
@@ -1,0 +1,26 @@
+# i-PRO WV-S65340-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | AC24V / PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2
+
+---
+*Auto-generated from i-pro-wv-s65340-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z2g.md
+++ b/docs/cameras/i-pro/wv-s65340-z2g.md
@@ -1,0 +1,37 @@
+# i-PRO WV-S65340-Z2G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z2G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.017 lux, 0.03 lux color |
+| Power | PoE++/PoE+/AC24V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI auto-tracking
+- 21x optical zoom
+- Super Dynamic 144dB HDR
+- 256 presets
+- Image stabilization
+- FIPS 140-2 Level 3 secure element
+- 32 privacy zones
+- Smart Coding
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2g
+
+---
+*Auto-generated from i-pro-wv-s65340-z2g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z2k.md
+++ b/docs/cameras/i-pro/wv-s65340-z2k.md
@@ -1,0 +1,33 @@
+# i-PRO WV-S65340-Z2K
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z2K |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | PoE++ or AC24V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- motorized zoom
+- motorized focus
+- IR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2k
+
+---
+*Auto-generated from i-pro-wv-s65340-z2k.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-s65340-z2n.md
+++ b/docs/cameras/i-pro/wv-s65340-z2n.md
@@ -1,0 +1,41 @@
+# i-PRO WV-S65340-Z2N
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-S65340-Z2N |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | PoE++ (IEEE 802.3bt) / PoE+ (IEEE 802.3at) / AC 24V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- PTZ
+- 21x optical zoom
+- AI auto-tracking
+- AI video motion detection
+- AI privacy guard
+- face detection
+- people detection
+- vehicle detection
+- FIPS 140-2 Level 3 secure element
+- 256 preset positions
+- IEEE 802.1X
+- HTTPS
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-s65340-z2n
+
+---
+*Auto-generated from i-pro-wv-s65340-z2n.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u61300-zy.md
+++ b/docs/cameras/i-pro/wv-u61300-zy.md
@@ -1,0 +1,34 @@
+# i-PRO WV-U61300-ZY
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U61300-ZY |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-115° |
+| Night vision | color, 0.004 lux, 0.007 lux color |
+| Power | DC12V or PoE (IEEE802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 3.1x optical zoom
+- motorized zoom
+- motorized focus
+- 256 preset positions
+- pan 350°
+- tilt 90°
+- ONVIF Profile G/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zy
+
+---
+*Auto-generated from i-pro-wv-u61300-zy.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u61300-zyg.md
+++ b/docs/cameras/i-pro/wv-u61300-zyg.md
@@ -1,0 +1,36 @@
+# i-PRO WV-U61300-ZYG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U61300-ZYG |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-115° |
+| Night vision | color, 0.012 lux, 0.02 lux color |
+| Power | PoE (IEEE 802.3af) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- PTZ
+- 3.1x optical zoom
+- 350° pan
+- 90° tilt
+- 256 presets
+- Super Dynamic 144dB WDR
+- ONVIF Profile G/S/T
+- FIPS 140-2 level 3
+- privacy zones
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61300-zyg
+
+---
+*Auto-generated from i-pro-wv-u61300-zyg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u61301-z1.md
+++ b/docs/cameras/i-pro/wv-u61301-z1.md
@@ -1,0 +1,33 @@
+# i-PRO WV-U61301-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U61301-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-3.0 |
+| Field of view | 6.7-62° |
+| Night vision | none, 0.006 lux, 0.011 lux color |
+| Power | DC12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- PTZ
+- 256 preset positions
+- Super Dynamic (144dB WDR)
+- autofocus
+- FIPS 140-2 level 3
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z1
+
+---
+*Auto-generated from i-pro-wv-u61301-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u61301-z2.md
+++ b/docs/cameras/i-pro/wv-u61301-z2.md
@@ -1,0 +1,37 @@
+# i-PRO WV-U61301-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U61301-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.001 lux color |
+| Power | DC12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- 256 presets
+- auto focus
+- image stabilizer
+- 144dB super dynamic range
+- privacy zones
+- video motion detection
+- ICR
+- FIPS 140-2 level 3 security
+- NDAA compliant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301-z2
+
+---
+*Auto-generated from i-pro-wv-u61301-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u61301a-z2.md
+++ b/docs/cameras/i-pro/wv-u61301a-z2.md
@@ -1,0 +1,24 @@
+# i-PRO WV-U61301A-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U61301A-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77 (H)° |
+| Night vision | color, 0.0004 lux, 0.001 lux color |
+| Power | DC 12V or PoE (IEEE 802.3af) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u61301a-z2
+
+---
+*Auto-generated from i-pro-wv-u61301a-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65300-zy.md
+++ b/docs/cameras/i-pro/wv-u65300-zy.md
@@ -1,0 +1,26 @@
+# i-PRO WV-U65300-ZY
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65300-ZY |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-113° |
+| Night vision | color, 0.0003 lux, 0.007 lux color |
+| Power | PoE (IEEE802.3af) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zy
+
+---
+*Auto-generated from i-pro-wv-u65300-zy.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65300-zyg.md
+++ b/docs/cameras/i-pro/wv-u65300-zyg.md
@@ -1,0 +1,33 @@
+# i-PRO WV-U65300-ZYG
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65300-ZYG |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-2.5 |
+| Field of view | 113 (wide) - 36 (tele)° |
+| Night vision | color, 0.012 lux, 0.02 lux color |
+| Power | DC 12V or PoE IEEE 802.3af |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 3.1x optical zoom
+- color night vision
+- motorized varifocal
+- PTZ
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65300-zyg
+
+---
+*Auto-generated from i-pro-wv-u65300-zyg.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65301-z1.md
+++ b/docs/cameras/i-pro/wv-u65301-z1.md
@@ -1,0 +1,33 @@
+# i-PRO WV-U65301-Z1
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65301-Z1 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 62 (Wide) - 6.7 (Tele) horizontal° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | DC 12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- color night vision
+- ONVIF Profile G/S/T
+- full duplex audio
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1
+
+---
+*Auto-generated from i-pro-wv-u65301-z1.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65301-z1g.md
+++ b/docs/cameras/i-pro/wv-u65301-z1g.md
@@ -1,0 +1,38 @@
+# i-PRO WV-U65301-Z1G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65301-Z1G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.7-47mm F1.6-F3.0 |
+| Field of view | 6.7-62° |
+| Night vision | color, 0.017 lux, 0.03 lux color |
+| Power | DC12V, PoE (IEEE 802.3af), PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 10x optical zoom
+- 360° endless pan
+- 256 preset positions
+- Super Dynamic 144dB WDR
+- ONVIF Profile G/S/T
+- Privacy zones
+- IEEE 802.1X
+- FIPS 140-2 Level 3 secure element
+- Intelligent auto mode
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65301-z1g
+
+---
+*Auto-generated from i-pro-wv-u65301-z1g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65302-z2.md
+++ b/docs/cameras/i-pro/wv-u65302-z2.md
@@ -1,0 +1,41 @@
+# i-PRO WV-U65302-Z2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65302-Z2 |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 3.7-77° |
+| Night vision | color, 0.006 lux, 0.011 lux color |
+| Power | DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- 31x HD Extra Optical Zoom
+- Color night vision
+- Image stabilizer (gyro)
+- Super Dynamic 144dB WDR
+- Intelligent Auto
+- Privacy zones (up to 8)
+- FIPS 140-2 Level 3
+- NDAA compliant
+- ONVIF Profile G/S/T
+- 360° endless pan
+- Alarm recording
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2
+
+---
+*Auto-generated from i-pro-wv-u65302-z2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-u65302-z2g.md
+++ b/docs/cameras/i-pro/wv-u65302-z2g.md
@@ -1,0 +1,33 @@
+# i-PRO WV-U65302-Z2G
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-U65302-Z2G |
+| Type | ptz |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 4.0-84.6mm F1.6-F4.5 |
+| Field of view | 77-3.7° |
+| Night vision | ir, 0.017 lux, 0.03 lux color |
+| Power | DC12V / PoE (IEEE802.3af) / PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 21x optical zoom
+- 31x HD extra optical zoom
+- FIPS 140-2 Level 3 secure element
+- NDAA compliant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-u65302-z2g
+
+---
+*Auto-generated from i-pro-wv-u65302-z2g.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22300a-v3l.md
+++ b/docs/cameras/i-pro/wv-x22300a-v3l.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X22300A-V3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22300A-V3L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 1080p (2.1MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-114° |
+| Night vision | ir (70m), 0.007 lux color |
+| Power | DC12V or PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI
+- varifocal
+- motorized-zoom
+- IR
+- vandal-resistant
+- ONVIF Profile G/M/S/T
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22300a-v3l
+
+---
+*Auto-generated from i-pro-wv-x22300a-v3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22500-v3l.md
+++ b/docs/cameras/i-pro/wv-x22500-v3l.md
@@ -1,0 +1,25 @@
+# i-PRO WV-X22500-V3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22500-V3L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5.3MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 33-105° |
+| Night vision | ir (70m), 0.03 lux color |
+| Power | PoE+ (IEEE 802.3at) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500-v3l
+
+---
+*Auto-generated from i-pro-wv-x22500-v3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22500a-v3l.md
+++ b/docs/cameras/i-pro/wv-x22500a-v3l.md
@@ -1,0 +1,33 @@
+# i-PRO WV-X22500A-V3L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22500A-V3L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×2304) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 33-105° |
+| Night vision | ir (70m), 0.03 lux color |
+| Power | PoE+ (IEEE 802.3at) or DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI
+- motorized zoom
+- 3.1x optical zoom
+- vandal resistant
+- IR illumination
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22500a-v3l
+
+---
+*Auto-generated from i-pro-wv-x22500a-v3l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22600-v2l.md
+++ b/docs/cameras/i-pro/wv-x22600-v2l.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X22600-V2L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22600-V2L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.03 lux, 0.04 lux color |
+| Power | PoE+ (IEEE802.3at) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI analytics
+- motorized zoom
+- motorized focus
+- FIPS 140-2 Level 3 security
+- ONVIF Profile G/S/T/M
+- vandal resistant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600-v2l
+
+---
+*Auto-generated from i-pro-wv-x22600-v2l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22600a-v2l.md
+++ b/docs/cameras/i-pro/wv-x22600a-v2l.md
@@ -1,0 +1,39 @@
+# i-PRO WV-X22600A-V2L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22600A-V2L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.04 lux color |
+| Power | DC12V or PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- varifocal
+- motorized-zoom
+- ir
+- edge-ai
+- vandal-resistant
+- wide-dynamic-range
+- onvif-profile-g
+- onvif-profile-m
+- onvif-profile-s
+- onvif-profile-t
+- fips-140-3
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22600a-v2l
+
+---
+*Auto-generated from i-pro-wv-x22600a-v2l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22700-v2l.md
+++ b/docs/cameras/i-pro/wv-x22700-v2l.md
@@ -1,0 +1,43 @@
+# i-PRO WV-X22700-V2L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22700-V2L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.29MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.03 lux, 0.04 lux color |
+| Power | DC 12V or PoE+ (IEEE 802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- varifocal
+- motorized-zoom
+- motorized-focus
+- AI-analytics
+- edge-AI
+- face-detection
+- vehicle-detection
+- occupancy-detection
+- privacy-guard
+- ONVIF-Profile-G
+- ONVIF-Profile-S
+- ONVIF-Profile-T
+- ONVIF-Profile-M
+- MQTT
+- vandal-resistant
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700-v2l
+
+---
+*Auto-generated from i-pro-wv-x22700-v2l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x22700a-v2l.md
+++ b/docs/cameras/i-pro/wv-x22700a-v2l.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X22700A-V2L
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X22700A-V2L |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.03 lux, 0.04 lux color |
+| Power | PoE+ (802.3at) or DC12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- 2x optical zoom
+- AI analytics
+- image stabilizer
+- privacy zones
+- ONVIF Profile G/M/S/T
+- FIPS 140-3 Level 3 secure element
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x22700a-v2l
+
+---
+*Auto-generated from i-pro-wv-x22700a-v2l.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25300-v3ln.md
+++ b/docs/cameras/i-pro/wv-x25300-v3ln.md
@@ -1,0 +1,34 @@
+# i-PRO WV-X25300-V3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25300-V3LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-113° |
+| Night vision | ir (70m), 0.007 lux color |
+| Power | DC12V or PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- AI engine
+- FIPS 140-2 Level 3
+- NDAA compliant
+- motorized zoom
+- IR
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300-v3ln
+
+---
+*Auto-generated from i-pro-wv-x25300-v3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25300a-v3ln.md
+++ b/docs/cameras/i-pro/wv-x25300a-v3ln.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X25300A-V3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25300A-V3LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 1080p (2MP, 1920×1080) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 36-113° |
+| Night vision | ir (70m), 0.007 lux color |
+| Power | DC12V or PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- motorized zoom
+- autofocus
+- Edge AI
+- NDAA compliant
+- FIPS 140-3 Level 3
+- IR illumination
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25300a-v3ln
+
+---
+*Auto-generated from i-pro-wv-x25300a-v3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25500-v3ln.md
+++ b/docs/cameras/i-pro/wv-x25500-v3ln.md
@@ -1,0 +1,40 @@
+# i-PRO WV-X25500-V3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25500-V3LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 33-103° |
+| Night vision | ir (70m), 0.03 lux color |
+| Power | DC12V or PoE+ (IEEE802.3at) |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | No |
+
+## Features
+
+- motorized zoom
+- 3.1x optical zoom
+- IR
+- Edge AI analytics
+- FIPS 140-2 level 3 security
+- 132dB WDR
+- face detection
+- people detection
+- vehicle detection
+- privacy guard
+- occupancy detection
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500-v3ln
+
+---
+*Auto-generated from i-pro-wv-x25500-v3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25500a-v3ln.md
+++ b/docs/cameras/i-pro/wv-x25500a-v3ln.md
@@ -1,0 +1,26 @@
+# i-PRO WV-X25500A-V3LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25500A-V3LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.9-9mm F1.3-F2.5 |
+| Field of view | 33-103° |
+| Night vision | ir (70m), 0.03 lux color |
+| Power | DC 12V or PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25500a-v3ln
+
+---
+*Auto-generated from i-pro-wv-x25500a-v3ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25580-f2ln2.md
+++ b/docs/cameras/i-pro/wv-x25580-f2ln2.md
@@ -1,0 +1,33 @@
+# i-PRO WV-X25580-F2LN2
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25580-F2LN2 |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 5MP (5.3MP, 3072×1728) |
+| Sensor | 1/2.8" CMOS |
+| Lens | 1× 2.3mm F2.2 |
+| Field of view | 131° |
+| Night vision | ir (21m), 0.07 lux, 0.08 lux color |
+| Power | PoE (IEEE 802.3af) or DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP69 |
+| IK rating | IK11 |
+| Two-way audio | No |
+
+## Features
+
+- AI engine
+- anti-ligature
+- IR illumination
+- MQTT support
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25580-f2ln2
+
+---
+*Auto-generated from i-pro-wv-x25580-f2ln2.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25600-v2ln.md
+++ b/docs/cameras/i-pro/wv-x25600-v2ln.md
@@ -1,0 +1,26 @@
+# i-PRO WV-X25600-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25600-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.04 lux color |
+| Power | DC12V or PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600-v2ln
+
+---
+*Auto-generated from i-pro-wv-x25600-v2ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25600a-v2ln.md
+++ b/docs/cameras/i-pro/wv-x25600a-v2ln.md
@@ -1,0 +1,26 @@
+# i-PRO WV-X25600A-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25600A-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 6MP (6.2MP, 3328×1872) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.04 lux, 0.04 lux color |
+| Power | PoE+ / DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25600a-v2ln
+
+---
+*Auto-generated from i-pro-wv-x25600a-v2ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25700-v2ln.md
+++ b/docs/cameras/i-pro/wv-x25700-v2ln.md
@@ -1,0 +1,42 @@
+# i-PRO WV-X25700-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25700-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.29MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.03 lux, 0.04 lux color |
+| Power | PoE+ (IEEE 802.3at) or DC 12V |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp, http |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- IR
+- Motorized Zoom
+- AI Analytics
+- Edge AI
+- Face Detection
+- People Detection
+- Vehicle Detection
+- Occupancy Detection
+- Privacy Masking
+- FIPS 140-2 Level 3
+- IEEE 802.1X
+- ONVIF Profile G/S/T/M
+- 4K
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700-v2ln
+
+---
+*Auto-generated from i-pro-wv-x25700-v2ln.json — do not edit by hand.*

--- a/docs/cameras/i-pro/wv-x25700a-v2ln.md
+++ b/docs/cameras/i-pro/wv-x25700a-v2ln.md
@@ -1,0 +1,35 @@
+# i-PRO WV-X25700A-V2LN
+
+| Field | Spec |
+|-------|------|
+| Brand | i-PRO |
+| Model | WV-X25700A-V2LN |
+| Type | dome |
+| Connectivity | ethernet |
+| Resolution | 4K (8.3MP, 3840×2160) |
+| Sensor | 1/1.8" CMOS |
+| Lens | 1× 4.3-8.6mm F1.5-F2.4 |
+| Field of view | 52-101° |
+| Night vision | ir (70m), 0.02 lux, 0.04 lux color |
+| Power | DC 12V or PoE+ |
+| Storage | microSD ≤ 512GB, NVR |
+| Protocols | onvif, rtsp |
+| IP rating | IP66/IP67 |
+| IK rating | IK10 |
+| Two-way audio | Yes |
+
+## Features
+
+- AI analytics
+- FIPS 140-3 Level 3
+- NDAA compliant
+- Smart Coding
+- motorized zoom
+- motorized focus
+
+## Sources
+
+- https://i-pro.com/products_and_solutions/en/surveillance/products/wv-x25700a-v2ln
+
+---
+*Auto-generated from i-pro-wv-x25700a-v2ln.json — do not edit by hand.*


### PR DESCRIPTION
## Summary

- Adds 60 i-PRO cameras from two form-factor families:
  - **PTZ cameras** (39 models): WV-S65340, WV-S65302, WV-S65301, WV-S65300, WV-S61702, WV-S61602, WV-S61501, WV-S61302, WV-S61301, WV-S61300, WV-U65302, WV-U65301, WV-U65300, WV-U61301, WV-U61300 (outdoor WV-S/WV-U series)
  - **Dome cameras** (21 models): WV-X25700, WV-X25600, WV-X25580, WV-X25500, WV-X25300, WV-X22700, WV-X22600, WV-X22500, WV-X22300, WV-S25700, WV-S25600, WV-S25500 (indoor/outdoor X and S series)
- Each entry includes: sensor, lens, resolution, video codecs, max FPS, night vision, audio, storage, power, connectivity, protocols, environment, features, and Frigate NVR config snippets
- PTZ cameras with onboard auto-tracking have `ptz.autotracking: true` set

## Models added

WV-S65340-Z2N, WV-S65340-Z2K, WV-S65340-Z2G, WV-S65340-Z2, WV-S65302-Z2G, WV-S65302-Z2-1, WV-S65302-Z2, WV-S65301-Z1S, WV-S65301-Z1G, WV-S65301-Z1-1, WV-S65301-Z1, WV-S65300-ZYG, WV-S65300-ZY, WV-S61702A-Z3, WV-S61702-Z3, WV-S61602A-Z3, WV-S61602-Z3, WV-S61501-Z1, WV-S61302A-Z4, WV-S61302-Z4, WV-S61301A-Z2-1, WV-S61301A-Z2, WV-S61301-Z2, WV-S61301-Z1, WV-S61300-ZYG, WV-S61300-ZY, WV-U65302-Z2G, WV-U65302-Z2, WV-U65301-Z1G, WV-U65301-Z1, WV-U65300-ZYG, WV-U65300-ZY, WV-U61301A-Z2, WV-U61301-Z2, WV-U61301-Z1, WV-U61300-ZYG, WV-U61300-ZY, WV-X25700A-V2LN, WV-X25700-V2LN, WV-X25600A-V2LN, WV-X25600-V2LN, WV-X25580-F2LN2, WV-X25500A-V3LN, WV-X25500-V3LN, WV-X25300A-V3LN, WV-X25300-V3LN, WV-X22700A-V2L, WV-X22700-V2L, WV-X22600A-V2L, WV-X22600-V2L, WV-X22500A-V3L, WV-X22500-V3L, WV-X22300A-V3L, WV-S25700-V2LN1, WV-S25700-V2LN, WV-S25700-V2LG, WV-S25600-V2LN, WV-S25600-V2LG, WV-S25600-V2L, WV-S25500-V3LN1

## Source

i-PRO official product pages: https://i-pro.com/products_and_solutions/en/surveillance/documentation-database

## Method

Automated spec extraction from https://i-pro.com/products_and_solutions/en/surveillance/documentation-database