### PR TITLE
Verify Dahua IPC-HDW5442T-ZE Frigate config (#315)

### DIFF
--- a/cameras/dahua/ipc-hdw5442t-ze.json
+++ b/cameras/dahua/ipc-hdw5442t-ze.json
@@ -65,7 +65,11 @@
         "fps": 5
       },
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+      "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+      "verified": true,
+      "tested_by": "glennasnicar (GitHub #315)",
+      "tested_version": "0.17.2",
+      "notes": "If the camera has RTSP-over-TLS enabled, use the rtsps:// scheme instead of rtsp:// (same path). Plain rtsp:// on port 554 is the default otherwise."
     },
     "home_assistant": {
       "integration": "onvif",
@@ -79,7 +83,7 @@
   "markets": [
     "global"
   ],
-  "last_verified": "2026-08-08",
+  "last_verified": "2026-08-24",
   "environment": [
     "outdoor"
   ]

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -109514,7 +109514,11 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "verified": true,
+        "tested_by": "glennasnicar (GitHub #315)",
+        "tested_version": "0.17.2",
+        "notes": "If the camera has RTSP-over-TLS enabled, use the rtsps:// scheme instead of rtsp:// (same path). Plain rtsp:// on port 554 is the default otherwise."
       },
       "home_assistant": {
         "integration": "onvif",
@@ -109528,7 +109532,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-08-08",
+    "last_verified": "2026-08-24",
     "environment": [
       "outdoor"
     ],

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -109514,7 +109514,11 @@
           "fps": 5
         },
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=0",
-        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1"
+        "best_substream": "rtsp://{user}:{pass}@{ip}:554/cam/realmonitor?channel=1&subtype=1",
+        "verified": true,
+        "tested_by": "glennasnicar (GitHub #315)",
+        "tested_version": "0.17.2",
+        "notes": "If the camera has RTSP-over-TLS enabled, use the rtsps:// scheme instead of rtsp:// (same path). Plain rtsp:// on port 554 is the default otherwise."
       },
       "home_assistant": {
         "integration": "onvif",
@@ -109528,7 +109532,7 @@
     "markets": [
       "global"
     ],
-    "last_verified": "2026-08-08",
+    "last_verified": "2026-08-24",
     "environment": [
       "outdoor"
     ],


### PR DESCRIPTION
Closes #315.

Community config-verification report from @glennasnicar: the shipped Frigate config works on **Frigate 0.17.2** (both main + sub streams).

- Set `configs.frigate.verified: true` + `tested_by` + `tested_version`, bumped `last_verified`.
- The reporter's unit runs **RTSP-over-TLS**, so they used `rtsps://` instead of `rtsp://` (same path). Documented that in `configs.frigate.notes`; the base template stays plain `rtsp://` on 554 (the Dahua default), since TLS is opt-in per device.

Reporter credited via `Co-authored-by`.