### PR TITLE
Verify Reolink E1 Outdoor SE PoE Frigate config (#319)

### DIFF
--- a/cameras/reolink/e1-outdoor-se-poe.json
+++ b/cameras/reolink/e1-outdoor-se-poe.json
@@ -71,6 +71,9 @@
       "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Preview_01_main",
       "best_substream": "rtsp://{user}:{pass}@{ip}:554/Preview_01_sub",
       "autotracking": false,
+      "verified": true,
+      "tested_by": "roger-shrop (GitHub #319)",
+      "tested_version": "0.17.2",
       "notes": "Frigate autotracking unsupported: Reolink uses absolute ONVIF PTZ; Frigate autotracking requires relative movement. Use the official /Preview_01_main path (Reolink RTSP KB); it serves the stream at the codec configured in the camera. The legacy /h264Preview_01_main path forces an H.264 re-encode and delivers noticeably lower quality on current firmware (community report, GitHub #280)."
     },
     "home_assistant": {
@@ -100,5 +103,5 @@
   "environment": [
     "outdoor"
   ],
-  "last_verified": "2026-07-06"
+  "last_verified": "2026-08-25"
 }

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -285933,6 +285933,9 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Preview_01_main",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Preview_01_sub",
         "autotracking": false,
+        "verified": true,
+        "tested_by": "roger-shrop (GitHub #319)",
+        "tested_version": "0.17.2",
         "notes": "Frigate autotracking unsupported: Reolink uses absolute ONVIF PTZ; Frigate autotracking requires relative movement. Use the official /Preview_01_main path (Reolink RTSP KB); it serves the stream at the codec configured in the camera. The legacy /h264Preview_01_main path forces an H.264 re-encode and delivers noticeably lower quality on current firmware (community report, GitHub #280)."
       },
       "home_assistant": {
@@ -285962,7 +285965,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-25",
     "added": "2026-07-06",
     "sensor_size_inch": 0.3704,
     "substream_count": 0,

--- a/docs/cameras.json
+++ b/docs/cameras.json
@@ -285933,6 +285933,9 @@
         "rtsp_url_template": "rtsp://{user}:{pass}@{ip}:554/Preview_01_main",
         "best_substream": "rtsp://{user}:{pass}@{ip}:554/Preview_01_sub",
         "autotracking": false,
+        "verified": true,
+        "tested_by": "roger-shrop (GitHub #319)",
+        "tested_version": "0.17.2",
         "notes": "Frigate autotracking unsupported: Reolink uses absolute ONVIF PTZ; Frigate autotracking requires relative movement. Use the official /Preview_01_main path (Reolink RTSP KB); it serves the stream at the codec configured in the camera. The legacy /h264Preview_01_main path forces an H.264 re-encode and delivers noticeably lower quality on current firmware (community report, GitHub #280)."
       },
       "home_assistant": {
@@ -285962,7 +285965,7 @@
     "environment": [
       "outdoor"
     ],
-    "last_verified": "2026-07-06",
+    "last_verified": "2026-08-25",
     "added": "2026-07-06",
     "sensor_size_inch": 0.3704,
     "substream_count": 0,


### PR DESCRIPTION
Closes #319.

Community config-verification from @roger-shrop: the shipped Frigate config works on **Frigate 0.17.2** (both main + sub streams, no changes needed).

- Set `configs.frigate.verified: true` + `tested_by` + `tested_version`, bumped `last_verified`.
- Reporter credited via `Co-authored-by`.

Verified-config count 26 → 27.