### PR TITLE
Add DS-2CD2743G2-IZS stream breakdown

### DIFF
--- a/cameras/hikvision/ds-2cd2743g2-izs.json
+++ b/cameras/hikvision/ds-2cd2743g2-izs.json
@@ -56,7 +56,8 @@
     "IK10"
   ],
   "sources": [
-    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/Pro-Series-EasyIP-/ds-2cd2743g2-izs/"
+    "https://www.hikvision.com/en/products/IP-Products/Network-Cameras/Pro-Series-EasyIP-/ds-2cd2743g2-izs/",
+    "https://assets.hikvision.com/prd/public/all/doc/sm000058844/DS-2CD2743G2-IZS_Datasheet_V5.5.113_20230303.pdf"
   ],
   "power_source": [
     "poe",
@@ -82,7 +83,37 @@
       "notes": "Select 'Hikvision' profile. Use main stream for recording, sub stream for live view."
     }
   },
-  "last_verified": "2026-08-08",
+  "video": {
+    "codecs": [
+      "H.265+",
+      "H.265",
+      "H.264+",
+      "H.264",
+      "MJPEG"
+    ],
+    "max_fps": 30,
+    "streams": [
+      {
+        "name": "main",
+        "resolution": "2688x1520",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "sub",
+        "resolution": "1280x720",
+        "fps": 30,
+        "codec": "H.265"
+      },
+      {
+        "name": "third",
+        "resolution": "1920x1080",
+        "fps": 10,
+        "codec": "H.265"
+      }
+    ]
+  },
+  "last_verified": "2026-08-27",
   "environment": [
     "outdoor"
   ]


### PR DESCRIPTION
## Summary

- add the main, sub, and third stream breakdown for Hikvision DS-2CD2743G2-IZS
- add the official Hikvision datasheet source
- refresh the record's verification date

Refs #177.

## Source

Hikvision's datasheet specifies:

- main: 2688x1520 at 30 fps (60 Hz)
- sub: 1280x720 at 30 fps (60 Hz)
- third: 1920x1080 at 10 fps
- H.265/H.264 across all three streams, with H.265+/H.264+ on main and MJPEG on sub

## Validation

- parsed the changed JSON
- validated it against `schema/camera.schema.json`
- verified canonical JSON formatting and a clean staged diff