### PR TITLE
feat: network.ethernet_speed_mbps + NetBox device-type export (46 Hikvision)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cameras/**/*.md
 
 # Local datasheet cache — pulled datasheets kept for reuse, never committed
 datasheet-cache/
+netbox-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ---
 
+## [Unreleased]
+
+### Added
+- **`network` schema block** — optional `network.ethernet_speed_mbps` (RJ45 link speed: 10 / 100 / 1000 / 2500 / 10000) and `network.ethernet_ports`, read from the datasheet's Ethernet / Network Interface row. The field is optional; no existing record is affected.
+- **Ethernet link speed for 46 Hikvision PoE cameras** — backfilled from the official datasheets (44 × 100 Mbps `10M/100M self-adaptive`, 2 × Gigabit on the iDS-2CD7A DeepinView pair). No values estimated. Two records (DS-2CD1027G2H-LIU, DS-2CD3086G2-IS) also had their `sources` upgraded from JS product pages to the official `assets.hikvision.com` datasheet PDFs.
+- **`scripts/gen-netbox.js`** — exports cameras that have a known link speed to [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) YAML device types. Skips any camera missing `ethernet_speed_mbps`, so the NetBox interface `type` is never guessed.
+
+---
+
 ## [2.0.0] — 2026-08-21
 
 Major milestone: a full redesign of the companion website ([cctv-database.com](https://cctv-database.com)), a new Dahua PTZ, three community-verified Frigate configs, and a Reolink RTSP-path correction. No dataset schema changes.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ RTSP_PATTERNS_DATE=$(date +%Y-%m-%d) node scripts/build-rtsp-patterns.js
 
 The shipped `configs.frigate` snippets are generated; run one of these cameras and you can mark it **community-verified** (`configs.frigate.verified` / `tested_by` / `tested_version`) via the [Verify a Frigate config](../../issues/new?template=verify-frigate-config.yml) issue form.
 
+### NetBox device-type export
+
+`scripts/gen-netbox.js` exports cameras into [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) YAML device types — PoE interface (with the standard parsed from `power.method`), DC power port, microSD module bay, and weight, sourced from each camera's datasheet.
+
+```bash
+node scripts/gen-netbox.js --brand Hikvision            # → netbox-out/device-types/Hikvision/*.yaml
+node scripts/gen-netbox.js --brand Hikvision --report   # list PoE cameras still missing a link speed
+```
+
+A device type is only emitted when the camera has a known RJ45 link speed (`network.ethernet_speed_mbps`), since the library requires an interface `type` and it is never guessed.
+
 ### Querying the data
 
 ```js
@@ -306,6 +317,7 @@ Common optional fields:
 | `night_vision.range_m` | `number` | `30` |
 | `night_vision.min_lux_color` | `number` | `0.01` |
 | `power.method` | `string` | `"PoE (802.3af) / DC 12V"` |
+| `network.ethernet_speed_mbps` | `number` | `100` (RJ45 link speed) |
 | `ip_rating` | `string` | `"IP67"` |
 | `ik_rating` | `string` | `"IK10"` |
 | `audio.two_way` | `boolean` | `true` |

--- a/cameras/hikvision/ds-2cd1023g0e-i.json
+++ b/cameras/hikvision/ds-2cd1023g0e-i.json
@@ -113,5 +113,9 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ds-2cd1027g2h-liu.json
+++ b/cameras/hikvision/ds-2cd1027g2h-liu.json
@@ -70,7 +70,7 @@
   ],
   "release_notes": "Specs verified against the official Hikvision datasheet DS-2CD1027G2H-LIUF (Ver. 20240718). -F suffix adds a microSD slot + reset key; lens is 2.8mm or 4mm.",
   "sources": [
-    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/value-series/ds-2cd1027g2h-liu-f-/",
+    "https://assets.hikvision.com/prd/public/all/doc/sm000059821/DS-2CD1027G2H-LIUF_Datasheet_20240718.pdf",
     "https://assets.hikvision.com/prd/public/all/doc/sm000059821/DS-2CD1027G2H-LIUF_Datasheet_20240718.pdf"
   ],
   "last_verified": "2026-07-04",
@@ -120,5 +120,9 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ds-2cd20126g3-iuy-srb.json
+++ b/cameras/hikvision/ds-2cd20126g3-iuy-srb.json
@@ -105,5 +105,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd20126g3-iy.json
+++ b/cameras/hikvision/ds-2cd20126g3-iy.json
@@ -104,5 +104,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
+++ b/cameras/hikvision/ds-2cd20166g3-iuy-sl.json
@@ -117,5 +117,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd20166g3-iuy.json
+++ b/cameras/hikvision/ds-2cd20166g3-iuy.json
@@ -113,5 +113,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2046g2-iu-sl.json
+++ b/cameras/hikvision/ds-2cd2046g2-iu-sl.json
@@ -122,5 +122,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2047g3-li2uy.json
+++ b/cameras/hikvision/ds-2cd2047g3-li2uy.json
@@ -133,5 +133,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. ONVIF supported."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2066g2-iu-sl.json
+++ b/cameras/hikvision/ds-2cd2066g2-iu-sl.json
@@ -123,5 +123,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2087g3-li2uy.json
+++ b/cameras/hikvision/ds-2cd2087g3-li2uy.json
@@ -117,5 +117,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view. ONVIF supported."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2126g2-ims.json
+++ b/cameras/hikvision/ds-2cd2126g2-ims.json
@@ -102,5 +102,9 @@
     }
   },
   "dimensions_mm": "Ø119 x 90",
-  "weight_g": 440
+  "weight_g": 440,
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2143g2-liptrzs2uy.json
@@ -115,5 +115,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
+++ b/cameras/hikvision/ds-2cd2146g3-iptrzs2uy.json
@@ -117,5 +117,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2147g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2147g3-lis2uy.json
@@ -122,5 +122,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. ONVIF supported. Main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2166g2-isu.json
+++ b/cameras/hikvision/ds-2cd2166g2-isu.json
@@ -123,5 +123,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2186g2-ims.json
+++ b/cameras/hikvision/ds-2cd2186g2-ims.json
@@ -100,5 +100,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2187g3-lis2uy.json
+++ b/cameras/hikvision/ds-2cd2187g3-lis2uy.json
@@ -131,5 +131,9 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ds-2cd23126g3-i2uy.json
+++ b/cameras/hikvision/ds-2cd23126g3-i2uy.json
@@ -104,5 +104,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
+++ b/cameras/hikvision/ds-2cd23126g3-is2uy-sl.json
@@ -111,5 +111,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd23166g3-i2uy.json
+++ b/cameras/hikvision/ds-2cd23166g3-i2uy.json
@@ -132,5 +132,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd23166g3-iy.json
+++ b/cameras/hikvision/ds-2cd23166g3-iy.json
@@ -130,5 +130,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2347g3-li2uy.json
+++ b/cameras/hikvision/ds-2cd2347g3-li2uy.json
@@ -124,5 +124,9 @@
       "notes": "Select 'Hikvision' profile. ONVIF supported."
     }
   },
-  "last_verified": "2026-08-13"
+  "last_verified": "2026-08-13",
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ds-2cd2566g2-is.json
+++ b/cameras/hikvision/ds-2cd2566g2-is.json
@@ -124,5 +124,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2647g3t-lizsy.json
+++ b/cameras/hikvision/ds-2cd2647g3t-lizsy.json
@@ -124,5 +124,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. ONVIF supported."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2686g2-izs.json
+++ b/cameras/hikvision/ds-2cd2686g2-izs.json
@@ -124,5 +124,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2687g3t-lizsy.json
+++ b/cameras/hikvision/ds-2cd2687g3t-lizsy.json
@@ -128,5 +128,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Main stream 101 for recording, sub stream 102 for live view. ONVIF supported."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-sl.json
@@ -116,5 +116,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzs2uy-srb.json
@@ -118,5 +118,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2747g3-liptrzsy.json
@@ -114,5 +114,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzs2uy-sl.json
@@ -118,5 +118,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2767g3-liptrzsy.json
@@ -116,5 +116,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2767g3t-lizsy.json
+++ b/cameras/hikvision/ds-2cd2767g3t-lizsy.json
@@ -115,5 +115,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-sl.json
@@ -122,5 +122,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzs2uy-srb.json
@@ -120,5 +120,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
+++ b/cameras/hikvision/ds-2cd2787g3-liptrzsy.json
@@ -116,5 +116,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t127g3p-lis2uy-sl.json
@@ -115,5 +115,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t167g3p-lis2uy-sl.json
@@ -114,5 +114,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
+++ b/cameras/hikvision/ds-2cd2t87g3p-lis2uy-sl.json
@@ -114,5 +114,9 @@
       "verified": false,
       "notes": "Hikvision native RTSP path (main 101 / sub 102); enable RTSP in the web UI."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd3056g2-is.json
+++ b/cameras/hikvision/ds-2cd3056g2-is.json
@@ -129,5 +129,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd3086g2-is.json
+++ b/cameras/hikvision/ds-2cd3086g2-is.json
@@ -109,7 +109,7 @@
     "outdoor"
   ],
   "sources": [
-    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/Ultra-Series-SmartIP-/ds-2cd3086g2-is/"
+    "https://assets.hikvision.com/prd/public/all/doc/sm000050059/DS-2CD3086G2-IS-H_Datasheet_20230712.pdf"
   ],
   "last_verified": "2026-08-10",
   "configs": {
@@ -130,5 +130,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd3156g2-is-u.json
+++ b/cameras/hikvision/ds-2cd3156g2-is-u.json
@@ -131,5 +131,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd3746g2-izs.json
+++ b/cameras/hikvision/ds-2cd3746g2-izs.json
@@ -133,5 +133,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2cd3766g2t-izs-y.json
+++ b/cameras/hikvision/ds-2cd3766g2t-izs-y.json
@@ -133,5 +133,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
+++ b/cameras/hikvision/ds-2sf7c425mxg2-lm-el.json
@@ -132,5 +132,9 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.json
+++ b/cameras/hikvision/ids-2cd7a46g0-p-izhs-y.json
@@ -136,5 +136,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/hikvision/ids-2cd7a47g2-xzhsy.json
+++ b/cameras/hikvision/ids-2cd7a47g2-xzhsy.json
@@ -146,5 +146,9 @@
       "profile": "Hikvision",
       "notes": "Select 'Hikvision' profile. ONVIF supported. Main stream /Streaming/Channels/101, sub /Streaming/Channels/102."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
   }
 }

--- a/schema/camera.schema.json
+++ b/schema/camera.schema.json
@@ -472,6 +472,28 @@
         "discontinued"
       ],
       "description": "Product availability status."
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Wired network interface details from the datasheet (Ethernet / RJ45 row).",
+      "properties": {
+        "ethernet_speed_mbps": {
+          "type": "integer",
+          "enum": [
+            10,
+            100,
+            1000,
+            2500,
+            10000
+          ],
+          "description": "Max link speed of the RJ45 port as stated in the datasheet (e.g. '10M/100M self-adaptive' = 100)."
+        },
+        "ethernet_ports": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
     }
   }
 }

--- a/scripts/gen-netbox.js
+++ b/scripts/gen-netbox.js
@@ -29,9 +29,24 @@ const REPORT = args.includes('--report');
 
 const SPEED_TYPE = { 10: '10base-t', 100: '100base-tx', 1000: '1000base-t', 2500: '2.5gbase-t', 10000: '10gbase-t' };
 
-function slugify(s) {
-  // devicetype-library rule: lowercase, keep letters/digits/hyphens, dots and whitespace -> hyphen, drop everything else
-  return s.toLowerCase().replace(/[.\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-+|-+$/g, '');
+// Mirror devicetype-library's exact slug rules (tests/device_types.py) — the
+// ordered replace chains must match theirs char-for-char, or their CI rejects
+// the slug (e.g. a model like "…2UY/SL" must slugify to "…2uy-sl", not "…2uysl").
+function slugifyManufacturer(s) {
+  return s.toLowerCase()
+    .replaceAll(' ', '-').replaceAll('sfp+', 'sfpp').replaceAll('poe+', 'poep')
+    .replaceAll('-+', '-plus-').replaceAll('+', '-plus').replaceAll('_', '-')
+    .replaceAll('!', '').replaceAll('/', '-').replaceAll(',', '').replaceAll("'", '')
+    .replaceAll('*', '-').replaceAll('&', 'and').replaceAll('.', '-');
+}
+function slugifyModel(s) {
+  let x = s.toLowerCase()
+    .replaceAll(' ', '-').replaceAll('sfp+', 'sfpp').replaceAll('poe+', 'poep')
+    .replaceAll('-+', '-plus').replaceAll('+', '-plus-').replaceAll('_', '-')
+    .replaceAll('&', '-and-').replaceAll('!', '').replaceAll('/', '-').replaceAll(',', '')
+    .replaceAll("'", '').replaceAll('*', '-').replaceAll('(', '').replaceAll(')', '')
+    .replaceAll(';', '').replaceAll('.', '-');
+  return x.endsWith('-') ? x.slice(0, -1) : x;
 }
 
 function poeType(method) {
@@ -63,7 +78,7 @@ function toYaml(c) {
   const pt = poeType(method);
   const dcV = dcVoltage(method);
   const draw = c.power && c.power.consumption_w;
-  const slug = `${slugify(c.brand)}-${slugify(c.model)}`;
+  const slug = `${slugifyManufacturer(c.brand)}-${slugifyModel(c.model)}`;
 
   const L = [];
   L.push(`manufacturer: ${yamlStr(c.brand)}`);
@@ -129,7 +144,13 @@ for (const c of cams) {
   if (!r) { skipped++; continue; }
   const dir = path.join(OUT, 'device-types', c.brand);
   fs.mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, `${c.model.replace(/[\/\\]/g, '-')}.yaml`);
+  // Filename must equal the model or its slug (their CI checks this, case-insensitively).
+  // Raw model when filesystem-safe (keeps parens, matching library convention); for a
+  // model with a slash, drop the slash + parens so the name still resolves to the slug.
+  const fname = /[/\\]/.test(c.model)
+    ? c.model.replace(/[/\\]/g, '-').replace(/[()]/g, '')
+    : c.model;
+  const file = path.join(dir, `${fname}.yaml`);
   if (fs.existsSync(file)) { console.error(`EXISTS - skip ${file}`); continue; }
   fs.writeFileSync(file, r.yaml);
   n++;

--- a/scripts/gen-netbox.js
+++ b/scripts/gen-netbox.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * gen-netbox.js — generate NetBox devicetype-library YAML from camera JSON.
+ *
+ * Usage:
+ *   node scripts/gen-netbox.js --brand Hikvision [--out netbox-out] [--limit 50] [--report]
+ *
+ * Rules (mirrors the project's datasheet-only policy):
+ *   - Only cameras with power_source "poe" AND a known Ethernet link speed are emitted.
+ *     Link speed must come from `network.ethernet_speed_mbps` (10/100/1000/2500/10000).
+ *     devicetype-library requires an interface `type`; we never guess 100base-tx.
+ *   - poe_type is derived from power.method text (802.3af/at/bt). Unparseable → poe_type omitted.
+ *   - weight only emitted when weight_g is present (library asks for it, does not require it).
+ *   - DC power port only emitted when power.method names a DC voltage.
+ *   - comments link to the first entry in `sources` (the datasheet) + cctv-database.com page.
+ *
+ * --report lists PoE cameras that are blocked only by a missing ethernet speed,
+ * with their datasheet URL so the field can be filled from the source.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const opt = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
+const BRAND = opt('--brand', null);
+const OUT = opt('--out', 'netbox-out');
+const LIMIT = parseInt(opt('--limit', '0'), 10);
+const REPORT = args.includes('--report');
+
+const SPEED_TYPE = { 10: '10base-t', 100: '100base-tx', 1000: '1000base-t', 2500: '2.5gbase-t', 10000: '10gbase-t' };
+
+function slugify(s) {
+  // devicetype-library rule: lowercase, keep letters/digits/hyphens, dots and whitespace -> hyphen, drop everything else
+  return s.toLowerCase().replace(/[.\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function poeType(method) {
+  if (!method) return null;
+  const m = method.toLowerCase();
+  if (/802\.3 ?bt|poe\+\+|hi-?poe|90 ?w|60 ?w/.test(m)) return 'type3-ieee802.3bt';
+  if (/802\.3 ?at|poe\+/.test(m)) return 'type2-ieee802.3at';
+  if (/802\.3 ?af/.test(m)) return 'type1-ieee802.3af';
+  return null; // plain "PoE" — don't guess the standard
+}
+
+function dcVoltage(method) {
+  if (!method) return null;
+  const m = method.match(/(\d{1,2})\s*V\s*DC|DC\s*(\d{1,2})\s*V|(\d{1,2})\s*VDC/i);
+  if (!m) return null;
+  return parseInt(m[1] || m[2] || m[3], 10);
+}
+
+function yamlStr(s) {
+  // quote only when YAML would otherwise misparse (colons, parens are fine; leading special chars, quotes, '#')
+  return /[:#'"{}\[\],&*?|<>=!%@`]|^\s|\s$|^$/.test(s) ? `'${s.replace(/'/g, "''")}'` : s;
+}
+
+function toYaml(c) {
+  const speed = c.network && c.network.ethernet_speed_mbps;
+  const ifType = SPEED_TYPE[speed];
+  if (!ifType) return null;
+  const method = c.power && c.power.method;
+  const pt = poeType(method);
+  const dcV = dcVoltage(method);
+  const draw = c.power && c.power.consumption_w;
+  const slug = `${slugify(c.brand)}-${slugify(c.model)}`;
+
+  const L = [];
+  L.push(`manufacturer: ${yamlStr(c.brand)}`);
+  L.push(`model: ${yamlStr(c.model)}`);
+  L.push(`slug: ${slug}`);
+  L.push(`part_number: ${yamlStr(c.model)}`);
+  L.push(`u_height: 0`);
+  L.push(`is_full_depth: false`);
+  L.push(`airflow: passive`);
+  if (c.weight_g) { L.push(`weight: ${c.weight_g}`); L.push(`weight_unit: g`); }
+  L.push(`interfaces:`);
+  L.push(`  - name: eth0`);
+  L.push(`    type: ${ifType}`);
+  L.push(`    poe_mode: pd`);
+  if (pt) L.push(`    poe_type: ${pt}`);
+  if (draw || (c.power && c.power.poe_class != null)) {
+    const d = [];
+    if (c.power.poe_class != null) d.push(`PoE Class ${c.power.poe_class}`);
+    if (draw) d.push(`max ${draw} W`);
+    L.push(`    description: ${yamlStr(d.join(', '))}`);
+  }
+  if (dcV) {
+    L.push(`power-ports:`);
+    L.push(`  - name: DC IN`);
+    L.push(`    type: dc-terminal`);
+    if (draw) { L.push(`    maximum_draw: ${Math.ceil(draw)}`); }
+    L.push(`    description: ${dcV}V DC`);
+  }
+  if (c.storage && c.storage.onboard && c.storage.max_microsd_gb) {
+    L.push(`module-bays:`);
+    L.push(`  - name: microSD`);
+    L.push(`    position: microSD`);
+    L.push(`    description: up to ${c.storage.max_microsd_gb} GB`);
+  }
+  const ds = c.sources && c.sources[0];
+  const page = `https://cctv-database.com/camera/${c.id}`;
+  L.push(`comments: >`);
+  L.push(`  [${c.brand} ${c.model} datasheet](${ds}) | [Specs on cctv-database.com](${page})`);
+  L.push('');
+  return { slug, yaml: L.join('\n') };
+}
+
+// ---- main
+let cams = [];
+for (const b of fs.readdirSync('cameras')) {
+  const d = path.join('cameras', b);
+  if (!fs.statSync(d).isDirectory()) continue;
+  for (const f of fs.readdirSync(d)) if (f.endsWith('.json')) cams.push(JSON.parse(fs.readFileSync(path.join(d, f))));
+}
+cams = cams.filter(c => (c.power_source || []).includes('poe') && (c.connectivity || []).includes('ethernet'));
+if (BRAND) cams = cams.filter(c => c.brand.toLowerCase() === BRAND.toLowerCase());
+
+if (REPORT) {
+  const missing = cams.filter(c => !(c.network && c.network.ethernet_speed_mbps));
+  console.log(`${missing.length} PoE cameras missing network.ethernet_speed_mbps`);
+  for (const c of missing) console.log(`${c.id}\t${c.weight_g ? 'w' : '-'}${c.power && c.power.consumption_w ? 'p' : '-'}\t${c.sources[0]}`);
+  process.exit(0);
+}
+
+let n = 0, skipped = 0;
+for (const c of cams) {
+  const r = toYaml(c);
+  if (!r) { skipped++; continue; }
+  const dir = path.join(OUT, 'device-types', c.brand);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${c.model.replace(/[\/\\]/g, '-')}.yaml`);
+  if (fs.existsSync(file)) { console.error(`EXISTS - skip ${file}`); continue; }
+  fs.writeFileSync(file, r.yaml);
+  n++;
+  if (LIMIT && n >= LIMIT) break;
+}
+console.log(`wrote ${n} device types to ${OUT}/, skipped ${skipped} (no ethernet speed)`);


### PR DESCRIPTION
Groundwork for contributing our cameras to [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library), which today has almost no cameras (Hikvision: 1, and it's the only camera among 17 switch/NVR entries).

## What their library needs

- One YAML per model; `manufacturer, model, slug, u_height, is_full_depth` required, plus every `interfaces[].type`. ASCII-only, no null fields, draft PR first, CI validates.
- Maintainers accept camera entries carrying `interfaces` (`poe_mode: pd`, `poe_type`), `power-ports` (dc-terminal, `maximum_draw`), `module-bays` (microSD), `weight`, and a datasheet link in `comments`.

## The one blocker: Ethernet link speed

Their schema requires `interfaces[].type` (`100base-tx` vs `1000base-t`), but our schema had no field for RJ45 link speed — and guessing violates our datasheet-only policy. This PR fixes that.

## What's in this PR

- **Schema:** new optional `network` block — `ethernet_speed_mbps` (10/100/1000/2500/10000) and `ethernet_ports`. Optional, so no existing record breaks (AJV over the full tree: 0 invalid). Useful on its own — Frigate/4K users care whether a camera is 100M-capped.
- **Backfill:** `ethernet_speed_mbps` filled for **46 Hikvision PoE cameras** — every value read from the official datasheet's Ethernet/Network Interface row (44 × 100M `10M/100M self-adaptive`, 2 × Gigabit on the iDS-2CD7A DeepinView pair). Nothing estimated. Two records also had their `sources[0]` upgraded from JS product pages to official `assets.hikvision.com` datasheet PDFs.
- **Tooling:** `scripts/gen-netbox.js` generates the devicetype-library YAML from camera JSON — parses the PoE standard from `power.method`, emits DC port + microSD bay only when present, and **skips any camera without a known link speed** so the interface `type` is never guessed. `--report` lists PoE cameras still missing the field.
- **Docs:** CHANGELOG `[Unreleased]` entry + README "NetBox device-type export" section + the new field in the schema table.

## Verification

- AJV schema validation over all 3,431 cameras: **0 invalid**; `lint --fix` clean.
- Generator emits exactly the 46 filled cameras (`wrote 46 device types, skipped 345 — no ethernet speed`); output is byte-identical to a hand-checked reference sample.
- **Dedup vs. upstream:** checked all 46 against `device-types/Hikvision/` — **no filename or slug collisions**; all 46 are net-new.

## Next (separate, upstream)

The actual devicetype-library contribution is a follow-up: run their `pytest -k Hikvision` against the generated YAML, then open a **draft PR** there (branch `hikvision-cameras`). More vendors (Dahua, Uniview, Axis, Hanwha) to follow as separate PRs.
