### PR TITLE
feat: ethernet speed for 30 Dahua PoE cameras (NetBox export)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - **`network` schema block** — optional `network.ethernet_speed_mbps` (RJ45 link speed: 10 / 100 / 1000 / 2500 / 10000) and `network.ethernet_ports`, read from the datasheet's Ethernet / Network Interface row. The field is optional; no existing record is affected.
 - **Ethernet link speed for 46 Hikvision PoE cameras** — backfilled from the official datasheets (44 × 100 Mbps `10M/100M self-adaptive`, 2 × Gigabit on the iDS-2CD7A DeepinView pair). No values estimated. Two records (DS-2CD1027G2H-LIU, DS-2CD3086G2-IS) also had their `sources` upgraded from JS product pages to the official `assets.hikvision.com` datasheet PDFs.
-- **`scripts/gen-netbox.js`** — exports cameras that have a known link speed to [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) YAML device types. Skips any camera missing `ethernet_speed_mbps`, so the NetBox interface `type` is never guessed.
+- **Ethernet link speed for 30 Dahua PoE cameras** — backfilled from the official datasheets' `Network Port RJ-45` row (26 × 100 Mbps, 4 × Gigabit on the WizSense-3 PRO models). `IPC-HDW1439V-IL-K` was deliberately left unfilled — its exact `-IL-K` datasheet isn't publicly published, and the family value wasn't read from that model's own sheet.
+- **`scripts/gen-netbox.js`** — exports cameras that have a known link speed to [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) YAML device types. Skips any camera missing `ethernet_speed_mbps`, so the NetBox interface `type` is never guessed, and only annotates PoE (`poe_mode`/`poe_type`) when the datasheet states the 802.3 standard.
+
+### Changed
+- **PoE standard added to `power.method` for 22 Dahua cameras** — where the datasheet's Power Supply row states it (e.g. `12VDC/PoE` → `12VDC/PoE (802.3af)`, `12VDC/PoE+` → `12VDC/PoE+ (802.3at)`). Datasheet-grounded; enables a correct NetBox `poe_type`.
 
 ---
 

--- a/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3449r1-zas-pv-pro.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0003
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 16.1,
     "voltage": "12VDC"
   },
@@ -90,5 +90,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3649r1-zas-pv-pro.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0005
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 16.9,
     "voltage": "12VDC"
   },
@@ -90,5 +90,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdbw3849f-as-il.json
+++ b/cameras/dahua/ipc-hdbw3849f-as-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.008
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 10.1,
     "voltage": "12VDC"
   },
@@ -88,5 +88,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hdbw3849r1-zas-pv-pro.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0006
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 16.9,
     "voltage": "12VDC"
   },
@@ -90,5 +90,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdbw5259r-ase-il.json
+++ b/cameras/dahua/ipc-hdbw5259r-ase-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0007
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 15.5,
     "voltage": "12VDC"
   },
@@ -90,5 +90,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdw2249t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2249t-zs-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.002
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 10.1,
     "voltage": "12VDC"
   },
@@ -103,5 +103,9 @@
       }
     ],
     "max_fps": 30
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw2449t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2449t-zs-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.006
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 7.8,
     "voltage": "12VDC"
   },
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw2449tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2449tm-s-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.006
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 5.2,
     "voltage": "12VDC"
   },
@@ -103,5 +103,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw2649t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2649t-zs-il.json
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw2649tm-s-il.json
+++ b/cameras/dahua/ipc-hdw2649tm-s-il.json
@@ -103,5 +103,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw2849t-s-pro.json
+++ b/cameras/dahua/ipc-hdw2849t-s-pro.json
@@ -116,5 +116,9 @@
   },
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdw2849t-zs-il.json
+++ b/cameras/dahua/ipc-hdw2849t-zs-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.008
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 10.1,
     "voltage": "12VDC"
   },
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hdw3849t-zs-il.json
+++ b/cameras/dahua/ipc-hdw3849t-zs-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.007
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 9.8,
     "voltage": "12VDC"
   },
@@ -88,5 +88,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdw5259t-ze-il.json
+++ b/cameras/dahua/ipc-hdw5259t-ze-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0007
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 17.5,
     "voltage": "12VDC"
   },
@@ -88,5 +88,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hdw5259tm-ase-il.json
+++ b/cameras/dahua/ipc-hdw5259tm-ase-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0007
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 15.5,
     "voltage": "12VDC"
   },
@@ -88,5 +88,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/ipc-hfw2449t-as-il.json
+++ b/cameras/dahua/ipc-hfw2449t-as-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.006
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 7.2,
     "voltage": "12VDC"
   },
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2449t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2449t-zas-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.006
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 10.2,
     "voltage": "12VDC"
   },
@@ -105,5 +105,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2649t-as-il.json
+++ b/cameras/dahua/ipc-hfw2649t-as-il.json
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2649t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2649t-zas-il.json
@@ -105,5 +105,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2849t-as-il.json
+++ b/cameras/dahua/ipc-hfw2849t-as-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.008
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 8.3,
     "voltage": "12VDC"
   },
@@ -104,5 +104,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2849t-zas-il.json
+++ b/cameras/dahua/ipc-hfw2849t-zas-il.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.008
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 12.7,
     "voltage": "12VDC"
   },
