### PR TITLE
fix(amcrest): AD410 doorbell is NVR-compatible (#307)

### DIFF
--- a/cameras/amcrest/ad410-doorbell.json
+++ b/cameras/amcrest/ad410-doorbell.json
@@ -33,7 +33,7 @@
   "storage": {
     "onboard": false,
     "max_microsd_gb": 128,
-    "nvr_compatible": false,
+    "nvr_compatible": true,
     "cloud": true
   },
   "protocols": [
@@ -64,7 +64,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-08-21",
+  "last_verified": "2026-08-22",
   "power_source": [
     "battery",
     "ac-mains"


### PR DESCRIPTION
Corrects `storage.nvr_compatible` false → true on the Amcrest AD410 doorbell. Owner-confirmed running on an Amcrest NVR (#307); the AD410 speaks the Dahua protocol (`/cam/realmonitor` RTSP + ONVIF) and is marketed as Amcrest-NVR compatible. Bumped `last_verified`. Credits @jeffstearns.

Refs #307 (left open).