### PR TITLE
docs(readme): add NDAA-compliant query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ const uk = cameras.filter(c =>
 const noSub = cameras.filter(c =>
   c.features?.some(f => f.toLowerCase().includes('no subscription'))
 );
+
+// Only NDAA (Section 889) compliant cameras — manufacturer-stated
+const ndaa = cameras.filter(c => c.ndaa_compliant === true);
 ```
 
 Or open `data/cameras.csv` in any spreadsheet for a quick browse.


### PR DESCRIPTION
Small docs improvement: adds a one-liner to the README's *Querying the JSON* section showing how to filter for `ndaa_compliant === true` records (the field added in 2.14.0). No data changes.