@@ -105,5 +105,9 @@
       }
     ],
     "max_fps": 20
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw2849tl-s-pro.json
+++ b/cameras/dahua/ipc-hfw2849tl-s-pro.json
@@ -119,5 +119,9 @@
     "blue_iris": {
       "profile": "Dahua"
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw3449t1-as-pv.json
+++ b/cameras/dahua/ipc-hfw3449t1-as-pv.json
@@ -62,7 +62,7 @@
     "min_lux_color": 0.003
   },
   "power": {
-    "method": "12VDC/PoE",
+    "method": "12VDC/PoE (802.3af)",
     "consumption_w": 8.8,
     "voltage": "12VDC"
   },
@@ -125,5 +125,9 @@
       "profile": "Dahua",
       "notes": "Select 'Dahua' profile. Supports both main and sub streams."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.json
+++ b/cameras/dahua/ipc-hfw3849t1-zas-pv-pro.json
@@ -30,7 +30,7 @@
     "min_lux_color": 0.0006
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 18.3,
     "voltage": "12VDC"
   },
@@ -88,5 +88,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 1000,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd22404db-gny.json
+++ b/cameras/dahua/sd22404db-gny.json
@@ -108,5 +108,9 @@
   "last_verified": "2026-08-21",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd49425db-hny.json
+++ b/cameras/dahua/sd49425db-hny.json
@@ -34,7 +34,7 @@
     "onvif_ptz": "relative"
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 21,
     "voltage": "12VDC"
   },
@@ -92,5 +92,9 @@
   "last_verified": "2026-08-08",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd4d225mb-hnr.json
+++ b/cameras/dahua/sd4d225mb-hnr.json
@@ -34,7 +34,7 @@
     "onvif_ptz": "relative"
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 23,
     "voltage": "12VDC"
   },
@@ -92,5 +92,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd4d425mb-hnr.json
+++ b/cameras/dahua/sd4d425mb-hnr.json
@@ -34,7 +34,7 @@
     "onvif_ptz": "relative"
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 23,
     "voltage": "12VDC"
   },
@@ -92,5 +92,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd4d825mb-hnr.json
+++ b/cameras/dahua/sd4d825mb-hnr.json
@@ -34,7 +34,7 @@
     "onvif_ptz": "relative"
   },
   "power": {
-    "method": "12VDC/PoE+",
+    "method": "12VDC/PoE+ (802.3at)",
     "consumption_w": 23,
     "voltage": "12VDC"
   },
@@ -93,5 +93,9 @@
   "last_verified": "2026-07-04",
   "environment": [
     "outdoor"
-  ]
+  ],
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
+  }
 }

--- a/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
+++ b/cameras/dahua/sd6c3432gb-hnr-a-pv1.json
@@ -136,5 +136,9 @@
       "profile": "Dahua",
       "notes": "Select 'Dahua' profile. Supports both main and sub streams."
     }
+  },
+  "network": {
+    "ethernet_speed_mbps": 100,
+    "ethernet_ports": 1
   }
 }

--- a/scripts/gen-netbox.js
+++ b/scripts/gen-netbox.js
@@ -92,8 +92,10 @@ function toYaml(c) {
   L.push(`interfaces:`);
   L.push(`  - name: eth0`);
   L.push(`    type: ${ifType}`);
-  L.push(`    poe_mode: pd`);
-  if (pt) L.push(`    poe_type: ${pt}`);
+  // devicetype-library rejects poe_mode without a matching poe_type, so only annotate
+  // PoE when the datasheet gave us the standard (802.3af/at/bt); otherwise leave the
+  // interface as a plain port rather than guess the PoE type.
+  if (pt) { L.push(`    poe_mode: pd`); L.push(`    poe_type: ${pt}`); }
   if (draw || (c.power && c.power.poe_class != null)) {
     const d = [];
     if (c.power.poe_class != null) d.push(`PoE Class ${c.power.poe_class}`);


### PR DESCRIPTION
Second vendor in the NetBox device-type export effort (after Hikvision #286).

### Added
- **`network.ethernet_speed_mbps` for 30 Dahua PoE cameras** — read from each official datasheet's `Network Port RJ-45 (…Base-T)` row (26 × 100 Mbps, 4 × Gigabit on the WizSense-3 PRO models). No values estimated. `IPC-HDW1439V-IL-K` is intentionally left unfilled: its exact `-IL-K` datasheet isn't publicly published, so its value wasn't read from that model's own sheet.

### Changed
- **PoE 802.3 standard added to `power.method` for 22 Dahua records** — where the datasheet's Power Supply row states it (`12VDC/PoE` → `12VDC/PoE (802.3af)`, `12VDC/PoE+` → `12VDC/PoE+ (802.3at)`). Enables a correct NetBox `poe_type`.
- **`gen-netbox.js`** now only writes `poe_mode`/`poe_type` when the datasheet gives the 802.3 standard — devicetype-library rejects `poe_mode` without `poe_type`. The 4 Dahua 6MP cameras whose datasheet omits the standard export a plain port instead of a guessed PoE type.

### Verification
- All 30 generated YAMLs pass devicetype-library's `tests/definitions_test.py`.
- No slug/filename collisions with the existing upstream `device-types/Dahua/`.
- Full-tree AJV: 3,431 cameras, 0 invalid; lint clean.
